### PR TITLE
fix(build): include slug-text examples in docs build dependency graph

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,7 @@
         "example-three-pass-effects#build",
         "example-three-tilemap#build",
         "example-three-tsl-nodes#build",
+        "example-three-slug-text#build",
         "example-react-animation#build",
         "example-react-basic-sprite#build",
         "example-react-batch-demo#build",
@@ -55,6 +56,7 @@
         "example-react-pass-effects#build",
         "example-react-tilemap#build",
         "example-react-tsl-nodes#build",
+        "example-react-slug-text#build",
         "example-three-skia#build",
         "example-react-skia#build"
       ],


### PR DESCRIPTION
## Summary

The slug-text example 404s on prod because both `example-three-slug-text` and `example-react-slug-text` are missing from the `docs#build` task's \`dependsOn\` array in \`turbo.json\`.

Without the dependency, turbo doesn't build the slug-text examples before docs starts. The \`copy-examples\` vite plugin (\`docs/vite-plugins/copy-examples.js\`) runs in docs' \`buildStart\` hook and walks \`examples/{type}/{name}/dist/\`. Missing \`dist/\` directories are silently skipped via the \`if (!existsSync(distDir)) continue\` check. The result on prod: no \`docs/public/examples/three/slug-text/\` or \`docs/public/examples/react/slug-text/\` artifacts, so the iframe URL \`/three-flatland/examples/three/slug-text/\` returns 404.

The packages shipped with #20 but the turbo dependency was never wired up.

## Fix

Two lines added to \`docs#build.dependsOn\`:

- \`example-three-slug-text#build\`
- \`example-react-slug-text#build\`

## Test plan

- [ ] \`pnpm build\` succeeds and turbo's stream output shows both slug-text packages building before docs
- [ ] \`docs/public/examples/three/slug-text/index.html\` exists after the build
- [ ] \`docs/public/examples/react/slug-text/index.html\` exists after the build
- [ ] Once deployed, \`/three-flatland/examples/three/slug-text/\` and \`/three-flatland/examples/react/slug-text/\` load instead of 404