### PR TITLE
refactor(observable): consolidate Sprite2D onto the shared observable strategies (finish #28 port)

### DIFF
--- a/.changeset/auto-three-flatland-3ry6czq.md
+++ b/.changeset/auto-three-flatland-3ry6czq.md
@@ -1,0 +1,14 @@
+---
+"three-flatland": patch
+---
+
+> Branch: fix/observable-single-pattern
+> PR: https://github.com/thejustinwalsh/three-flatland/pull/113
+
+- `Sprite2D` now delegates tint and anchor reactivity to `observable.color.attach` / `observable.vector2.attach` — removes ~100 lines of inline duplicate property-descriptor logic
+- `observable.color.attach` and `observable.vector2.attach` are now used internally; the public module is no longer orphaned
+- `attach` is idempotent: re-attaching a value swaps its `notify` closure safely, making values reusable across ownership changes
+- R3F in-place mutation path (`sprite.tint.set(r, g, b)`) now reliably flushes to the batch color buffer without a systems pass; locked by a new `SpriteGroup` test
+- `observable` module docs updated: `WithPropsSync` tuple-form example replaced with the direct-attach pattern that external extenders should use
+
+Removes the last inline duplicate of the observe-in-place strategy from `Sprite2D`, consolidating all reactive property wiring behind the public `observable` module.

--- a/packages/three-flatland/src/observable/index.ts
+++ b/packages/three-flatland/src/observable/index.ts
@@ -14,31 +14,37 @@
  * notify-firing getters/setters.
  *
  * Each strategy provides:
- *   - `attach(value, notify)` — wire the value's mutation surface
+ *   - `attach(value, notify)` — wire the value's mutation surface so
+ *     any in-place write fires `notify`
  *   - `snapshot(value)` — capture a flat record of its fields for
  *     shallow memoization (reference-`===` doesn't work for in-place
  *     mutation)
  *
- * A strategy is paired with a schema entry via the `WithPropsSync`
- * tuple form: `[coerce, observable.color]`. The registry installs
- * the strategy on each coerced value and supplies a stale-safe
- * `notify` closure.
+ * Callers invoke a strategy's `attach` directly on a value they own.
+ * Internal classes like `Sprite2D` attach in their constructor so a
+ * setter such as `sprite.tint.set(...)` or `sprite.anchor.set(...)`
+ * pushes the new value to the GPU; external three.js extenders use
+ * the same exports to make their own Color/Vector2/Vector3/Euler
+ * props reactive. `attach` is idempotent — re-attaching just swaps
+ * the `notify` closure (handy when a value outlives the object that
+ * first wired it).
  *
  * @example
  * ```ts
  * import { observable } from 'three-flatland'
+ * import { Color } from 'three'
  *
- * WithPropsSync(Mesh, {
- *   tint: [
- *     (v?: Color | string | number | [number, number, number]): Color => {
- *       if (v === undefined) return new Color(0xffffff)
- *       if (Array.isArray(v)) return new Color().setRGB(v[0], v[1], v[2])
- *       if (v instanceof Color) return v.clone()
- *       return new Color().set(v)
- *     },
- *     observable.color,
- *   ],
- * })
+ * class Foo {
+ *   tint = new Color(0xffffff)
+ *   constructor() {
+ *     // R3F sets `material.tint.set(...)` by mutating in place;
+ *     // wrap it so each write fires our sync.
+ *     observable.color.attach(this.tint, () => this.syncToGpu())
+ *   }
+ *   syncToGpu() {
+ *     // read this.tint.r/.g/.b and upload
+ *   }
+ * }
  * ```
  */
 
@@ -49,8 +55,9 @@ export type Snapshot = Record<string, unknown>
 
 /**
  * Strategy that wires an observable value's mutation surface and
- * captures field snapshots for memoization. Paired with a schema
- * entry in the `WithPropsSync` tuple form.
+ * captures field snapshots for memoization. The public contract for
+ * teaching the observable system about a custom value type — call
+ * `attach` to make a value reactive, `snapshot` to memoize it.
  */
 export type ObservableStrategy<T> = {
   readonly attach: (value: T, notify: () => void) => void
@@ -111,50 +118,98 @@ interface ObservableEuler extends Euler {
 
 const colorDesc: PropertyDescriptorMap = {
   r: {
-    get(this: ObservableColor) { return this._or },
-    set(this: ObservableColor, v: number) { this._or = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableColor) {
+      return this._or
+    },
+    set(this: ObservableColor, v: number) {
+      this._or = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
   g: {
-    get(this: ObservableColor) { return this._og },
-    set(this: ObservableColor, v: number) { this._og = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableColor) {
+      return this._og
+    },
+    set(this: ObservableColor, v: number) {
+      this._og = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
   b: {
-    get(this: ObservableColor) { return this._ob },
-    set(this: ObservableColor, v: number) { this._ob = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableColor) {
+      return this._ob
+    },
+    set(this: ObservableColor, v: number) {
+      this._ob = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
 }
 
 const vector2Desc: PropertyDescriptorMap = {
   x: {
-    get(this: ObservableVector2) { return this._ox },
-    set(this: ObservableVector2, v: number) { this._ox = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableVector2) {
+      return this._ox
+    },
+    set(this: ObservableVector2, v: number) {
+      this._ox = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
   y: {
-    get(this: ObservableVector2) { return this._oy },
-    set(this: ObservableVector2, v: number) { this._oy = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableVector2) {
+      return this._oy
+    },
+    set(this: ObservableVector2, v: number) {
+      this._oy = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
 }
 
 const vector3Desc: PropertyDescriptorMap = {
   x: {
-    get(this: ObservableVector3) { return this._ox },
-    set(this: ObservableVector3, v: number) { this._ox = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableVector3) {
+      return this._ox
+    },
+    set(this: ObservableVector3, v: number) {
+      this._ox = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
   y: {
-    get(this: ObservableVector3) { return this._oy },
-    set(this: ObservableVector3, v: number) { this._oy = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableVector3) {
+      return this._oy
+    },
+    set(this: ObservableVector3, v: number) {
+      this._oy = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
   z: {
-    get(this: ObservableVector3) { return this._oz },
-    set(this: ObservableVector3, v: number) { this._oz = v; this._cb() },
-    configurable: true, enumerable: true,
+    get(this: ObservableVector3) {
+      return this._oz
+    },
+    set(this: ObservableVector3, v: number) {
+      this._oz = v
+      this._cb()
+    },
+    configurable: true,
+    enumerable: true,
   },
 }
 
@@ -239,8 +294,9 @@ function snapshotEuler(e: Euler): Snapshot {
 // ============================================
 
 /**
- * Observable strategies for three.js value types. Each strategy is
- * the second element of a `WithPropsSync` tuple-form schema entry.
+ * Observable strategies for three.js value types. Call a strategy's
+ * `attach(value, notify)` directly to make a value fire `notify` on
+ * in-place mutation (R3F compat).
  *
  * - `observable.color` — Color (r, g, b)
  * - `observable.vector2` — Vector2 (x, y)
@@ -250,7 +306,13 @@ function snapshotEuler(e: Euler): Snapshot {
  */
 export const observable = {
   color: { attach: attachColor, snapshot: snapshotColor } satisfies ObservableStrategy<Color>,
-  vector2: { attach: attachVector2, snapshot: snapshotVector2 } satisfies ObservableStrategy<Vector2>,
-  vector3: { attach: attachVector3, snapshot: snapshotVector3 } satisfies ObservableStrategy<Vector3>,
+  vector2: {
+    attach: attachVector2,
+    snapshot: snapshotVector2,
+  } satisfies ObservableStrategy<Vector2>,
+  vector3: {
+    attach: attachVector3,
+    snapshot: snapshotVector3,
+  } satisfies ObservableStrategy<Vector3>,
   euler: { attach: attachEuler, snapshot: snapshotEuler } satisfies ObservableStrategy<Euler>,
 } as const

--- a/packages/three-flatland/src/pipeline/SpriteGroup.test.ts
+++ b/packages/three-flatland/src/pipeline/SpriteGroup.test.ts
@@ -229,6 +229,30 @@ describe('SpriteGroup', () => {
     expect(array[slot * 16 + 4 + 2]).toBeCloseTo(0) // b
   })
 
+  it('batched: in-place tint.set() mutation writes to batch buffer immediately (R3F compat)', () => {
+    renderer = new SpriteGroup()
+    const sprite = new Sprite2D({ material })
+
+    renderer.add(sprite)
+    renderer.updateMatrixWorld()
+
+    const entity = sprite._entity!
+    const batchEntity = entity.targetFor(InBatch)!
+    const mesh = batchEntity.get(BatchMesh)!.mesh!
+    const slot = entity.get(BatchSlot)!.slot
+
+    // R3F sets nested props by mutating the returned Color in place
+    // (`sprite.tint.set(...)`), NOT by reassigning `sprite.tint`. The
+    // observable.color.attach wrapper must fire the notify so the batch
+    // color buffer updates without a systems pass.
+    sprite.tint.set(0, 1, 0)
+
+    const array = mesh.getColorAttribute().array as Float32Array
+    expect(array[slot * 16 + 4 + 0]).toBeCloseTo(0) // r
+    expect(array[slot * 16 + 4 + 1]).toBeCloseTo(1) // g
+    expect(array[slot * 16 + 4 + 2]).toBeCloseTo(0) // b
+  })
+
   it('update() and updateMatrixWorld() should not run systems twice', () => {
     renderer = new SpriteGroup()
     const sprite = new Sprite2D({ material })

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -19,103 +19,7 @@ import {
 import type { RegistryData } from '../ecs/batchUtils'
 import { ENTITY_ID_MASK, resolveStore } from '../ecs/snapshot'
 import { getGlobalWorld } from '../ecs/world'
-
-// ============================================
-// Observable property helpers
-// ============================================
-//
-// Convert data properties (x/y/z, r/g/b) on Three.js objects to accessor
-// properties that fire a callback on write. Replaces the generic Proxy approach
-// with zero per-instance function allocations — descriptors are shared at
-// module level and reuse `this._cb` on the instance.
-//
-// Works because ALL Three.js Vector3/Color/Vector2 methods mutate via
-// `this.x = ...` etc., so the accessor setters catch every mutation path.
-
-/** @internal */
-interface Observable {
-  _cb: () => void
-}
-
-const _vec2Desc: PropertyDescriptorMap = {
-  x: {
-    get(this: Observable & { _ox: number }) {
-      return this._ox
-    },
-    set(this: Observable & { _ox: number }, v: number) {
-      this._ox = v
-      this._cb()
-    },
-    configurable: true,
-    enumerable: true,
-  },
-  y: {
-    get(this: Observable & { _oy: number }) {
-      return this._oy
-    },
-    set(this: Observable & { _oy: number }, v: number) {
-      this._oy = v
-      this._cb()
-    },
-    configurable: true,
-    enumerable: true,
-  },
-}
-
-const _colorDesc: PropertyDescriptorMap = {
-  r: {
-    get(this: Observable & { _or: number }) {
-      return this._or
-    },
-    set(this: Observable & { _or: number }, v: number) {
-      this._or = v
-      this._cb()
-    },
-    configurable: true,
-    enumerable: true,
-  },
-  g: {
-    get(this: Observable & { _og: number }) {
-      return this._og
-    },
-    set(this: Observable & { _og: number }, v: number) {
-      this._og = v
-      this._cb()
-    },
-    configurable: true,
-    enumerable: true,
-  },
-  b: {
-    get(this: Observable & { _ob: number }) {
-      return this._ob
-    },
-    set(this: Observable & { _ob: number }, v: number) {
-      this._ob = v
-      this._cb()
-    },
-    configurable: true,
-    enumerable: true,
-  },
-}
-
-/** Convert a Vector2's x/y data properties to callback-firing accessors in place. */
-function observeVector2(v: Vector2, cb: () => void): void {
-  const a = v as unknown as Record<string, unknown>
-  a._ox = v.x
-  a._oy = v.y
-  a._cb = cb
-  Object.defineProperties(v, _vec2Desc)
-}
-
-/** Convert a Color's r/g/b data properties to callback-firing accessors in place. */
-function observeColor(c: Color, cb: () => void): void {
-  const a = c as unknown as Record<string, unknown>
-  a._or = c.r
-  a._og = c.g
-  a._ob = c.b
-  a._cb = cb
-  Object.defineProperties(c, _colorDesc)
-}
+import { observable } from '../observable'
 
 /** Size in floats for each attribute type. */
 const ATTR_TYPE_SIZES: Record<string, number> = { float: 1, vec2: 2, vec3: 3, vec4: 4 }
@@ -362,7 +266,7 @@ export class Sprite2D extends Mesh {
     // Position/rotation/scale are NOT observed — accessor overhead on these
     // hot properties (read/written millions of times per frame in game loops)
     // costs more than it saves. transformSyncSystem reads directly from Object3D.
-    observeColor(this._tintColor, () => {
+    observable.color.attach(this._tintColor, () => {
       const i = this._idx
       this._colorR[i] = this._tintColor.r
       this._colorG[i] = this._tintColor.g
@@ -391,7 +295,7 @@ export class Sprite2D extends Mesh {
     // rebuild. The empty callback exists to keep the observer wired
     // (in case future code wants to react), but no work is needed
     // since `updateMatrix` reads the current `_anchor` every frame.
-    observeVector2(this._anchor, () => {
+    observable.vector2.attach(this._anchor, () => {
       this.matrixWorldNeedsUpdate = true
     })
 
@@ -579,7 +483,7 @@ export class Sprite2D extends Mesh {
    *
    * The anchor offset is baked into the matrix transform — no
    * geometry rebuild. Writing `_anchor.set(...)` triggers the
-   * observeVector2 callback which marks the matrix dirty; the next
+   * observable.vector2 callback which marks the matrix dirty; the next
    * `updateMatrix` picks up the new value.
    */
   setAnchor(x: number, y: number): this {

--- a/planning/dirty-bits-unify-with-ecs.md
+++ b/planning/dirty-bits-unify-with-ecs.md
@@ -1,5 +1,7 @@
 # Unify WithPropsSync dirty bits with ECS dirty tracking
 
+> **Superseded (2026-05-24):** The dirty-bit work shipped as `BucketedDirtyTracker`, and the prop-sync layer consolidated onto the shared `observable` strategies (`packages/three-flatland/src/observable/`) — `Sprite2D` and external extenders now call `observable.color.attach(value, notify)` directly. The `WithPropsSync` installer/mixin was removed; references to it below are historical context only.
+
 **Status:** Future improvement. NOT in scope for the WithPropsSync recast PR.
 
 **Captured:** During the WithPropsSync recast discussion (event-driven → dirty-bit). User flagged the parallel to recent sprite-sort-fix work.
@@ -18,10 +20,12 @@ Both signal "this state is stale until something acts on it." The WithPropsSync 
 Sprite2D has a dual life — standalone or batched. Standalone = own geometry + local arrays. Batched = ECS-backed with array refs swapped to world SoA. Late enrollment (when added to a SpriteGroup parent) does the swap.
 
 This forces WithPropsSync's resolver to branch on `_entity`:
+
 - `if (!this._entity) this._updateOwnUV()` (standalone)
 - `else this._entity.set(SpriteUV, {...})` (batched)
 
 If every sprite was always ECS-backed from construction (no standalone path):
+
 - Sprite props project directly to ECS traits, unconditionally.
 - WithPropsSync's resolver could be auto-generated from schema-to-trait mapping.
 - Auto-batching dynamically batches/unbatches based on material/layer/etc. — sprite doesn't know or care.
@@ -32,12 +36,14 @@ This is the auto-batching milestone (referenced in existing plans). Late enrollm
 ## What it would mean
 
 The resolver currently has branches like:
+
 ```ts
 if (!this._entity) this._updateOwnUV()
 else this._entity.set(SpriteUV, { ... })
 ```
 
 With always-on-ECS:
+
 ```ts
 this._entity.set(SpriteUV, { ... })
 ```

--- a/planning/superpowers/plans/2026-05-19-rebase-lighting-onto-sprite-sort.md
+++ b/planning/superpowers/plans/2026-05-19-rebase-lighting-onto-sprite-sort.md
@@ -5,6 +5,7 @@
 **For:** the developer rebasing `lighting-stochastic-adoption` after `fix-sprite-sort-regression` lands on `main`.
 
 **TL;DR:**
+
 - Most of the cherry-pick is **additive** (new files, new symlinks) — adopt as-is.
 - Three file-level conflict zones to resolve carefully: `Sprite2D.ts` (anchor-in-matrix surgery), `index.ts` (barrel), and `package.json` (test script).
 - One bonus fix to adopt: `skills/package.json` validate script (iterates over skills).
@@ -15,17 +16,17 @@
 
 Beyond its core sprite-sort fixes (untouched here), the branch cherry-picked the following from the abandoned `feat/with-props-sync` work:
 
-| Item | Why it landed | Type |
-|------|---------------|------|
-| `packages/three-flatland/src/observable/` (whole directory) | Standalone mutation-hook utility for Color/Vector2/Vector3/Euler; useful primitive even without WithPropsSync | **New** |
-| `skills/codemod/` (single skill with authoring + applying routing) | Authoring + applying flow for breaking-change migrations | **New** |
-| `.claude/skills/codemod` (symlink to `../../skills/codemod`) | Standard skills-package convention | **New** |
-| `planning/dirty-bits-unify-with-ecs.md` | Direction doc for the future always-on-ECS work | **New** |
-| `vitest.config.ts` typecheck block | Enables `.test-d.ts` discovery | **Additive** |
-| `package.json` `test` script `--typecheck` flag | Bundles type tests into the default `pnpm test` run | **Additive** |
-| `packages/three-flatland/src/index.ts` `export * from './observable'` | Wires the new observable module into the barrel | **Additive** |
-| `packages/three-flatland/src/sprites/Sprite2D.ts` anchor-in-matrix surgery | Removes per-anchor-change geometry rebuild; bakes anchor offset into `updateMatrix` translation | **Modifies existing** |
-| `skills/package.json` validate script fix | `for d in */` loop instead of relying on glob-to-multi-arg | **Bug fix in existing** |
+| Item                                                                       | Why it landed                                                                                                                                                                                         | Type                    |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `packages/three-flatland/src/observable/` (whole directory)                | Shared mutation-hook strategies for Color/Vector2/Vector3/Euler; `Sprite2D` and external extenders call `observable.color.attach(value, notify)` directly (the `WithPropsSync` installer was removed) | **New**                 |
+| `skills/codemod/` (single skill with authoring + applying routing)         | Authoring + applying flow for breaking-change migrations                                                                                                                                              | **New**                 |
+| `.claude/skills/codemod` (symlink to `../../skills/codemod`)               | Standard skills-package convention                                                                                                                                                                    | **New**                 |
+| `planning/dirty-bits-unify-with-ecs.md`                                    | Direction doc for the future always-on-ECS work                                                                                                                                                       | **New**                 |
+| `vitest.config.ts` typecheck block                                         | Enables `.test-d.ts` discovery                                                                                                                                                                        | **Additive**            |
+| `package.json` `test` script `--typecheck` flag                            | Bundles type tests into the default `pnpm test` run                                                                                                                                                   | **Additive**            |
+| `packages/three-flatland/src/index.ts` `export * from './observable'`      | Wires the new observable module into the barrel                                                                                                                                                       | **Additive**            |
+| `packages/three-flatland/src/sprites/Sprite2D.ts` anchor-in-matrix surgery | Removes per-anchor-change geometry rebuild; bakes anchor offset into `updateMatrix` translation                                                                                                       | **Modifies existing**   |
+| `skills/package.json` validate script fix                                  | `for d in */` loop instead of relying on glob-to-multi-arg                                                                                                                                            | **Bug fix in existing** |
 
 ---
 
@@ -57,11 +58,13 @@ Lighting's main branched from the same Sprite2D as sprite-sort, so the BEFORE st
 #### Edit 1 — `observeVector2(this._anchor, …)` callback
 
 **Before (both branches):**
+
 ```ts
 observeVector2(this._anchor, () => this.updateAnchor())
 ```
 
 **After (sprite-sort):**
+
 ```ts
 // Anchor mutation triggers a matrix recompose — `updateMatrix`
 // bakes the anchor offset into the translation component, so the
@@ -79,6 +82,7 @@ observeVector2(this._anchor, () => {
 #### Edit 2 — `setAnchor(x, y)` body
 
 **Before (both branches):**
+
 ```ts
 setAnchor(x: number, y: number): this {
   this._anchor.set(x, y)
@@ -88,6 +92,7 @@ setAnchor(x: number, y: number): this {
 ```
 
 **After (sprite-sort):**
+
 ```ts
 setAnchor(x: number, y: number): this {
   this._anchor.set(x, y)
@@ -112,6 +117,7 @@ setAnchor(x: number, y: number): this {
 #### Edit 4 — `override updateMatrix()` bakes anchor offset
 
 **Before (both branches):**
+
 ```ts
 override updateMatrix(): void {
   const te = this.matrix.elements
@@ -125,6 +131,7 @@ override updateMatrix(): void {
 ```
 
 **After (sprite-sort):**
+
 ```ts
 override updateMatrix(): void {
   const te = this.matrix.elements
@@ -235,11 +242,13 @@ exclude: ['packages/skia/**', 'packages/devtools/**', '**/node_modules/**'],
 ### Resolution
 
 Adopt both:
+
 - Keep lighting's new `exclude` value (`packages/devtools/**` instead of `packages/tweakpane/**`) in the main `exclude`
 - Add sprite-sort's `typecheck` block
 - **Update the `typecheck` block's `exclude` to also use the lighting convention** if needed — i.e., `'packages/devtools/**'` instead of `'packages/tweakpane/**'`
 
 Final:
+
 ```ts
 test: {
   // ...
@@ -366,7 +375,7 @@ If knightmark animation looks stuck on one frame, or tiles don't render: revisit
 ## What's NOT in this PR (intentionally parked)
 
 - `setFrame` removal — depends on always-on-ECS resolving the synchronous-setter contract. Codemod authored but not shipped.
-- WithPropsSync reactive mixin (event-driven OR dirty-bit) — confirmed the wrong tool for Sprite2D's ECS-bridge case. Pivoting to always-on-ECS instead.
+- WithPropsSync reactive mixin (event-driven OR dirty-bit) — confirmed the wrong tool for Sprite2D's ECS-bridge case and since removed. Prop reactivity now goes through the shared `observable` strategies (`observable.color.attach(value, notify)`); the deeper ECS-bridge coordination pivots to always-on-ECS instead.
 - Sprite2D's `texture`/`frame`/`material` reactive coordination — same reason.
 
 See [`planning/dirty-bits-unify-with-ecs.md`](../../dirty-bits-unify-with-ecs.md) for the always-on-ECS roadmap. That's the next major refactor; this PR clears the runway.


### PR DESCRIPTION
## Summary

Finishes the observable port started in #28. That PR moved sprite property-sync to direct buffer writes + the `BucketedDirtyTracker` and deleted the old `WithPropsSync` installer — but left the work half-done: `Sprite2D` **duplicated** the observe-in-place logic inline instead of consuming the shared `observable` strategies, so the public module was orphaned and its docs still described the deleted `WithPropsSync` API.

The intended design is **one shared observable pattern**, exported from `@three-flatland`, used both internally *and* by external three.js extenders building their own batched primitives. This restores that.

## What changed

- **`Sprite2D`** now uses `observable.color.attach` / `observable.vector2.attach` for its `tint`/`anchor` R3F-compat proxies (the canonical version — idempotent re-attach guard + non-enumerable backing fields, so `JSON.stringify(color)` stays clean). Deleted ~100 lines of inline duplicate (`observeColor`/`observeVector2` + the `_colorDesc`/`_vec2Desc` descriptor maps + the local `Observable` type) — confirmed referenced only within the deleted block.
- **`observable/index.ts`** docs rewritten off the deleted `WithPropsSync` tuple-form/registry to the actual **direct-`attach`** pattern; `ObservableStrategy` documented as the public contract for custom types. No runtime change.
- **R3F compat locked with a test** — `SpriteGroup.test.ts` now asserts in-place `sprite.tint.set(...)` writes the batch color buffer (no test previously covered the mutate-in-place path; existing ones only used assignment).
- Stale `WithPropsSync` references fixed in `dirty-bits-unify-with-ecs.md` (marked superseded) and `rebase-lighting-onto-sprite-sort.md`.

No public API change — the `observable` exports were already public; they're now actually consumed (and usable by extenders as intended). R3F in-place mutation behavior is preserved.

## Test plan

- [x] `pnpm lint` (eslint) — exit 0
- [x] `pnpm typecheck` — 27/27 packages
- [x] `pnpm test` — 685 passed / 5 skipped, incl. the new R3F `tint.set()` test
- [x] `prettier --check` clean on edited files
- [ ] Manual: R3F example mutating a sprite's tint/anchor in place still updates on screen

Completes #28. Independent of #27 (lighting).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced duplicated in-file reactivity wiring with a shared observable implementation for sprite tint and anchor.

* **Tests**
  * Added a test ensuring in-place sprite tint mutations immediately update batched color buffers.

* **Documentation**
  * Updated planning and module docs to reflect observable strategy consolidation and related workflow changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thejustinwalsh/three-flatland/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->