### PR TITLE
fix(slides): deck light-mode readability + batch-rendering draw-call wording

### DIFF
--- a/docs/src/components/slides/make-web-games/SpriteSizzleStats.tsx
+++ b/docs/src/components/slides/make-web-games/SpriteSizzleStats.tsx
@@ -57,7 +57,7 @@ export function SpriteSizzleStats() {
         </span>
       </Headline>
       <Subline>
-        Automatic, ECS-driven batching · one draw call · FPS:{' '}
+        Automatic, ECS-driven batching · FPS:{' '}
         <span style={{ display: 'inline-block', minWidth: '2ch', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
           <span ref={fpsRef}>0</span>
         </span>

--- a/docs/src/components/slides/make-web-games/slides/index.tsx
+++ b/docs/src/components/slides/make-web-games/slides/index.tsx
@@ -167,7 +167,7 @@ export function Slides() {
         <aside className="notes">
           The real tech on display: automatic, ECS-driven sprite batching. This demo
           ramps the sprite count on a timer with live FPS and count on screen, scaling
-          until it stops being stable (≈30k, not a magic 100k). One draw call the whole way.
+          until it stops being stable (≈30k, not a magic 100k).
         </aside>
       </Slide>
 

--- a/docs/src/styles/deck.css
+++ b/docs/src/styles/deck.css
@@ -1,6 +1,18 @@
 /* Deck layout: the R3F scene is a fixed backdrop; reveal sits over it, transparent.
  * Gem tokens (--gold, --turquoize, --background, --foreground, …) come from
  * `starlight-theme/styles/theme` imported by the page. */
+
+/* The deck is always dark. The site theme flips its tokens under
+ * `@media (prefers-color-scheme: light)`, but this standalone page has no theme
+ * toggle, so a light system preference would turn slide text dark on the
+ * near-black scene. Pin the dark tokens here — this rule is unlayered, so it
+ * beats the theme's `@layer theme` values regardless of the OS preference. */
+:root {
+  color-scheme: dark;
+  --background: oklch(18% 0.006 250); /* ≈ #111418 */
+  --foreground: oklch(92% 0.008 250); /* near-white */
+}
+
 html,
 body {
   margin: 0;
@@ -41,5 +53,11 @@ body {
 /* Bold-minimalist type defaults for slide content. */
 .reveal .slides section {
   font-family: 'Public Sans', system-ui, sans-serif;
+  color: var(--foreground, #fff);
+}
+
+/* reveal.js hardcodes the prev/next nav arrows to black; keep them on the
+ * light foreground so they read on the near-black scene. */
+.reveal .controls {
   color: var(--foreground, #fff);
 }


### PR DESCRIPTION
### **User description**
Two fixes for the `make-web-games` slides deck.

## Light-mode readability (`deck.css`)

The deck is a standalone page that bypasses the Starlight layout and has no theme toggle. Under `prefers-color-scheme: light` the site theme flipped `--foreground` to a dark value, so slide text went **black on the near-black scene**, and reveal.js renders its prev/next arrows black by default.

- Pin `--foreground` / `--background` and `color-scheme: dark` on `:root` (unlayered, so it beats the theme's `@layer theme` light-media values regardless of OS preference).
- Set `.reveal .controls` to `--foreground` so the nav arrows aren't hardcoded black.

Verified in a browser under emulated `prefers-color-scheme: light`: `--foreground` resolves to `oklch(92% …)` (near-white); slide text and nav arrows are readable.

## Remove the "one draw call" claim from the sprite-batching slide

The SpriteSizzle demo can span more than one draw call (a batch is per material, not per scene), so "one draw call" is inaccurate. Removed it from the live stats overlay (`SpriteSizzleStats.tsx`) and the speaker note (`slides/index.tsx`).

`astro check`: 0 errors, 0 warnings.


___

### **PR Type**
Bug fix


___

### **Description**
- Override OS light color scheme in the deck by pinning dark CSS tokens and fixing nav arrow colors

- Remove inaccurate "one draw call" claim from the sprite‑batching slide overlay and speaker notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Light OS scheme"] --> B["Deck unreadable"]
    B --> C[":root dark tokens & arrow fix"]
    C --> D["Readable deck"]
    E["'One draw call' claim"] --> F["Removed from UI & notes"]
    F --> G["Accurate info"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deck.css</strong><dd><code>Force dark theme for deck and fix navigation arrows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/styles/deck.css

<ul><li>Added :root rule to force dark color scheme and pin --background / <br>--foreground tokens<br> <li> Added .reveal .controls rule to use --foreground, making navigation <br>arrows visible</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/140/files#diff-19223b153149e6e57e699a7ee7045d2d5b82be8c0a0bc2745e6cc4cf1e1b1ec1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SpriteSizzleStats.tsx</strong><dd><code>Remove incorrect 'one draw call' from stats overlay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/components/slides/make-web-games/SpriteSizzleStats.tsx

- Removed "· one draw call ·" from the live stats overlay subline


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/140/files#diff-7fc69888f852d1f612108c414eedd7ce22b1927450e1c7aa2b31577cb79d913f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove inaccurate 'one draw call' from speaker notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/components/slides/make-web-games/slides/index.tsx

<ul><li>Removed the "One draw call the whole way." sentence from the <br>sprite‑batching speaker notes</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/140/files#diff-494d30d509f55998624d3be684cf9cad209a929f772c105b36fe7fa2a3411c4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

