### PR TITLE
perf(examples): reuse one collision-visitor closure per frame in knightmark

### DIFF
--- a/examples/three/knightmark/main.ts
+++ b/examples/three/knightmark/main.ts
@@ -494,26 +494,33 @@ async function main() {
     for (const k of knights) spatialHash.insert(k)
     const collisionDist = sim.hitRadius * 2
     const collisionDistSq = collisionDist * collisionDist
+    // One reusable visitor closure per frame, steered by `_current`, instead
+    // of allocating a fresh `(other) => …` per WALK knight every frame — at
+    // 20k knights that was ~20k closures/frame, ~0.3MB/frame of allocation
+    // churn (both GC pressure and raw allocation cost).
+    let _current: Knight = knights[0]!
+    const _visitor = (other: Knight): boolean => {
+      if (other.state !== 'WALK') return false
+      const dx = other.sprite.position.x - _current.sprite.position.x
+      const dy = other.sprite.position.y - _current.sprite.position.y
+      const distSq = dx * dx + dy * dy
+      if (distSq < collisionDistSq) {
+        const tripChanceA = _current.speed / (_current.speed + other.speed)
+        if (Math.random() < tripChanceA) {
+          triggerTrip(_current)
+          triggerRoll(other)
+        } else {
+          triggerTrip(other)
+          triggerRoll(_current)
+        }
+        return true
+      }
+      return false
+    }
     for (const k of knights) {
       if (k.state !== 'WALK') continue
-      spatialHash.forEachNeighbor(k, (other) => {
-        if (other.state !== 'WALK') return false
-        const dx = other.sprite.position.x - k.sprite.position.x
-        const dy = other.sprite.position.y - k.sprite.position.y
-        const distSq = dx * dx + dy * dy
-        if (distSq < collisionDistSq) {
-          const tripChanceA = k.speed / (k.speed + other.speed)
-          if (Math.random() < tripChanceA) {
-            triggerTrip(k)
-            triggerRoll(other)
-          } else {
-            triggerTrip(other)
-            triggerRoll(k)
-          }
-          return true
-        }
-        return false
-      })
+      _current = k
+      spatialHash.forEachNeighbor(k, _visitor)
     }
 
     // Render — systems run automatically in updateMatrixWorld


### PR DESCRIPTION
### **User description**
## What

The knightmark collision loop allocated a fresh visitor closure **per WALK knight, every frame** — `spatialHash.forEachNeighbor(k, (other) => { … })` inside `for (const k of knights)`. At 20k knights that's ~20k closure allocations/frame. This hoists it to a single reusable closure steered by a `_current` reference set each iteration.

## Why

Surfaced while profiling knightmark at 20k+ knights. Per-frame heap sampling measured ~0.3 MB/frame of the scene's allocation churn coming from these closures — both GC-pause pressure and the raw cost of ~20k allocations/frame. Behavior is identical (same collision math, same trip/roll outcomes).

This is example-only and orthogonal to any library change (knightmark's `main.ts` was byte-identical across the recent overdraw/sort-layers work).

## Verification

- `pnpm --filter=example-three-knightmark typecheck` — clean
- Heap sampling at 20k: per-frame allocation dropped ~1.46 → ~1.12 MB/frame after the hoist.

Note: absolute fps at 20k in a dev build is dominated by the dev-only ECS perf instrumentation (~25% of main-thread time) and knightmark's stochastic collision sim, so this is scoped as an allocation/GC-pressure reduction rather than a headline fps claim.


___

### **PR Type**
Enhancement


___

### **Description**
- Reuse one collision-visitor closure per frame instead of per knight

- Reduce allocation churn (~0.3MB/frame at 20k knights)

- Maintain identical collision behavior

- Lower GC pressure with fewer short-lived closures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["For each WALK knight"]
  A -->|"before"| B["Allocate new (other) => ..."]
  B --> C["spatialHash.forEachNeighbor(k, closure)"]
  A -->|"after"| D["Set _current = k"]
  D --> E["Reuse _visitor closure"]
  E --> C
  C --> F["Collision detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Reuse collision visitor closure per frame in knightmark</code>&nbsp; &nbsp; </dd></summary>
<hr>

examples/three/knightmark/main.ts

<ul><li>Hoist collision visitor closure out of per-knight loop to one per <br>frame.<br> <li> Introduce reusable <code>_visitor</code> closure steered by <code>_current</code> reference.<br> <li> Update <code>_current</code> before each <code>spatialHash.forEachNeighbor</code> call.<br> <li> Remove per-knight allocation of arrow function, reducing ~0.3 MB/frame <br>of churn.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/163/files#diff-a18f45bca7b8bffcd727653a743c270d9405cd753962eec451a2174762c6ec7f">+25/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved collision processing efficiency in the knight animation, reducing per-frame overhead.
  * Kept the existing interaction behavior the same while making the animation loop more lightweight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->