### PR TITLE
ci: generate changesets inside CI, instapass the bot commit

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,6 @@ graph TD
     PR(["Pull Request event"])
     Push(["Push to main event"])
     Manual(["workflow_dispatch event"])
-    ChangesetWF["changeset.yml"]
-    ChangesetWF -->|"pushes .changeset/ files"| PR
 
     subgraph CIOrch ["ci.yml (orchestrator)"]
         CIChanges["changes.yml"]
@@ -18,7 +16,11 @@ graph TD
         CIBuild --> Gate["ci-passed (gate)"]
         CISmoke --> Gate
         CISize --> Gate
+        CIBuild --> ChangesetJob["changeset (PRs only)"]
+        CISmoke --> ChangesetJob
+        CISize --> ChangesetJob
     end
+    ChangesetJob -->|"pushes .changeset/ files (PAT) → re-runs CI, instapasses"| PR
 
     subgraph DocsOrch ["docs.yml (orchestrator)"]
         DocsChanges["changes.yml"]
@@ -35,7 +37,6 @@ graph TD
     end
 
     PR ==> CIOrch
-    PR ==> ChangesetWF
     Push ==> CIOrch
     Push ==> DocsOrch
     Manual ==> DocsOrch
@@ -53,12 +54,13 @@ graph TD
 
 | File | Role | Trigger |
 |---|---|---|
-| `ci.yml` | Orchestrator: paths-filter → build matrix → smoke/size → gate | `push`, `pull_request` |
+| `ci.yml` | Orchestrator: paths-filter → build matrix → smoke/size → changeset → gate | `push`, `pull_request` |
 | `docs.yml` | Orchestrator: paths-filter → smoke → build-pages → deploy | `push` to `main`, `workflow_dispatch` |
 | `changes.yml` | dorny/paths-filter; emits `packages` / `minis` / `examples` / `docs` / `configs` / `ci` bucket outputs | `workflow_call` |
 | `build.yml` | Build + typecheck + lint + test + skia test (single node version, takes `node-version` + `node-tag` inputs) | `workflow_call` |
 | `smoke.yml` | Playwright smoke tests against built docs site | `workflow_call` |
 | `size.yml` | Bundle size diff via size-limit; comments on PR | `workflow_call` |
+| `changeset.yml` | Generate + Copilot-enhance + push the release changeset (via `CHANGESET_PAT`) | `workflow_call` |
 
 The matrix lives at the orchestrator layer (`ci.yml`) — `build.yml` is single-node and reusable. Release could call it directly for a clean publish build if we ever want to dedupe `release.yml`.
 
@@ -68,16 +70,17 @@ Branch protection is a **repository ruleset** with a single required status chec
 
 Doc-only or meta-only PRs (where build / smoke / size are skipped via paths-filter gating) still produce a passing `CI passed` check and can merge. Code-changing PRs wait for the real jobs to complete before `CI passed` resolves.
 
+The `changeset` job is **not** required and is **not** in `ci-passed`'s `needs` — changeset generation is best-effort and never gates merge. The changeset bot's own `ci: generate changesets` commit instapasses: `changes.yml` flags it `changeset_only`, build / smoke / size skip, and `CI passed` resolves green in seconds. See [Changeset-only skip](#changeset-only-skip).
+
 > **Ruleset name:** `Main Branch CI` — manage at Settings > Rules > Rulesets
 
 ## Workflows
 
 | Workflow | File | Triggers | Purpose |
 |---|---|---|---|
-| **CI** | `ci.yml` (+ `changes.yml`, `build.yml`, `smoke.yml`, `size.yml`) | push to `main`, pull requests | Build matrix, lint, test, typecheck, smoke (Playwright), bundle size, gated by `ci-passed` |
+| **CI** | `ci.yml` (+ `changes.yml`, `build.yml`, `smoke.yml`, `size.yml`) | push to `main`, pull requests | Build matrix, lint, test, typecheck, smoke (Playwright), bundle size, gated by `ci-passed`; on PRs, generates the release changeset (Copilot-enhanced) as the final `changeset` job after the gate jobs pass |
 | **Release** | `release.yml` | after CI succeeds on `main`, manual | Publish packages to npm via changesets |
 | **Deploy Docs** | `docs.yml` (+ `changes.yml`, `smoke.yml`) | push to `main`, manual | Self-gated docs deploy: runs paths-filter + smoke before building the Pages artifact and deploying |
-| **Generate Changeset** | `changeset.yml` | pull requests (opened, synchronize) | Auto-generate changeset files with Copilot enhancement |
 
 ## Path Filtering (CI)
 
@@ -101,11 +104,21 @@ Job gating:
 | `ci.build` (matrix) | `packages` ∨ `minis` ∨ `examples` ∨ `docs` ∨ `configs` ∨ `ci` — lint/typecheck/test are too valuable to bucket-gate; turbo cache makes the no-ops cheap |
 | `ci.smoke` | `packages` ∨ `minis` ∨ `examples` ∨ `docs` ∨ `configs` ∨ `ci` (and upstream `build` didn't fail) |
 | `ci.size` | `packages` ∨ `configs` ∨ `ci` (PR events only; size-limit only tracks published packages) |
+| `ci.changeset` | PR events only, when `build` succeeded and `smoke` / `size` didn't fail, and not `changeset_only` — generates + pushes the release changeset after the gate jobs pass |
 | `ci-passed` | always — gates the merge |
 | `docs.smoke` | `packages` ∨ `minis` ∨ `examples` ∨ `docs` ∨ `configs` ∨ `ci` — docs#build pulls in all of them (API reference from `packages`, showcases from `minis`, embedded demos from `examples`) |
 | `docs.build-pages` / `docs.deploy` | gated on `docs.smoke` success |
 
 A change in `ci` or `configs` triggers everything — CI/config changes need to validate themselves.
+
+### Changeset-only skip
+
+The `changeset` job pushes a `.changeset/`-only commit on top of each code commit (via `CHANGESET_PAT`, so the push triggers a fresh CI run — `GITHUB_TOKEN` pushes don't). That follow-up run has nothing to build, so `changes.yml` emits `changeset_only`:
+
+- On a `pull_request` synchronize, it compares the pushed delta (`before...after` via the compare API). If **every** changed file is under `.changeset/` **and** the base commit's `CI passed` was green, `changeset_only = true`.
+- `build` / `smoke` / `size` gate on `changeset_only != 'true'`, so they skip; `ci-passed` (skipped = success) resolves green in seconds — the bot commit instapasses instead of re-running the full pipeline.
+
+The flag keys on the **file delta**, not the commit message, so it can't be spoofed, and the base-passed guard means a changeset stacked on a red commit never gets green-lit. Because the `changeset` job runs only *after* the gate jobs pass, the bot commit always lands on an already-green base, so its run cancels nothing — `cancel-in-progress` stays on.
 
 ## Node Version Policy
 
@@ -146,10 +159,9 @@ graph LR
 
 | Workflow | Concurrency Group | Behavior |
 |---|---|---|
-| CI | `ci-{PR number or ref}` | Latest push cancels in-progress run for same PR |
+| CI | `ci-{PR number or ref}` | Latest push cancels in-progress run for same PR. Safe with the `changeset` job: it pushes its commit only after the gate jobs finish, so the bot commit's run cancels nothing. |
 | Release | `Release-refs/heads/main` | Only one release at a time per branch |
 | Deploy Docs | `pages` | Latest deploy cancels in-progress deploys |
-| Generate Changeset | none | Self-skips via commit message check |
 
 ## Manual Triggers
 
@@ -219,7 +231,7 @@ Follow these rules when modifying or creating workflows:
 
 COMPOSABLE LAYOUT
 - ci.yml is a slim orchestrator. Real work lives in reusable workflows declared with `on: workflow_call:` only
-- Reusable workflows in this repo: changes.yml, build.yml, smoke.yml, size.yml
+- Reusable workflows in this repo: changes.yml, build.yml, smoke.yml, size.yml, changeset.yml
 - The orchestrator calls them via `uses: ./.github/workflows/<name>.yml` and passes inputs/secrets
 - New steps that fit an existing reusable workflow go there; otherwise add a new reusable workflow and call it from ci.yml
 - Matrix lives at the orchestrator layer — reusable workflows are single-instance and take parameters as inputs

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -59,7 +59,9 @@ jobs:
             echo "changeset_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base_conclusion="$(gh api "repos/${{ github.repository }}/commits/$before/check-runs" --jq '[.check_runs[] | select(.name == "CI passed") | .conclusion] | last // ""' 2>/dev/null || echo '')"
+          # Sort by completed_at, not API return order (undocumented), so a
+          # re-run can't surface a stale earlier conclusion as the "last" one.
+          base_conclusion="$(gh api "repos/${{ github.repository }}/commits/$before/check-runs" --jq '[.check_runs[] | select(.name == "CI passed")] | sort_by(.completed_at) | last // {} | .conclusion // ""' 2>/dev/null || echo '')"
           echo "Base 'CI passed' conclusion: '$base_conclusion'"
           if [ "$base_conclusion" = 'success' ]; then
             echo "changeset_only=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -15,6 +15,8 @@ on:
         value: ${{ jobs.detect.outputs.configs }}
       ci:
         value: ${{ jobs.detect.outputs.ci }}
+      changeset_only:
+        value: ${{ jobs.detect.outputs.changeset_only }}
 
 jobs:
   detect:
@@ -26,8 +28,44 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       configs: ${{ steps.filter.outputs.configs }}
       ci: ${{ steps.filter.outputs.ci }}
+      changeset_only: ${{ steps.skip.outputs.changeset_only }}
     steps:
       - uses: actions/checkout@v6
+
+      # The changeset bot pushes a `.changeset/`-only commit on top of each
+      # code commit. Such a push has nothing to build, so skip the heavy jobs
+      # and let the `CI passed` gate go green on the skips — but only when the
+      # base commit it sits on already passed CI, so a changeset stacked on a
+      # red commit can never be green-lit. Keys on the pushed file delta, not
+      # the commit message, so it can't be spoofed.
+      - name: Detect changeset-only push on a passing base
+        id: skip
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          before='${{ github.event.before }}'
+          after='${{ github.event.after }}'
+          # No usable base (PR opened/reopened, or null SHA) → run full CI.
+          if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+            echo "changeset_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(gh api "repos/${{ github.repository }}/compare/$before...$after" --jq '.files[].filename' 2>/dev/null)" || changed='__err__'
+          echo "Pushed delta $before...$after:"
+          printf '%s\n' "$changed"
+          # Any file outside .changeset/ (or a compare error / empty delta) → run full CI.
+          if [ "$changed" = '__err__' ] || [ -z "$changed" ] || printf '%s\n' "$changed" | grep -qvE '^\.changeset/'; then
+            echo "changeset_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base_conclusion="$(gh api "repos/${{ github.repository }}/commits/$before/check-runs" --jq '[.check_runs[] | select(.name == "CI passed") | .conclusion] | last // ""' 2>/dev/null || echo '')"
+          echo "Base 'CI passed' conclusion: '$base_conclusion'"
+          if [ "$base_conclusion" = 'success' ]; then
+            echo "changeset_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changeset_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,53 +1,44 @@
-name: Generate Changeset
+name: Changeset
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize]
+  workflow_call:
+
+# The push authenticates with CHANGESET_PAT (a secret), not the GITHUB_TOKEN,
+# so the token only needs read access — the checkout fetch is all it covers.
+permissions:
+  contents: read
 
 jobs:
-  generate-changeset:
+  changeset:
+    name: Generate changeset
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 2
-
-      - name: Skip if last commit was from this workflow
-        id: check
-        run: |
-          msg=$(git log -1 --format="%s")
-          if [ "$msg" = "ci: generate changesets" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Fetch full history
-        if: steps.check.outputs.skip != 'true'
-        run: git fetch --unshallow || true
+          # Full history so `origin/main..HEAD` and `--base origin/main` resolve.
+          fetch-depth: 0
+          # PAT (not the default GITHUB_TOKEN) so the changeset commit this job
+          # pushes triggers CI — GitHub suppresses workflow runs for pushes made
+          # with GITHUB_TOKEN, which would leave the bot commit without the
+          # required "CI passed" check. That triggered run instapasses via the
+          # changeset-only skip in changes.yml.
+          token: ${{ secrets.CHANGESET_PAT }}
 
       - name: Install pnpm
-        if: steps.check.outputs.skip != 'true'
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        if: steps.check.outputs.skip != 'true'
         uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: steps.check.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Generate template changesets
-        if: steps.check.outputs.skip != 'true'
         run: >-
           pnpm changeset:generate
           --branch ${{ github.event.pull_request.head.ref }}
@@ -57,7 +48,6 @@ jobs:
           --cap-major
 
       - name: Compute branch id
-        if: steps.check.outputs.skip != 'true'
         id: bid
         run: |
           ts=$(git log --format="%ct" --reverse origin/main..HEAD | head -1)
@@ -65,11 +55,9 @@ jobs:
           echo "value=$value" >> "$GITHUB_OUTPUT"
 
       - name: Install Copilot CLI
-        if: steps.check.outputs.skip != 'true'
         run: npm install -g @github/copilot
 
       - name: Enhance changesets with Copilot
-        if: steps.check.outputs.skip != 'true'
         continue-on-error: true
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
@@ -111,7 +99,6 @@ jobs:
           IMPORTANT: Preserve each file's frontmatter block exactly as-is. Only write to the files listed above."
 
       - name: Commit and push changesets
-        if: steps.check.outputs.skip != 'true'
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  checks: read
 
 jobs:
   changes:
@@ -21,12 +22,14 @@ jobs:
   build:
     needs: changes
     if: |
-      needs.changes.outputs.packages == 'true' ||
-      needs.changes.outputs.minis == 'true' ||
-      needs.changes.outputs.examples == 'true' ||
-      needs.changes.outputs.docs == 'true' ||
-      needs.changes.outputs.configs == 'true' ||
-      needs.changes.outputs.ci == 'true'
+      needs.changes.outputs.changeset_only != 'true' && (
+        needs.changes.outputs.packages == 'true' ||
+        needs.changes.outputs.minis == 'true' ||
+        needs.changes.outputs.examples == 'true' ||
+        needs.changes.outputs.docs == 'true' ||
+        needs.changes.outputs.configs == 'true' ||
+        needs.changes.outputs.ci == 'true'
+      )
     strategy:
       matrix:
         include:
@@ -43,6 +46,7 @@ jobs:
     needs: [changes, build]
     if: |
       !cancelled() && needs.build.result != 'failure' &&
+      needs.changes.outputs.changeset_only != 'true' &&
       (needs.changes.outputs.packages == 'true' ||
        needs.changes.outputs.minis == 'true' ||
        needs.changes.outputs.examples == 'true' ||
@@ -56,10 +60,29 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       !cancelled() && needs.build.result != 'failure' &&
+      needs.changes.outputs.changeset_only != 'true' &&
       (needs.changes.outputs.packages == 'true' ||
        needs.changes.outputs.configs == 'true' ||
        needs.changes.outputs.ci == 'true')
     uses: ./.github/workflows/size.yml
+    secrets: inherit
+
+  # Generate the release changeset only AFTER the gate jobs pass, as the final
+  # step of CI rather than a parallel workflow. Sequencing it here means the
+  # bot's `ci: generate changesets` commit is created on an already-green base —
+  # so its own CI run instapasses via the changeset-only skip, and because this
+  # PR's CI is finished by then, that run cancels nothing (cancel-in-progress
+  # stays safe). Not a dependency of `ci-passed`: changeset generation is
+  # best-effort and never gates merge.
+  changeset:
+    needs: [changes, build, smoke, size]
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.changeset_only != 'true' &&
+      needs.build.result == 'success' &&
+      needs.smoke.result != 'failure' &&
+      needs.size.result != 'failure'
+    uses: ./.github/workflows/changeset.yml
     secrets: inherit
 
   ci-passed:


### PR DESCRIPTION
## Summary
Folds changeset generation into the CI pipeline so the changeset bot commit can no longer block or full-rerun the PR — the recurring "stuck on checks" pain.

- **`changeset.yml`** is now a `workflow_call` reusable (matching `changes`/`build`/`smoke`/`size`), called from `ci.yml` via `uses:` + `secrets: inherit`. It runs **after** the gate jobs, not as a parallel workflow.
- **`changes.yml`** emits `changeset_only`: true when a PR push's delta (`before...after` via the compare API) is confined to `.changeset/` **and** the base commit's `CI passed` was green. Keyed on the file delta, not the commit message, so it can't be spoofed; the base-passed guard means a changeset stacked on a red commit never goes green.
- **`ci.yml`** gates `build`/`smoke`/`size` on `changeset_only != 'true'`, adds the `changeset` job (not in `ci-passed`'s `needs` — best-effort, never gates merge), and adds `checks: read`.
- Pushes via `CHANGESET_PAT` so the bot commit triggers CI; `GITHUB_TOKEN` tightened to `contents: read` since the PAT (not the token) does the push.

## Why this is the fix
Because changeset-gen runs only after the gate jobs pass, the bot commit always lands on an already-green base. Its CI run instapasses via the `changeset_only` skip and cancels nothing — so `cancel-in-progress` stays on, with no race. No more `GITHUB_TOKEN`-push deadlock, no close/reopen.

## Self-test
This PR touches `.github/workflows/**`, so it runs the new `ci.yml` against itself: full build → the `changeset` job pushes a `ci: generate changesets` commit → that commit instapasses via the skip. A clean green PR (with the bot commit going green in seconds) is the proof.

## Test plan
- [x] CI green on this commit (full pipeline, since `.github/workflows/**` changed)
- [x] `changeset` job runs and pushes a `ci: generate changesets` commit
- [ ] that bot commit's CI run skips build/smoke/size and `CI passed` resolves green in seconds (instapass)
- [ ] no close/reopen needed; PR mergeable without manual intervention