### PR TITLE
docs: fix SpriteGroup.stats JSDoc reference to nonexistent Flatland.stats

### DIFF
--- a/packages/three-flatland/src/pipeline/SpriteGroup.ts
+++ b/packages/three-flatland/src/pipeline/SpriteGroup.ts
@@ -559,7 +559,7 @@ export class SpriteGroup extends Group implements WorldProvider {
    *
    * Note: `drawCalls` is NOT computed here — it must come from
    * `renderer.info.render.calls` after the actual Three.js render pass.
-   * See Flatland.stats for the real value, or capture the delta yourself:
+   * See `flatland.spriteGroup.stats` for the real value, or capture the delta yourself:
    * ```ts
    * const before = renderer.info.render.calls
    * renderer.render(scene, camera)


### PR DESCRIPTION
Fixes #99.

`Flatland` exposes no `stats` getter; the correct accessor is `flatland.spriteGroup.stats`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on locating performance metrics for sprite groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->