### PR TITLE
fix(three-flatland): make render surfaces authoritative

### DIFF
--- a/.changeset/auto-three-flatland-3rvrwel.md
+++ b/.changeset/auto-three-flatland-3rvrwel.md
@@ -1,0 +1,15 @@
+---
+"three-flatland": patch
+---
+
+> Branch: fix/flatland-react-aspect
+> PR: https://github.com/thejustinwalsh/three-flatland/pull/181
+
+## Fixes
+
+- `Flatland` now auto-derives the camera aspect ratio from the render surface (renderer viewport, or the `RenderTarget` when rendering to texture) on every render, instead of defaulting to a static `1` and requiring a manual `resize()` call. Fixes scenes rendering at the wrong scale when nothing calls `resize()` (e.g. under R3F, where there was no natural place to wire a resize handler).
+- `aspect` is now a real get/set accessor (previously constructor-only), so it can be assigned via property-setting, including from JSX under R3F.
+- Setting `aspect` explicitly, or calling `resize()`, permanently switches Flatland to manual aspect control — auto-sync only applies when `aspect` is omitted, so existing manual callers are unaffected.
+- Unchanged renderer/render-target sizes short-circuit the aspect recompute, avoiding unnecessary `LightEffect` tile buffer reallocation. Zero/negative/NaN dimensions are ignored rather than latching a broken frustum, so a `0x0` initial frame self-heals automatically.
+
+Verified on WebGPU: React and three.js example twins now render pixel-identical geometry with no example-side changes required.

--- a/.changeset/auto-three-flatland-3rvrwel.md
+++ b/.changeset/auto-three-flatland-3rvrwel.md
@@ -1,0 +1,50 @@
+---
+'three-flatland': minor
+'create-three-flatland': patch
+'@three-flatland/skills': patch
+'@three-flatland/presets': patch
+---
+
+Make the render surface the default source of truth for `Flatland` camera and
+lighting dimensions. `render()` now derives its size from the active render
+target or renderer, skips unchanged dimensions, and safely waits through an
+initial `0×0` canvas measurement. React Three Fiber and vanilla Three.js users no
+longer need a manual resize bridge for the usual responsive-canvas case.
+Surface-dependent lighting and shadow buffers use physical drawing-buffer pixels,
+so HiDPI canvases and equivalent render targets share the same sizing contract.
+Each `LightEffect` also exposes `resolutionScale` for an explicit per-effect
+quality/performance tradeoff without changing camera framing, canvas DPR, or
+logical viewport uniforms.
+
+`aspect` is now a settable property for fixed camera framing, including R3F JSX
+property assignment. A fixed aspect still lets surface-dependent lighting buffers
+follow the real target size. Assigning `aspect = 'auto'` restores automatic sizing,
+including after `resize(width, height)`, which remains the escape hatch for full
+manual control of both camera and effect dimensions.
+
+Once a valid surface size exists, light effects receive a deterministic
+`init → resize → update` lifecycle.
+Effects attached after the first frame, re-enabled after a resize, or mounted
+before the canvas is measurable receive the latest valid dimensions before their
+next update. Replacing an active effect disposes its owned GPU resources before
+detachment, making later reattachment safe.
+
+Render targets without authored color-space metadata now default to sRGB, while
+explicit linear/HDR targets remain untouched. Flatland applies the final output
+color transform only when presenting to the screen, avoiding an sRGB encode in
+intermediate render targets.
+
+## BREAKING CHANGES
+
+`Flatland` no longer keeps a square `aspect = 1` frustum by default. It follows
+the render surface unless configured otherwise. If a square frustum was
+intentional, pass `aspect: 1` (or set `flatland.aspect = 1`). Otherwise, remove
+manual per-frame and `useThree(state => state.size)` resize bridges and let
+`render()` synchronize the surface. Use `'auto'` rather than removing a conditional
+R3F `aspect` prop: `aspect={locked ? 1 : 'auto'}`.
+
+The React starter template, packaged R3F skill, and Breakout mini now use the
+automatic sizing path so generated and maintained examples teach the new
+canonical integration. Paired React and Three examples, plus both starter
+templates, also select sRGB output with no tone mapping explicitly. This avoids
+R3F alpha 3's ACES default producing a different palette from plain Three.js.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@
 
 ## Build & Test
 
+- `pnpm install` is an exclusive workspace mutation. Wait for it to exit successfully before starting Nx, dev,
+  build, test, or review commands in that worktree. Never overlap an install with workspace tasks: pnpm rewrites
+  `node_modules` in place, so a concurrent Nx process can lose its own executor mid-run.
+- Run parallel validation through one Nx invocation per worktree. Do not launch independent Nx processes that
+  build the same projects concurrently; their declared outputs are shared directories.
 - `pnpm dev` — docs (port 4000) + examples MPA (port 5174) behind microfrontends proxy at http://localhost:5173
 - `pnpm --filter=example-react-tilemap dev` — run a single example
 - `pnpm sync:pack` — sync example/mini package.json deps with the workspace catalog after editing `pnpm-workspace.yaml`

--- a/docs/src/content/docs/guides/flatland.mdx
+++ b/docs/src/content/docs/guides/flatland.mdx
@@ -160,6 +160,8 @@ const indicator = new Sprite2D({ texture, lit: false }) // always full brightnes
 
 `resolutionScale` belongs to the effect that owns the surface-dependent resources. A value of `0.5` receives half-width and half-height dimensions in `LightEffect.resize()`, reducing area to one quarter while leaving camera framing, canvas resolution, renderer DPR, and logical viewport uniforms unchanged. Change Three.js `renderer.setPixelRatio()` or R3F `<Canvas dpr={...}>` instead when the entire frame should render at a lower resolution.
 
+Flatland owns an attached effect's lifecycle. Replacing the active effect or calling `setLighting(null)` disposes its GPU resources before detaching it. The effect instance can be attached again and will receive a fresh `init → resize → update` sequence, but effect-owned GPU resource handles must not be used while it is detached.
+
 See the [2D Lighting guide](../lighting/) for preset comparisons, Light2D types, and custom effects.
 
 ## Render Loop

--- a/docs/src/content/docs/guides/flatland.mdx
+++ b/docs/src/content/docs/guides/flatland.mdx
@@ -33,13 +33,18 @@ Use `Flatland` when you want a complete 2D rendering setup. Use `SpriteGroup` wh
     await renderer.init()
     document.body.appendChild(renderer.domElement)
 
+    function resizeRenderer() {
+      renderer.setSize(window.innerWidth, window.innerHeight)
+    }
+    resizeRenderer()
+    window.addEventListener('resize', resizeRenderer)
+
     const flatland = new Flatland({ viewSize: 400, clearColor: 0x1a1a2e })
     const texture = await new TextureLoader().loadAsync('/sprites/hero.png')
 
     flatland.add(new Sprite2D({ texture }))
 
     function animate() {
-      flatland.resize(window.innerWidth, window.innerHeight)
       flatland.render(renderer)
       requestAnimationFrame(animate)
     }
@@ -48,7 +53,7 @@ Use `Flatland` when you want a complete 2D rendering setup. Use `SpriteGroup` wh
   </TabItem>
   <TabItem label="React" icon="simple-icons:react">
     ```tsx
-    import { useRef, useEffect } from 'react'
+    import { useRef } from 'react'
     import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
     import { Flatland, Sprite2D, Sprite2DMaterial } from 'three-flatland/react'
     import type { Flatland as FlatlandType } from 'three-flatland/react'
@@ -58,11 +63,7 @@ Use `Flatland` when you want a complete 2D rendering setup. Use `SpriteGroup` wh
 
     function Scene() {
       const flatlandRef = useRef<FlatlandType>(null)
-      const { renderer, size } = useThree()
-
-      useEffect(() => {
-        flatlandRef.current?.resize(size.width, size.height)
-      }, [size.width, size.height])
+      const renderer = useThree((state) => state.renderer)
 
       // Render in the 'render' phase so R3F skips its own render
       useFrame(() => {
@@ -100,7 +101,7 @@ const flatland = new Flatland({
   clearAlpha: 1,          // Background alpha (< 1 for transparent)
   autoClear: true,        // Clear before each render
   postProcessing: false,  // Enable post-processing pipeline
-  aspect: 1,              // Initial aspect ratio (use resize() to update)
+  aspect: undefined,      // Auto-sync from the render surface; set a number to pin it
   camera: null,           // Custom OrthographicCamera (null = internal)
   renderTarget: null,     // RenderTarget (null = render to viewport)
 })
@@ -139,7 +140,9 @@ Flatland manages 2D lighting with `Light2D` sources and a `LightEffect` pipeline
 ```typescript
 import { DefaultLightEffect } from '@three-flatland/presets'
 
-flatland.setLighting(new DefaultLightEffect())
+const lighting = new DefaultLightEffect()
+lighting.resolutionScale = 0.5 // Optional: half-resolution effect resources
+flatland.setLighting(lighting)
 ```
 
 All sprites receive lighting by default. Set `lit: false` to opt out:
@@ -153,6 +156,9 @@ const indicator = new Sprite2D({ texture, lit: false }) // always full brightnes
 | `setLighting(effect)` | Set the active LightEffect (or `null` to disable) |
 | `lighting` | Current LightEffect (read-only) |
 | `lights` | All tracked Light2D instances (read-only) |
+| `effect.resolutionScale` | Processing resolution relative to the physical surface (default: `1`) |
+
+`resolutionScale` belongs to the effect that owns the surface-dependent resources. A value of `0.5` receives half-width and half-height dimensions in `LightEffect.resize()`, reducing area to one quarter while leaving camera framing, canvas resolution, renderer DPR, and logical viewport uniforms unchanged. Change Three.js `renderer.setPixelRatio()` or R3F `<Canvas dpr={...}>` instead when the entire frame should render at a lower resolution.
 
 See the [2D Lighting guide](../lighting/) for preset comparisons, Light2D types, and custom effects.
 
@@ -163,17 +169,22 @@ import framePipeline from '../../../assets/diagrams/frame-pipeline.svg?raw';
 
 <Diagram caption="Per-frame render pipeline" src={framePipeline} />
 
-Each frame, call `resize()` to sync the aspect ratio, then `render()` to draw:
+Each frame, call `render()`. `Flatland` reads the renderer drawing buffer or active render target size and updates its camera aspect when the surface dimensions change:
 
 ```typescript
 function animate() {
-  flatland.resize(canvas.width, canvas.height)
   flatland.render(renderer)
   requestAnimationFrame(animate)
 }
 ```
 
-`resize()` updates the internal camera frustum and render target dimensions. `render()` syncs global uniforms (time, viewport), updates sprite batches, and draws everything.
+`render()` syncs the camera, global uniforms, lighting buffers, and sprite batches before drawing. Surface-dependent GPU resources use physical drawing-buffer pixels so canvas DPR and render-target texels stay in the same coordinate space; `globals.viewportSize` remains the renderer's logical size and is paired with `globals.pixelRatio`. To keep a fixed camera aspect, pass `aspect` or assign `flatland.aspect`. Calling `resize(width, height)` opts into manual surface sizing and keeps the previous explicit-resize behavior, including resizing the current render target with `setSize()`. Automatic sizing only observes user-owned render targets; it never resizes them. Assigning either a numeric `aspect` or `'auto'` after `resize()` resumes automatic effect sizing; `'auto'` also resumes automatic camera framing. The explicit sentinel works for conditional R3F props such as `aspect={locked ? 1 : 'auto'}`. Read `flatland.resolvedAspect` when you need the current numeric ratio.
+
+When you supply a camera through `camera`, Flatland preserves its authored frustum. The aspect controls above apply to the internal camera; `resolvedAspect` reports the supplied camera's actual frustum ratio.
+
+:::caution[Breaking default]
+`Flatland` previously kept `aspect = 1` until `resize()` was called. Pass `aspect: 1` when that fixed square frustum was intentional. Remove per-frame or `useThree(state => state.size)` resize bridges when the camera should follow the render surface.
+:::
 
 ## Global Uniforms
 
@@ -183,7 +194,7 @@ Every Flatland instance exposes a `globals` object with shared uniforms. These u
 |---------|-------------|
 | `time` | Elapsed seconds (`undefined` = auto) |
 | `globalTint` | Color tint for all sprites |
-| `viewportSize` | Viewport size in pixels |
+| `viewportSize` | Logical viewport size in pixels |
 | `pixelRatio` | Device pixel ratio |
 | `wind` | Wind direction and strength |
 | `fogColor` | Fog color |

--- a/docs/src/content/docs/guides/lighting-setup.mdx
+++ b/docs/src/content/docs/guides/lighting-setup.mdx
@@ -21,6 +21,9 @@ This guide covers the practical side of 2D lighting: adding `Light2D` sources, p
     const renderer = new WebGPURenderer({ antialias: false })
     await renderer.init()
     document.body.appendChild(renderer.domElement)
+    const resizeRenderer = () => renderer.setSize(window.innerWidth, window.innerHeight)
+    resizeRenderer()
+    window.addEventListener('resize', resizeRenderer)
 
     const flatland = new Flatland({ viewSize: 400, clearColor: 0x050508 })
 
@@ -58,7 +61,7 @@ This guide covers the practical side of 2D lighting: adding `Light2D` sources, p
   </TabItem>
   <TabItem label="React" icon="simple-icons:react">
     ```tsx
-    import { Suspense, useRef, useEffect } from 'react'
+    import { Suspense, useRef } from 'react'
     import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
     import type { WebGPURenderer } from 'three/webgpu'
     import {
@@ -71,11 +74,7 @@ This guide covers the practical side of 2D lighting: adding `Light2D` sources, p
 
     function Scene() {
       const flatlandRef = useRef<Flatland>(null)
-      const { renderer, size } = useThree()
-
-      useEffect(() => {
-        flatlandRef.current?.resize(size.width, size.height)
-      }, [size.width, size.height])
+      const renderer = useThree((state) => state.renderer)
 
       useFrame(() => {
         flatlandRef.current?.render(renderer as unknown as WebGPURenderer)

--- a/docs/src/content/docs/guides/shadows-setup.mdx
+++ b/docs/src/content/docs/guides/shadows-setup.mdx
@@ -174,7 +174,7 @@ Setting `castsShadow: false` on cosmetic fill lights (slime auras, particle glow
 :::
 
 - Per-sprite `castsShadow` controls the silhouette mask, which is rendered once per frame regardless of light count. Adding more caster sprites grows the mask render cost; adding more lights grows the trace cost.
-- The OcclusionPass defaults to `resolutionScale: 0.5` (half-res silhouette mask). Drop to `0.25` on low-end mobile if shadow cost dominates and a blockier silhouette is acceptable.
+- The OcclusionPass renders its silhouette mask at half of the active `LightEffect` processing surface. Set `lighting.resolutionScale = 0.5` to halve all effect-owned surface dimensions; the shadow mask then becomes one quarter of the physical drawing-buffer dimensions. This can improve low-end performance or deliberately produce a blockier result without changing camera framing or canvas DPR.
 
 ## Next Steps
 

--- a/examples/_shared/rendererColorManagement.ts
+++ b/examples/_shared/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/animation/App.tsx
+++ b/examples/react/animation/App.tsx
@@ -4,6 +4,7 @@ import type { OrthographicCamera as ThreeOrthographicCamera } from 'three'
 import { AnimatedSprite2D, SpriteSheetLoader, SortLayers, type AnimationSetDefinition } from 'three-flatland/react'
 import { DevtoolsProvider, usePane, usePaneFolder } from '@three-flatland/devtools/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground } from './GemBackground'
 import { GEM } from './gem'
 
@@ -227,7 +228,7 @@ export default function App() {
           top: 1,
           bottom: -1,
         }}
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
         onCreated={({ renderer }) => {
           renderer.domElement.style.imageRendering = 'pixelated'
         }}

--- a/examples/react/animation/rendererColorManagement.ts
+++ b/examples/react/animation/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/basic-sprite/App.tsx
+++ b/examples/react/basic-sprite/App.tsx
@@ -4,6 +4,7 @@ import { Color, type OrthographicCamera as ThreeOrthographicCamera } from 'three
 import { Sprite2D, TextureLoader } from 'three-flatland/react'
 import { DevtoolsProvider, usePane, usePaneFolder, usePaneInput } from '@three-flatland/devtools/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground } from './GemBackground'
 import { GEM } from './gem'
 
@@ -157,7 +158,7 @@ export default function App() {
   return (
     <Canvas
       dpr={1}
-      renderer={{ antialias: false }}
+      renderer={{ antialias: false, ...exampleRendererColorConfig }}
       fallback={<WebGPUFallback />}
       onCreated={({ renderer }) => {
         renderer.domElement.style.imageRendering = 'pixelated'

--- a/examples/react/basic-sprite/rendererColorManagement.ts
+++ b/examples/react/basic-sprite/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/batch-demo/App.tsx
+++ b/examples/react/batch-demo/App.tsx
@@ -13,6 +13,7 @@ import {
   type RenderStats,
 } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { DevtoolsProvider, usePane } from '@three-flatland/devtools/react'
 import type { Pane } from 'tweakpane'
 import { GemBackground } from './GemBackground'
@@ -488,7 +489,7 @@ export default function App() {
       <Canvas
         dpr={1}
         style={{ background: '#16191e' }}
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
         fallback={<WebGPUFallback />}
         onCreated={({ renderer }) => {
           renderer.domElement.style.imageRendering = 'pixelated'

--- a/examples/react/batch-demo/rendererColorManagement.ts
+++ b/examples/react/batch-demo/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/hierarchy-clipping/App.tsx
+++ b/examples/react/hierarchy-clipping/App.tsx
@@ -4,6 +4,7 @@ import { DevtoolsProvider, usePane } from '@three-flatland/devtools/react'
 import { DataTexture, NearestFilter, RGBAFormat, type Group, type OrthographicCamera } from 'three'
 import { Sprite2D, SpriteGroup } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground } from './GemBackground'
 import { GEM } from './gem'
 
@@ -111,6 +112,7 @@ export default function App() {
     <Canvas
       orthographic
       dpr={[1, 2]}
+      renderer={{ ...exampleRendererColorConfig }}
       frameloop="always"
       camera={{ position: [0, 0, 100], near: 0.1, far: 1000 }}
       fallback={<WebGPUFallback />}

--- a/examples/react/hierarchy-clipping/rendererColorManagement.ts
+++ b/examples/react/hierarchy-clipping/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/hit-test/App.tsx
+++ b/examples/react/hit-test/App.tsx
@@ -12,6 +12,7 @@ import { usePane, DevtoolsProvider } from '@three-flatland/devtools/react'
 import { Color, Vector3 } from 'three'
 import type { ThreeEvent } from '@react-three/fiber/webgpu'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground } from './GemBackground'
 import { GEM } from './gem'
 
@@ -589,7 +590,7 @@ export default function App() {
         orthographic
         dpr={1}
         camera={{ position: [0, 0, 100], near: 0.1, far: 1000 }}
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
         fallback={<WebGPUFallback />}
         onCreated={({ renderer }) => {
           renderer.domElement.style.imageRendering = 'pixelated'

--- a/examples/react/hit-test/rendererColorManagement.ts
+++ b/examples/react/hit-test/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/knightmark/App.tsx
+++ b/examples/react/knightmark/App.tsx
@@ -16,6 +16,7 @@ import {
   type TileLayerData,
 } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { DevtoolsProvider, usePane, usePaneFolder, usePaneInput } from '@three-flatland/devtools/react'
 // Knightmark doesn't render any gem-background layer — its sprites
 // fill the viewport. The body bg (#16191e) shows through during
@@ -591,7 +592,7 @@ export default function App() {
     <>
       <Canvas
         dpr={1}
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
         fallback={<WebGPUFallback />}
         onCreated={({ renderer }) => {
           renderer.domElement.style.imageRendering = 'pixelated'

--- a/examples/react/knightmark/rendererColorManagement.ts
+++ b/examples/react/knightmark/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/lighting/App.tsx
+++ b/examples/react/lighting/App.tsx
@@ -17,6 +17,7 @@ import {
   type AnimationSetDefinition,
 } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { DefaultLightEffect, NormalMapProvider } from '@three-flatland/presets'
 import '@three-flatland/presets/react'
 import { usePane, usePaneFolder, usePaneInput } from '@three-flatland/devtools/react'
@@ -281,7 +282,6 @@ function FlatlandScene(props: SceneProps) {
   const size = useThree((s) => s.size)
   const flatlandRef = useRef<Flatland>(null)
   const tilemapRef = useRef<TileMap2D>(null)
-  const defaultLightRef = useRef<InstanceType<typeof DefaultLightEffect>>(null)
 
   const torchLightRefs = useRef<(Light2D | null)[]>([])
   const [torchEnabled, setTorchEnabled] = useState<boolean[]>([])
@@ -406,84 +406,12 @@ function FlatlandScene(props: SceneProps) {
     if (slimesRef.current.length > props.slimeCount) slimesRef.current.length = props.slimeCount
   }
 
-  // Push uniform values each frame via refs — effect instance updates
-  // for *uniform* fields are zero-cost `.value =` writes on the
-  // underlying TSL uniform nodes. The compile-time toggles
-  // (`*Enabled`) below are different: assigning them re-runs the
-  // LightEffect's `_buildLightFn` and triggers a shader recompile.
-  useEffect(() => {
-    const e = defaultLightRef.current as unknown as {
-      bands: number
-      shadowStrength: number
-      shadowBias: number
-      shadowStartOffsetScale: number
-      shadowMaxDistance: number
-      shadowPixelSize: number
-      pixelSize: number
-      lightHeight: number
-      glowRadius: number
-      glowIntensity: number
-      rimIntensity: number
-    } | null
-    if (!e) return
-    e.bands = props.bands
-    e.shadowStrength = props.shadowStrength
-    e.shadowBias = props.shadowBias
-    e.shadowStartOffsetScale = props.shadowStartOffsetScale
-    e.shadowMaxDistance = props.shadowMaxDistance
-    e.shadowPixelSize = props.shadowPixelSize
-    e.pixelSize = props.pixelSize
-    e.lightHeight = props.lightHeight
-    e.glowRadius = props.glowRadius
-    e.glowIntensity = props.glowIntensity
-    e.rimIntensity = props.rimIntensity
-  }, [
-    props.bands,
-    props.shadowStrength,
-    props.shadowBias,
-    props.shadowStartOffsetScale,
-    props.shadowMaxDistance,
-    props.shadowPixelSize,
-    props.pixelSize,
-    props.lightHeight,
-    props.glowRadius,
-    props.glowIntensity,
-    props.rimIntensity,
-  ])
-
-  // Compile-time toggle pushes — separate from the uniform pushes
-  // above so a uniform tweak never accidentally bumps a constant.
-  // Each setter call here triggers `_rebuildLightFn` if the value
-  // actually changed (early-out on identity).
-  useEffect(() => {
-    const e = defaultLightRef.current as unknown as {
-      bandsEnabled: boolean
-      pixelSnapEnabled: boolean
-      shadowPixelSnapEnabled: boolean
-      glowEnabled: boolean
-      rimEnabled: boolean
-    } | null
-    if (!e) return
-    e.bandsEnabled = props.bandsEnabled
-    e.pixelSnapEnabled = props.pixelSnapEnabled
-    e.shadowPixelSnapEnabled = props.shadowPixelSnapEnabled
-    e.glowEnabled = props.glowEnabled
-    e.rimEnabled = props.rimEnabled
-  }, [props.bandsEnabled, props.pixelSnapEnabled, props.shadowPixelSnapEnabled, props.glowEnabled, props.rimEnabled])
-
   useEffect(() => {
     // torch_switch tiles hold a torch Light2D at their center — treating
     // them as shadow casters would self-shadow their own light. They remain
     // collision for the hero (handled separately), just not occluders.
     tilemapRef.current?.markOccluders(['collision'])
   }, [mapData])
-
-  useEffect(() => {
-    const fl = flatlandRef.current
-    if (!fl) return
-    fl.viewSize = viewSize
-    fl.resize(size.width, size.height)
-  }, [size.width, size.height, viewSize])
 
   // Hero input
   useEffect(() => {
@@ -882,8 +810,8 @@ function FlatlandScene(props: SceneProps) {
       <flatland ref={flatlandRef} viewSize={viewSize} clearColor={0x06060c}>
         {props.lightingEnabled && (
           <defaultLightEffect
-            ref={defaultLightRef}
             attach={attachLighting}
+            resolutionScale={0.5}
             bands={props.bands}
             shadowStrength={props.shadowStrength}
             shadowBias={props.shadowBias}
@@ -891,6 +819,15 @@ function FlatlandScene(props: SceneProps) {
             shadowMaxDistance={props.shadowMaxDistance}
             shadowPixelSize={props.shadowPixelSize}
             pixelSize={props.pixelSize}
+            lightHeight={props.lightHeight}
+            glowRadius={props.glowRadius}
+            glowIntensity={props.glowIntensity}
+            rimIntensity={props.rimIntensity}
+            bandsEnabled={props.bandsEnabled}
+            pixelSnapEnabled={props.pixelSnapEnabled}
+            shadowPixelSnapEnabled={props.shadowPixelSnapEnabled}
+            glowEnabled={props.glowEnabled}
+            rimEnabled={props.rimEnabled}
             categoryQuotas={{ slime: props.slimeQuota }}
           />
         )}
@@ -1079,7 +1016,7 @@ export default function App() {
   const rimEnabled = rimIntensity > 0
 
   return (
-    <Canvas renderer={{ antialias: false }} fallback={<WebGPUFallback />}>
+    <Canvas dpr={1} renderer={{ antialias: false, ...exampleRendererColorConfig }} fallback={<WebGPUFallback />}>
       <color attach="background" args={['#06060c']} />
       <Suspense fallback={null}>
         <FlatlandScene

--- a/examples/react/lighting/rendererColorManagement.ts
+++ b/examples/react/lighting/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/pass-effects/App.tsx
+++ b/examples/react/pass-effects/App.tsx
@@ -1,12 +1,13 @@
 import { Canvas, extend, useLoader, useFrame, useThree } from '@react-three/fiber/webgpu'
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useLayoutEffect } from 'react'
 import { convertToTexture } from 'three/tsl'
 import type { WebGPURenderer } from 'three/webgpu'
 import type TextureNode from 'three/src/nodes/accessors/TextureNode.js'
 import { Flatland, Sprite2D, TextureLoader, createPassEffect } from 'three-flatland/react'
 import type { PassEffect } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
-import { GemBackground } from './GemBackground'
+import { exampleRendererColorConfig } from './rendererColorManagement'
+import { useGemGradient } from './GemBackground'
 import { GEM } from './gem'
 import {
   crtComplete,
@@ -232,6 +233,20 @@ function FlatlandScene({ preset }: { preset: PresetName }) {
   const renderer = useThree((s) => s.renderer)
   const presetRef = useRef<ActivePreset>({ passes: [], timeDriven: [] })
   const elapsedRef = useRef(0)
+  const gemBackground = useGemGradient(GEM)
+
+  // Flatland owns and renders an internal scene. Writing backgroundNode to
+  // R3F's outer scene is invisible because the render-phase callback below
+  // deliberately presents Flatland's scene instead.
+  useLayoutEffect(() => {
+    const scene = flatlandRef.current?.scene as unknown as { backgroundNode?: unknown }
+    if (!scene) return
+    const previous = scene.backgroundNode
+    scene.backgroundNode = gemBackground
+    return () => {
+      scene.backgroundNode = previous
+    }
+  }, [gemBackground])
 
   // Apply preset when it changes (effect fires after mount, flatlandRef is ready)
   useEffect(() => {
@@ -253,19 +268,17 @@ function FlatlandScene({ preset }: { preset: PresetName }) {
   })
 
   // Render in the 'render' phase so R3F skips its own render.
-  const size = useThree((s) => s.size)
   useFrame(
     () => {
       const flatland = flatlandRef.current
       if (!flatland) return
-      flatland.resize(size.width, size.height)
       flatland.render(renderer as unknown as WebGPURenderer)
     },
     { phase: 'render' }
   )
 
   return (
-    <flatland ref={flatlandRef} viewSize={400} clearColor={0x1a1a2e}>
+    <flatland ref={flatlandRef} viewSize={400} clearColor={0x16191e}>
       <SpriteScene />
     </flatland>
   )
@@ -292,13 +305,12 @@ export default function App() {
       orthographic
       dpr={1}
       camera={{ zoom: 5, position: [0, 0, 100] }}
-      renderer={{ antialias: false }}
+      renderer={{ antialias: false, ...exampleRendererColorConfig }}
       fallback={<WebGPUFallback />}
       onCreated={({ renderer }) => {
         renderer.domElement.style.imageRendering = 'pixelated'
       }}
     >
-      <GemBackground gem={GEM} />
       <FlatlandScene preset={preset as PresetName} />
     </Canvas>
   )

--- a/examples/react/pass-effects/rendererColorManagement.ts
+++ b/examples/react/pass-effects/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/skia/App.tsx
+++ b/examples/react/skia/App.tsx
@@ -13,6 +13,7 @@ import {
   attachSkiaTexture,
 } from '@three-flatland/skia/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { SkiaPaint, SkiaPath } from '@three-flatland/skia'
 import type { SkiaCanvas as SkiaCanvasInstance } from '@three-flatland/skia/three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
@@ -676,7 +677,7 @@ export default function App() {
     <SkiaErrorBoundary>
       <Canvas
         camera={{ position: [0, 0.9, 4.5], fov: 40, near: 0.1, far: 100 }}
-        renderer={{ antialias: true }}
+        renderer={{ antialias: true, ...exampleRendererColorConfig }}
         fallback={<WebGPUFallback />}
         onCreated={({ scene, renderer }) => {
           // Pure-black clear + fog so foreground 3D meshes (floor, panels)

--- a/examples/react/skia/rendererColorManagement.ts
+++ b/examples/react/skia/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/slug-text/App.tsx
+++ b/examples/react/slug-text/App.tsx
@@ -11,6 +11,7 @@ import {
   usePaneRadioGrid,
 } from '@three-flatland/devtools/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground, gemGradientCanvas2D } from './GemBackground'
 import { GEM } from './gem'
 
@@ -1026,7 +1027,7 @@ export default function App() {
         // Slug provides its own analytic anti-aliasing via per-fragment
         // coverage — MSAA adds 4× sample cost + a canvas-area resolve pass
         // for zero visual gain. Keep it off.
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
       >
         <GemBackground gem={GEM} />
         <PixelCamera />

--- a/examples/react/slug-text/rendererColorManagement.ts
+++ b/examples/react/slug-text/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/template/App.tsx
+++ b/examples/react/template/App.tsx
@@ -4,6 +4,7 @@ import type { OrthographicCamera as ThreeOrthographicCamera } from 'three'
 import { Sprite2D, TextureLoader } from 'three-flatland/react'
 import { DevtoolsProvider, usePane, usePaneInput } from '@three-flatland/devtools/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 
 extend({ Sprite2D })
 
@@ -56,7 +57,7 @@ export default function App() {
         top: 1,
         bottom: -1,
       }}
-      renderer={{ antialias: false }}
+      renderer={{ antialias: false, ...exampleRendererColorConfig }}
       onCreated={({ renderer }) => {
         renderer.domElement.style.imageRendering = 'pixelated'
       }}

--- a/examples/react/template/rendererColorManagement.ts
+++ b/examples/react/template/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/tilemap/App.tsx
+++ b/examples/react/tilemap/App.tsx
@@ -4,6 +4,7 @@ import { DataTexture, RGBAFormat, NearestFilter, SRGBColorSpace, type Orthograph
 import { TileMap2D, type TileMapData, type TilesetData, type TileLayerData } from 'three-flatland/react'
 import { DevtoolsProvider, usePane, usePaneFolder, usePaneInput, usePaneButton } from '@three-flatland/devtools/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { GemBackground } from './GemBackground'
 import { GEM } from './gem'
 
@@ -692,7 +693,7 @@ export default function App() {
   return (
     <Canvas
       dpr={1}
-      renderer={{ antialias: false }}
+      renderer={{ antialias: false, ...exampleRendererColorConfig }}
       fallback={<WebGPUFallback />}
       style={{ touchAction: 'none' }}
       onCreated={({ renderer }) => {

--- a/examples/react/tilemap/rendererColorManagement.ts
+++ b/examples/react/tilemap/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/react/tsl-nodes/App.tsx
+++ b/examples/react/tsl-nodes/App.tsx
@@ -13,6 +13,7 @@ import {
   type AnimationSetDefinition,
 } from 'three-flatland/react'
 import { WebGPUFallback } from './WebGPUFallback'
+import { exampleRendererColorConfig } from './rendererColorManagement'
 import { tintAdditive, hueShift, saturate, outline8, pixelate, dissolvePixelated, tint } from '@three-flatland/nodes'
 import { DevtoolsProvider, usePane, usePaneFolder } from '@three-flatland/devtools/react'
 import { GemBackground } from './GemBackground'
@@ -454,7 +455,7 @@ export default function App() {
       {/* Three.js Canvas */}
       <Canvas
         dpr={1}
-        renderer={{ antialias: false }}
+        renderer={{ antialias: false, ...exampleRendererColorConfig }}
         fallback={<WebGPUFallback />}
         onCreated={({ renderer }) => {
           renderer.domElement.style.imageRendering = 'pixelated'

--- a/examples/react/tsl-nodes/rendererColorManagement.ts
+++ b/examples/react/tsl-nodes/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/animation/main.ts
+++ b/examples/three/animation/main.ts
@@ -5,6 +5,7 @@ import { createPane } from '@three-flatland/devtools'
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 /* HMR-tracked teardown state. Without this, every dev save accumulates
  * a fresh renderer + animate() loop while the previous one keeps
@@ -31,6 +32,7 @@ async function main() {
 
   // WebGPU Renderer (required for TSL materials)
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/animation/rendererColorManagement.ts
+++ b/examples/three/animation/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/basic-sprite/main.ts
+++ b/examples/three/basic-sprite/main.ts
@@ -5,6 +5,7 @@ import { createPane } from '@three-flatland/devtools'
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 // HMR cleanup — stop the old animate loop + dispose the old renderer
 // when Vite reloads this module. Without this, every dev save stacks a
@@ -36,6 +37,7 @@ async function main() {
 
   // WebGPU Renderer (required for TSL materials)
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/basic-sprite/rendererColorManagement.ts
+++ b/examples/three/basic-sprite/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/batch-demo/main.ts
+++ b/examples/three/batch-demo/main.ts
@@ -13,6 +13,7 @@ import { createPane } from '@three-flatland/devtools'
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 // Configuration
 const TILE_SIZE = 64
@@ -80,6 +81,7 @@ async function main() {
 
   // WebGPU Renderer
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/batch-demo/rendererColorManagement.ts
+++ b/examples/three/batch-demo/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/hierarchy-clipping/main.ts
+++ b/examples/three/hierarchy-clipping/main.ts
@@ -5,6 +5,7 @@ import { Sprite2D, SpriteGroup, createDevtoolsProvider } from 'three-flatland'
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 const palette = [0x55, 0xd6, 0xbe, 0xff, 0xb4, 0x8e, 0xff, 0xff, 0xff, 0xc8, 0x57, 0xff, 0xff, 0x73, 0xa8, 0xff]
 const texture = new DataTexture(new Uint8Array(palette), 4, 1, RGBAFormat)
@@ -51,6 +52,7 @@ viewport.add(firstView, secondView)
 
 async function main() {
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
   renderer.setSize(innerWidth, innerHeight)
   document.body.appendChild(renderer.domElement)

--- a/examples/three/hierarchy-clipping/rendererColorManagement.ts
+++ b/examples/three/hierarchy-clipping/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/hit-test/main.ts
+++ b/examples/three/hit-test/main.ts
@@ -5,6 +5,7 @@ import { createPane } from '@three-flatland/devtools'
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 // HMR cleanup — stop the old animate loop + dispose the old renderer
 // when Vite reloads this module. Without this, every dev save stacks a
@@ -83,6 +84,7 @@ async function main() {
 
   // WebGPU Renderer (required for TSL materials)
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/hit-test/rendererColorManagement.ts
+++ b/examples/three/hit-test/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/knightmark/main.ts
+++ b/examples/three/knightmark/main.ts
@@ -3,6 +3,7 @@ import { Scene, OrthographicCamera, NearestFilter } from 'three'
 import { gemClearColor } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 import {
   AnimatedSprite2D,
   Sprite2DMaterial,
@@ -203,6 +204,7 @@ let activeRenderer: WebGPURenderer | null = null
 async function main() {
   // WebGPU renderer
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/knightmark/rendererColorManagement.ts
+++ b/examples/three/knightmark/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/lighting/main.ts
+++ b/examples/three/lighting/main.ts
@@ -1,6 +1,7 @@
 import { WebGPURenderer } from 'three/webgpu'
 import { Vector2 } from 'three'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 import {
   Flatland,
   Light2D,
@@ -172,6 +173,7 @@ function newSlime(mapHalfW: number, mapHalfH: number): SlimeState {
 async function main() {
   // ─── Renderer ───────────────────────────────────────────────────
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1)
   renderer.domElement.style.imageRendering = 'pixelated'
@@ -182,13 +184,11 @@ async function main() {
   const flatland = new Flatland({
     viewSize: VIEW_SIZE,
     clearColor: 0x06060c,
-    aspect: window.innerWidth / window.innerHeight,
   })
-  flatland.resize(window.innerWidth, window.innerHeight)
 
   // ─── Lighting ───────────────────────────────────────────────────
   const lightEffect = new DefaultLightEffect()
-  flatland.setLighting(lightEffect)
+  lightEffect.resolutionScale = 0.5
   // Per-category quota: cap how many slime lights any single tile may
   // accumulate before falling back to compensation. Keeps hero/torch
   // lights from being crowded out in dense slime clusters.
@@ -207,7 +207,6 @@ async function main() {
   // Now that the map's world size is known, frame it to the canvas.
   const refitView = () => {
     flatland.viewSize = fitViewSize(window.innerWidth, window.innerHeight, mapHalfW * 2, mapHalfH * 2)
-    flatland.resize(window.innerWidth, window.innerHeight)
   }
   refitView()
 
@@ -473,6 +472,10 @@ async function main() {
   lightingConstants.glowEnabled = prevGlowEnabled
   lightingConstants.rimEnabled = prevRimEnabled
   pushUniforms()
+  // Attach only after the initial compile-time options are configured.
+  // Once attached, changing those options intentionally rebuilds the
+  // shader graph and emits a development warning.
+  flatland.setLighting(lightEffect)
 
   // ─── Tweakpane UI ───────────────────────────────────────────────
   const paneBundle = createPane({ driver: 'manual' })

--- a/examples/three/lighting/rendererColorManagement.ts
+++ b/examples/three/lighting/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/pass-effects/main.ts
+++ b/examples/three/pass-effects/main.ts
@@ -6,6 +6,7 @@ import { Flatland, Sprite2D, TextureLoader, createPassEffect } from 'three-flatl
 import { gemGradientNode } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 import type { PassEffect } from 'three-flatland'
 import {
   // CRT display nodes
@@ -304,6 +305,7 @@ async function main() {
   ;(flatland.scene as any).backgroundNode = gemGradientNode({ gem: GEM })
 
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art
@@ -311,8 +313,6 @@ async function main() {
   document.body.appendChild(renderer.domElement)
 
   if (!(await initializeRenderer(renderer))) return
-
-  flatland.resize(window.innerWidth, window.innerHeight)
 
   // Load texture and create sprite scene
   const texture = await TextureLoader.load('./icon.svg')
@@ -486,7 +486,6 @@ async function main() {
 
   window.addEventListener('resize', () => {
     renderer.setSize(window.innerWidth, window.innerHeight)
-    flatland.resize(window.innerWidth, window.innerHeight)
   })
 
   // ─── Render Loop ────────────────────────────────────────────────────────

--- a/examples/three/pass-effects/rendererColorManagement.ts
+++ b/examples/three/pass-effects/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/skia/main.ts
+++ b/examples/three/skia/main.ts
@@ -40,6 +40,7 @@ import {
 import { createPane } from '@three-flatland/devtools'
 import { createDevtoolsProvider } from 'three-flatland'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 function setStatus(msg: string, ok: boolean) {
   console.log(`[skia] ${msg}`)
@@ -114,6 +115,7 @@ async function main() {
 
   // ── Three.js setup (3D perspective) ──
   const renderer = new WebGPURenderer({ antialias: true })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(dpr)

--- a/examples/three/skia/rendererColorManagement.ts
+++ b/examples/three/skia/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/slug-text/main.ts
+++ b/examples/three/slug-text/main.ts
@@ -7,6 +7,7 @@ import { createPane } from '@three-flatland/devtools'
 import { gemGradientNode, gemGradientCanvas2D } from './GemBackground'
 import { GEM } from './gem'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 // --- Lorem ipsum generator ---
 
@@ -208,6 +209,7 @@ async function main() {
   // Slug's shader is analytically antialiased per-fragment; MSAA would add
   // 4× sample cost + a canvas-area resolve for zero visual gain.
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(w, h)
   renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))

--- a/examples/three/slug-text/rendererColorManagement.ts
+++ b/examples/three/slug-text/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/template/main.ts
+++ b/examples/three/template/main.ts
@@ -3,6 +3,7 @@ import { Scene, OrthographicCamera, Color } from 'three'
 import { Sprite2D, TextureLoader, createDevtoolsProvider } from 'three-flatland'
 import { createPane } from '@three-flatland/devtools'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 
 /* HMR-tracked teardown state. Without this, every dev save accumulates
  * a fresh renderer + animate() loop while the previous one keeps
@@ -27,6 +28,7 @@ async function main() {
   camera.position.z = 100
 
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/template/rendererColorManagement.ts
+++ b/examples/three/template/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/tilemap/main.ts
+++ b/examples/three/tilemap/main.ts
@@ -1,5 +1,6 @@
 import { WebGPURenderer } from 'three/webgpu'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 import {
   Scene,
   OrthographicCamera,
@@ -465,6 +466,7 @@ async function main() {
 
   // WebGPU Renderer
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/tilemap/rendererColorManagement.ts
+++ b/examples/three/tilemap/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/examples/three/tsl-nodes/main.ts
+++ b/examples/three/tsl-nodes/main.ts
@@ -1,5 +1,6 @@
 import { WebGPURenderer } from 'three/webgpu'
 import { initializeRenderer } from './rendererFallback'
+import { configureExampleRendererColor } from './rendererColorManagement'
 import { texture as sampleTexture, uv, attribute, vec2, vec4, float } from 'three/tsl'
 import { Scene, OrthographicCamera, NearestFilter, CanvasTexture, RepeatWrapping } from 'three'
 import { gemGradientNode } from './GemBackground'
@@ -164,6 +165,7 @@ async function main() {
 
   // WebGPU Renderer (required for TSL materials)
   const renderer = new WebGPURenderer({ antialias: false })
+  configureExampleRendererColor(renderer)
   activeRenderer = renderer
   renderer.setSize(window.innerWidth, window.innerHeight)
   renderer.setPixelRatio(1) // Pixel-perfect for pixel art

--- a/examples/three/tsl-nodes/rendererColorManagement.ts
+++ b/examples/three/tsl-nodes/rendererColorManagement.ts
@@ -1,0 +1,20 @@
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+
+/**
+ * Canonical color pipeline for paired examples.
+ *
+ * R3F initializes renderers with ACESFilmicToneMapping while a plain
+ * WebGPURenderer defaults to NoToneMapping. Leaving those framework defaults
+ * in place makes otherwise identical React and Three examples display
+ * different colors. Keep the presentation transform explicit on both sides.
+ */
+export const exampleRendererColorConfig = {
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+} as const
+
+export function configureExampleRendererColor(renderer: WebGPURenderer): void {
+  renderer.outputColorSpace = exampleRendererColorConfig.outputColorSpace
+  renderer.toneMapping = exampleRendererColorConfig.toneMapping
+}

--- a/minis/breakout/src/Game.tsx
+++ b/minis/breakout/src/Game.tsx
@@ -104,7 +104,6 @@ function GameScene({ soundsRef, isVisible, onGameStateChange, onStatsChange }: G
   const world = useWorld()
   const flatlandRef = useRef<FlatlandType>(null)
   const renderer = useThree((s) => s.renderer)
-  const size = useThree((s) => s.size)
   const fpsRef = useRef({ frames: 0, time: 0, current: 60 })
 
   // Create materials with TSL effects
@@ -240,7 +239,6 @@ function GameScene({ soundsRef, isVisible, onGameStateChange, onStatsChange }: G
       if (!isVisible) return
       const flatland = flatlandRef.current
       if (!flatland) return
-      flatland.resize(size.width, size.height)
       flatland.render(renderer as unknown as WebGPURenderer)
     },
     { phase: 'render' }

--- a/nx.json
+++ b/nx.json
@@ -49,8 +49,9 @@
       "cache": false
     },
     "lint": {
+      "dependsOn": ["^build"],
       "cache": true,
-      "inputs": ["default", "{workspaceRoot}/.oxlintrc.json"],
+      "inputs": ["default", "^production", "{workspaceRoot}/.oxlintrc.json"],
       "outputs": []
     }
   }

--- a/packages/create-three-flatland/templates/react/AGENTS.md
+++ b/packages/create-three-flatland/templates/react/AGENTS.md
@@ -24,7 +24,7 @@ Two corollaries: never add a `WebGLRenderer` fallback path (the fallback already
 
 ## The opinionated default: a `Flatland` root
 
-A `Flatland` instance is the front door. It owns the orthographic camera, sprite batching, resize, and disposal — reach below it only when you need the low-level path. The core of `src/App.tsx`:
+A `Flatland` instance is the front door. It owns the orthographic camera, sprite batching, render-surface sizing, and disposal — reach below it only when you need the low-level path. The core of `src/App.tsx`:
 
 ```tsx
 extend({ Flatland, Sprite2D }) // once, at module scope
@@ -36,11 +36,11 @@ extend({ Flatland, Sprite2D }) // once, at module scope
 </Canvas>
 ```
 
-`Flatland` owns an internal scene and camera, so it renders manually: `useFrame(() => flatlandRef.current?.render(gl), { phase: 'render' })` makes R3F skip its own render pass.
+`Flatland` owns an internal scene and camera, so it renders manually: `useFrame(() => flatlandRef.current?.render(renderer), { phase: 'render' })` makes R3F skip its own render pass.
 
 **Pointer events depend on which camera R3F raycasts with, and that differs by mode:**
 
-- **To the screen** (this template) — hand Flatland's camera to R3F as the default: `set({ camera: flatland.camera })` from a callback ref on `<flatland>`, with `camera.manual = true` so R3F leaves the frustum to `flatland.resize()`. One camera, nothing to keep in sync. Keep the `Canvas` `orthographic`.
+- **To the screen** (this template) — hand Flatland's camera to R3F as the default: `set({ camera: flatland.camera })` from a callback ref on `<flatland>`, with `camera.manual = true` so R3F leaves the frustum to `flatland.render()`. Flatland derives the frustum from the render surface, so no resize effect is needed. One camera, nothing to keep in sync. Keep the `Canvas` `orthographic`.
 - **To a texture, or children portalled into `flatland.scene`** — R3F's default camera is the wrong one, so re-cast the pointer with `createFlatlandCompute` from `three-flatland/react`:
   ```tsx
   createPortal(children, flatland.scene, {
@@ -55,7 +55,7 @@ Two R3F rules this project follows everywhere:
 1. **Register classes with `extend()` before using them as JSX.** `extend({ Flatland, Sprite2D })` is what makes `<flatland>` and `<sprite2D>` valid elements.
 2. **Import from `three-flatland/react` and `@react-three/fiber/webgpu`** — never bare `@react-three/fiber`. The `/react` subpath carries the JSX type augmentations; the `/webgpu` subpath is the renderer rule applied to R3F.
 
-The `flatland-r3f` skill (see Skills below) is the full integration guide — extend patterns, child routing, post-processing, resize wiring, and the imperative anti-patterns to avoid.
+The `flatland-r3f` skill (see Skills below) is the full integration guide — extend patterns, child routing, post-processing, automatic surface sizing, and the imperative anti-patterns to avoid.
 
 ## Package routing map
 

--- a/packages/create-three-flatland/templates/react/src/App.tsx
+++ b/packages/create-three-flatland/templates/react/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { CSSProperties, RefObject } from 'react'
 import { Canvas, extend, useFrame, useLoader, useThree } from '@react-three/fiber/webgpu'
+import { NoToneMapping, SRGBColorSpace } from 'three'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland, Sprite2D, TextureLoader } from 'three-flatland/react'
 // Pure scene maths, extracted so it can be unit-tested without a GPU or a
@@ -50,7 +51,6 @@ function Scene() {
   }, [])
   const flatlandRef = useRef<Flatland>(null)
   const set = useThree((s) => s.set)
-  const size = useThree((s) => s.size)
 
   // Flatland renders to the screen with its own camera, so hand that camera to
   // R3F as the default — pointer events then raycast through the same object
@@ -59,13 +59,11 @@ function Scene() {
     (instance: Flatland | null) => {
       flatlandRef.current = instance
       if (!instance) return
-      instance.resize(size.width, size.height)
       // `manual` is read by R3F but not declared on three's camera type.
       ;(instance.camera as typeof instance.camera & { manual?: boolean }).manual = true
-      instance.camera.updateProjectionMatrix()
       set({ camera: instance.camera })
     },
-    [set, size.width, size.height]
+    [set]
   )
   const spriteRef = useRef<Sprite2D>(null)
   const renderer = useThree((s) => s.renderer as WebGPURenderer)
@@ -113,7 +111,11 @@ export default function App() {
   const containerRef = useRef<HTMLDivElement>(null)
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
-      <Canvas orthographic renderer={{ antialias: false }} fallback={<RendererFallback />}>
+      <Canvas
+        orthographic
+        renderer={{ antialias: false, outputColorSpace: SRGBColorSpace, toneMapping: NoToneMapping }}
+        fallback={<RendererFallback />}
+      >
         <Suspense fallback={null}>
           <Scene />
         </Suspense>

--- a/packages/create-three-flatland/templates/three/src/main.ts
+++ b/packages/create-three-flatland/templates/three/src/main.ts
@@ -1,5 +1,5 @@
 import { WebGPURenderer } from 'three/webgpu'
-import { Color, Raycaster, Vector2 } from 'three'
+import { Color, NoToneMapping, Raycaster, SRGBColorSpace, Vector2 } from 'three'
 import { Flatland, Sprite2D, TextureLoader } from 'three-flatland'
 // Pure scene maths, extracted so it can be unit-tested without a GPU.
 // See src/interaction.test.ts — `npm run test`.
@@ -42,6 +42,8 @@ async function main() {
   // Always WebGPURenderer — it selects the backend itself (WebGPU where
   // supported, WebGL2 fallback where not). Never construct WebGLRenderer.
   const renderer = new WebGPURenderer({ antialias: false })
+  renderer.outputColorSpace = SRGBColorSpace
+  renderer.toneMapping = NoToneMapping
   activeRenderer = renderer
   activeFlatland = flatland
   container.appendChild(renderer.domElement)
@@ -112,7 +114,6 @@ async function main() {
   }
 
   const resize = () => {
-    flatland.resize(container.clientWidth, container.clientHeight)
     renderer.setSize(container.clientWidth, container.clientHeight)
   }
   on(window, 'resize', resize)

--- a/packages/presets/src/lighting/DefaultLightEffect.ts
+++ b/packages/presets/src/lighting/DefaultLightEffect.ts
@@ -1,4 +1,3 @@
-import { Vector2 } from 'three'
 import { vec2, vec3, vec4, float, int, Fn, Loop, If, Break } from 'three/tsl'
 import type Node from 'three/src/nodes/core/Node.js'
 import {
@@ -402,10 +401,6 @@ const _DefaultLightEffect = createLightEffect({
         return vec4(litColor, ctx.color.a)
       })() as Node<'vec4'>
     }
-  },
-  init(ctx) {
-    const size = ctx.renderer.getSize(new Vector2())
-    this.forwardPlus.init(size.x, size.y)
   },
   update(ctx) {
     this.forwardPlus.setWorldBounds(ctx.worldSize, ctx.worldOffset)

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -101,7 +101,12 @@ export interface FlatlandOptions {
   clearAlpha?: number
   /** Enable post-processing pipeline (default: false) */
   postProcessing?: boolean
-  /** Initial aspect ratio (default: 1, use resize() to update) */
+  /**
+   * Fixed aspect ratio. When omitted, Flatland derives the aspect from
+   * the renderer's viewport (or the render target) automatically on
+   * every render. Passing a value — or calling resize() — switches to
+   * manual control and disables the automatic sync.
+   */
   aspect?: number
 }
 
@@ -206,6 +211,18 @@ export class Flatland extends Group implements WorldProvider {
   /** Current aspect ratio */
   private _aspect: number
 
+  /**
+   * Whether the aspect ratio is derived from the renderer/render-target
+   * size on each render. Starts true; an explicit `aspect` option, an
+   * `aspect` property assignment, or a `resize()` call switches to
+   * manual control.
+   */
+  private _autoAspect: boolean
+
+  /** Last auto-synced size — skips redundant per-frame resize work */
+  private _lastSyncedWidth = 0
+  private _lastSyncedHeight = 0
+
   /** Whether we own the camera (for disposal) */
   private _ownsCamera: boolean
 
@@ -306,9 +323,11 @@ export class Flatland extends Group implements WorldProvider {
     this.spriteGroup = new SpriteGroup()
     this.scene.add(this.spriteGroup)
 
-    // Store view size and aspect
+    // Store view size and aspect. Omitted aspect = auto-derive from the
+    // renderer (or render target) each render; explicit aspect = manual.
     this._viewSize = options.viewSize ?? 400
     this._aspect = options.aspect ?? 1
+    this._autoAspect = options.aspect === undefined
 
     // Create or use provided camera
     if (options.camera) {
@@ -429,6 +448,27 @@ export class Flatland extends Group implements WorldProvider {
    */
   set viewSize(value: number) {
     this._viewSize = value
+    this._updateCameraFrustum()
+  }
+
+  /**
+   * Get the current aspect ratio.
+   */
+  get aspect(): number {
+    return this._aspect
+  }
+
+  /**
+   * Pin the aspect ratio manually, disabling the automatic per-render
+   * sync from the renderer/render-target size. Non-finite or
+   * non-positive values are ignored so a transient zero-sized layout
+   * (e.g. R3F's first commit before the canvas is measured) can never
+   * latch a broken frustum.
+   */
+  set aspect(value: number) {
+    if (!Number.isFinite(value) || value <= 0) return
+    this._autoAspect = false
+    this._aspect = value
     this._updateCameraFrustum()
   }
 
@@ -1235,6 +1275,11 @@ export class Flatland extends Group implements WorldProvider {
     // Auto-sync global uniforms from renderer
     this._syncGlobals(renderer)
 
+    // Auto-sync the camera aspect from the render surface (no-op once
+    // resize()/aspect take manual control). Must run before the world
+    // uniforms below read the camera bounds.
+    this._autoSyncSize(renderer)
+
     // Update LightingContext runtime fields before systems run
     const lctx = this._getLightingContext()
     if (lctx) {
@@ -1386,9 +1431,30 @@ export class Flatland extends Group implements WorldProvider {
   }
 
   /**
-   * Resize the rendering area.
+   * Resize the rendering area, taking manual control of the aspect
+   * ratio (the automatic per-render sync is disabled from here on).
+   *
+   * Zero, negative, or non-finite dimensions are ignored — a transient
+   * unmeasured layout (R3F's first commit reports a 0×0 canvas) must
+   * not latch a NaN/Infinity frustum, and must not disable the
+   * automatic sync that will pick up the real size once it exists.
    */
   resize(width: number, height: number): void {
+    if (!this._isValidSize(width, height)) return
+    this._autoAspect = false
+    this._applyResize(width, height)
+  }
+
+  /** Guard against zero/negative/NaN dimensions. */
+  private _isValidSize(width: number, height: number): boolean {
+    return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0
+  }
+
+  /**
+   * Shared resize path for explicit resize() calls and the automatic
+   * per-render size sync. Dimensions are pre-validated by callers.
+   */
+  private _applyResize(width: number, height: number): void {
     this._aspect = width / height
     this._updateCameraFrustum()
 
@@ -1401,6 +1467,41 @@ export class Flatland extends Group implements WorldProvider {
     if (this._lightEffect?.enabled) {
       this._lightEffect.resize(width, height)
     }
+  }
+
+  /**
+   * Auto-derive the aspect ratio from the render surface. Runs every
+   * render() while in auto mode (no explicit `aspect`, no resize()
+   * call): the render target's dimensions when rendering to texture,
+   * the renderer's viewport size otherwise. This is what makes a bare
+   * `<flatland>` in R3F track the canvas without a hand-rolled
+   * `useThree(s => s.size)` → resize() bridge — the renderer is already
+   * the source of truth for viewport-dependent state (`_syncGlobals`
+   * reads it each frame); the camera frustum follows the same truth.
+   */
+  private _autoSyncSize(renderer: WebGPURenderer): void {
+    if (!this._autoAspect) return
+
+    let width: number
+    let height: number
+    if (this._renderTarget) {
+      width = this._renderTarget.width
+      height = this._renderTarget.height
+    } else {
+      const size = renderer.getSize(this._tempVec2)
+      width = size.x
+      height = size.y
+    }
+
+    // Skip unmeasured/invalid surfaces (0×0 first R3F commit, NaN) and
+    // frames where nothing changed — LightEffect.resize can reallocate
+    // GPU tile buffers, so it must only fire on real size changes.
+    if (!this._isValidSize(width, height)) return
+    if (width === this._lastSyncedWidth && height === this._lastSyncedHeight) return
+
+    this._lastSyncedWidth = width
+    this._lastSyncedHeight = height
+    this._applyResize(width, height)
   }
 
   /**

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -108,7 +108,12 @@ export interface FlatlandOptions {
   clearAlpha?: number
   /** Enable post-processing pipeline (default: false) */
   postProcessing?: boolean
-  /** Initial aspect ratio (default: 1, use resize() to update) */
+  /**
+   * Fixed aspect ratio. When omitted, Flatland derives the aspect from
+   * the renderer's viewport (or the render target) automatically on
+   * every render. Passing a value — or calling resize() — switches to
+   * manual control and disables the automatic sync.
+   */
   aspect?: number
 }
 
@@ -213,6 +218,18 @@ export class Flatland extends Group implements WorldProvider {
   /** Current aspect ratio */
   private _aspect: number
 
+  /**
+   * Whether the aspect ratio is derived from the renderer/render-target
+   * size on each render. Starts true; an explicit `aspect` option, an
+   * `aspect` property assignment, or a `resize()` call switches to
+   * manual control.
+   */
+  private _autoAspect: boolean
+
+  /** Last auto-synced size — skips redundant per-frame resize work */
+  private _lastSyncedWidth = 0
+  private _lastSyncedHeight = 0
+
   /** Whether we own the camera (for disposal) */
   private _ownsCamera: boolean
 
@@ -313,9 +330,11 @@ export class Flatland extends Group implements WorldProvider {
     this.spriteGroup = new SpriteGroup()
     this.scene.add(this.spriteGroup)
 
-    // Store view size and aspect
+    // Store view size and aspect. Omitted aspect = auto-derive from the
+    // renderer (or render target) each render; explicit aspect = manual.
     this._viewSize = options.viewSize ?? 400
     this._aspect = options.aspect ?? 1
+    this._autoAspect = options.aspect === undefined
 
     // Create or use provided camera
     if (options.camera) {
@@ -433,6 +452,27 @@ export class Flatland extends Group implements WorldProvider {
    */
   set viewSize(value: number) {
     this._viewSize = value
+    this._updateCameraFrustum()
+  }
+
+  /**
+   * Get the current aspect ratio.
+   */
+  get aspect(): number {
+    return this._aspect
+  }
+
+  /**
+   * Pin the aspect ratio manually, disabling the automatic per-render
+   * sync from the renderer/render-target size. Non-finite or
+   * non-positive values are ignored so a transient zero-sized layout
+   * (e.g. R3F's first commit before the canvas is measured) can never
+   * latch a broken frustum.
+   */
+  set aspect(value: number) {
+    if (!Number.isFinite(value) || value <= 0) return
+    this._autoAspect = false
+    this._aspect = value
     this._updateCameraFrustum()
   }
 
@@ -1232,6 +1272,11 @@ export class Flatland extends Group implements WorldProvider {
     // Auto-sync global uniforms from renderer
     this._syncGlobals(renderer)
 
+    // Auto-sync the camera aspect from the render surface (no-op once
+    // resize()/aspect take manual control). Must run before the world
+    // uniforms below read the camera bounds.
+    this._autoSyncSize(renderer)
+
     // Update LightingContext runtime fields before systems run
     const lctx = this._getLightingContext()
     if (lctx) {
@@ -1418,9 +1463,30 @@ export class Flatland extends Group implements WorldProvider {
   }
 
   /**
-   * Resize the rendering area.
+   * Resize the rendering area, taking manual control of the aspect
+   * ratio (the automatic per-render sync is disabled from here on).
+   *
+   * Zero, negative, or non-finite dimensions are ignored — a transient
+   * unmeasured layout (R3F's first commit reports a 0×0 canvas) must
+   * not latch a NaN/Infinity frustum, and must not disable the
+   * automatic sync that will pick up the real size once it exists.
    */
   resize(width: number, height: number): void {
+    if (!this._isValidSize(width, height)) return
+    this._autoAspect = false
+    this._applyResize(width, height)
+  }
+
+  /** Guard against zero/negative/NaN dimensions. */
+  private _isValidSize(width: number, height: number): boolean {
+    return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0
+  }
+
+  /**
+   * Shared resize path for explicit resize() calls and the automatic
+   * per-render size sync. Dimensions are pre-validated by callers.
+   */
+  private _applyResize(width: number, height: number): void {
     this._aspect = width / height
     this._updateCameraFrustum()
 
@@ -1433,6 +1499,41 @@ export class Flatland extends Group implements WorldProvider {
     if (this._lightEffect?.enabled) {
       this._lightEffect.resize(width, height)
     }
+  }
+
+  /**
+   * Auto-derive the aspect ratio from the render surface. Runs every
+   * render() while in auto mode (no explicit `aspect`, no resize()
+   * call): the render target's dimensions when rendering to texture,
+   * the renderer's viewport size otherwise. This is what makes a bare
+   * `<flatland>` in R3F track the canvas without a hand-rolled
+   * `useThree(s => s.size)` → resize() bridge — the renderer is already
+   * the source of truth for viewport-dependent state (`_syncGlobals`
+   * reads it each frame); the camera frustum follows the same truth.
+   */
+  private _autoSyncSize(renderer: WebGPURenderer): void {
+    if (!this._autoAspect) return
+
+    let width: number
+    let height: number
+    if (this._renderTarget) {
+      width = this._renderTarget.width
+      height = this._renderTarget.height
+    } else {
+      const size = renderer.getSize(this._tempVec2)
+      width = size.x
+      height = size.y
+    }
+
+    // Skip unmeasured/invalid surfaces (0×0 first R3F commit, NaN) and
+    // frames where nothing changed — LightEffect.resize can reallocate
+    // GPU tile buffers, so it must only fire on real size changes.
+    if (!this._isValidSize(width, height)) return
+    if (width === this._lastSyncedWidth && height === this._lastSyncedHeight) return
+
+    this._lastSyncedWidth = width
+    this._lastSyncedHeight = height
+    this._applyResize(width, height)
   }
 
   /**

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -71,12 +71,20 @@ interface LightingContextData {
   materials: Set<Sprite2DMaterial>
   dirty: boolean
   initialized: boolean
+  surfaceSize: Vector2
+  resizePending: boolean
   renderer: WebGPURenderer | null
   camera: OrthographicCamera | null
   scene: Scene | null
   worldSize: Vector2
   worldOffset: Vector2
 }
+
+// R3F restores a removed JSX property from a no-arg instance of the class.
+// Remember every camera created for that default state so assigning one back
+// can restore this instance's own managed camera instead of adopting a foreign
+// default camera and permanently disabling automatic frustum updates.
+const _flatlandInternalCameras = new WeakMap<OrthographicCamera, Flatland>()
 
 /**
  * Options for creating a Flatland instance.
@@ -96,7 +104,10 @@ export interface FlatlandOptions {
    * attachment format.
    */
   renderTarget?: RenderTarget | null
-  /** Camera to use (null = use internal orthographic camera) */
+  /**
+   * Camera to use (null = use the internal orthographic camera). Flatland never
+   * rewrites a supplied camera's frustum; its owner remains responsible for it.
+   */
   camera?: OrthographicCamera | null
   /** Orthographic view size in pixels (default: 400) */
   viewSize?: number
@@ -109,12 +120,14 @@ export interface FlatlandOptions {
   /** Enable post-processing pipeline (default: false) */
   postProcessing?: boolean
   /**
-   * Fixed aspect ratio. When omitted, Flatland derives the aspect from
-   * the renderer's viewport (or the render target) automatically on
-   * every render. Passing a value — or calling resize() — switches to
-   * manual control and disables the automatic sync.
+   * Fixed aspect ratio. When omitted or set to `'auto'`, Flatland derives the aspect from
+   * the renderer's viewport (or the render target) when its dimensions
+   * change. Passing a value pins the internal camera aspect while lighting
+   * still follows the surface. A camera supplied through `camera` keeps its
+   * authored frustum. Calling resize() takes full manual size control;
+   * assigning `aspect = 'auto'` restores automatic sizing.
    */
-  aspect?: number
+  aspect?: number | 'auto'
 }
 
 /**
@@ -219,19 +232,24 @@ export class Flatland extends Group implements WorldProvider {
   private _aspect: number
 
   /**
-   * Whether the aspect ratio is derived from the renderer/render-target
-   * size on each render. Starts true; an explicit `aspect` option, an
-   * `aspect` property assignment, or a `resize()` call switches to
-   * manual control.
+   * Whether the camera aspect is derived from renderer/render-target size.
+   * An explicit `aspect` option, property assignment, or `resize()` call
+   * switches the camera to manual aspect control.
    */
   private _autoAspect: boolean
 
-  /** Last auto-synced size — skips redundant per-frame resize work */
+  /** Whether renderer/render-target dimensions are sampled each frame. */
+  private _autoSurfaceSize = true
+
+  /** Last valid render-surface size — skips redundant per-frame resize work */
   private _lastSyncedWidth = 0
   private _lastSyncedHeight = 0
 
-  /** Whether we own the camera (for disposal) */
+  /** Whether the active camera is Flatland's managed internal camera. */
   private _ownsCamera: boolean
+
+  /** Stable internal camera restored when R3F removes a custom camera prop. */
+  private _internalCamera: OrthographicCamera
 
   /** Render target (null = viewport) */
   private _renderTarget: RenderTarget | null = null
@@ -268,6 +286,9 @@ export class Flatland extends Group implements WorldProvider {
 
   /** Reusable Vector2 to avoid per-frame allocations */
   private _tempVec2 = new Vector2()
+
+  /** Reusable physical drawing-buffer size for surface-dependent GPU resources. */
+  private _drawingBufferSize = new Vector2()
 
   /**
    * Camera frustum bounds as TSL uniform nodes. Created once per Flatland
@@ -330,18 +351,24 @@ export class Flatland extends Group implements WorldProvider {
     this.spriteGroup = new SpriteGroup()
     this.scene.add(this.spriteGroup)
 
-    // Store view size and aspect. Omitted aspect = auto-derive from the
-    // renderer (or render target) each render; explicit aspect = manual.
+    // Store view size and aspect. Omitted/invalid aspect = auto-derive from
+    // the renderer (or render target) each render; valid explicit aspect = manual.
+    const fixedAspect = options.aspect
+    const hasFixedAspect = typeof fixedAspect === 'number' && Number.isFinite(fixedAspect) && fixedAspect > 0
     this._viewSize = options.viewSize ?? 400
-    this._aspect = options.aspect ?? 1
-    this._autoAspect = options.aspect === undefined
+    this._aspect = hasFixedAspect ? fixedAspect : 1
+    this._autoAspect = !hasFixedAspect
+
+    // Always retain an instance-owned camera so R3F can restore the no-arg
+    // constructor default after a conditional custom camera prop is removed.
+    this._internalCamera = this._createCamera()
 
     // Create or use provided camera
     if (options.camera) {
       this._camera = options.camera
       this._ownsCamera = false
     } else {
-      this._camera = this._createCamera()
+      this._camera = this._internalCamera
       this._ownsCamera = true
     }
 
@@ -404,6 +431,7 @@ export class Flatland extends Group implements WorldProvider {
 
     const camera = new OrthographicCamera(-halfWidth, halfWidth, halfHeight, -halfHeight, 0.1, 1000)
     camera.position.z = 100
+    _flatlandInternalCameras.set(camera, this)
     return camera
   }
 
@@ -433,9 +461,22 @@ export class Flatland extends Group implements WorldProvider {
   }
 
   /**
-   * Set a custom camera.
+   * Set a custom camera. Assigning the default camera read from a no-arg
+   * Flatland instance restores this instance's own managed camera; this is the
+   * property-removal path used by React Three Fiber.
    */
   set camera(value: OrthographicCamera) {
+    const internalOwner = _flatlandInternalCameras.get(value)
+    // R3F restores a removed property from its memoized no-arg prototype,
+    // whose Flatland instance never renders. Restore this instance's managed
+    // camera for that sentinel, but allow cameras from another live Flatland
+    // to be deliberately shared between views.
+    if (internalOwner === this || (internalOwner && internalOwner._lastRenderTime < 0)) {
+      this._camera = this._internalCamera
+      this._ownsCamera = true
+      this._updateCameraFrustum()
+      return
+    }
     this._camera = value
     this._ownsCamera = false
   }
@@ -456,22 +497,56 @@ export class Flatland extends Group implements WorldProvider {
   }
 
   /**
-   * Get the current aspect ratio.
+   * Get the configured aspect mode. Returns `'auto'` while Flatland's internal
+   * camera follows the render surface; use {@link resolvedAspect} for the
+   * camera's current numeric ratio. A user-supplied camera keeps its authored
+   * frustum regardless of this mode.
    */
-  get aspect(): number {
+  get aspect(): number | 'auto' {
+    return this._autoAspect ? 'auto' : this._aspect
+  }
+
+  /**
+   * Current numeric camera aspect. For Flatland's internal camera this includes
+   * the ratio resolved in auto mode; for a user-supplied camera it is derived
+   * directly from that camera's authored orthographic frustum.
+   */
+  get resolvedAspect(): number {
+    if (!this._ownsCamera) {
+      const width = Math.abs(this._camera.right - this._camera.left)
+      const height = Math.abs(this._camera.top - this._camera.bottom)
+      if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+        return width / height
+      }
+    }
     return this._aspect
   }
 
   /**
-   * Pin the aspect ratio manually, disabling the automatic per-render
-   * sync from the renderer/render-target size. Non-finite or
-   * non-positive values are ignored so a transient zero-sized layout
-   * (e.g. R3F's first commit before the canvas is measured) can never
-   * latch a broken frustum.
+   * A number pins the internal camera ratio manually. Assigning `'auto'`
+   * restores automatic internal-camera and effect sizing, including after
+   * `resize()`. User-supplied cameras keep their authored frustum. The explicit
+   * sentinel also lets R3F restore constructor defaults when an `aspect` JSX
+   * prop is removed. Invalid numeric values are ignored.
    */
-  set aspect(value: number) {
+  set aspect(value: number | 'auto') {
+    if (value === 'auto') {
+      this._autoAspect = true
+      this._autoSurfaceSize = true
+      // Force one fresh surface sync even when its dimensions happen to match
+      // the previous manual size; the camera may still have a pinned ratio.
+      this._lastSyncedWidth = 0
+      this._lastSyncedHeight = 0
+      return
+    }
     if (!Number.isFinite(value) || value <= 0) return
     this._autoAspect = false
+    this._autoSurfaceSize = true
+    // A numeric aspect pins only the camera. If resize() previously selected
+    // full manual surface control, resume physical surface tracking for GPU
+    // resources and force a fresh sample on the next render.
+    this._lastSyncedWidth = 0
+    this._lastSyncedHeight = 0
     this._aspect = value
     this._updateCameraFrustum()
   }
@@ -862,8 +937,14 @@ export class Flatland extends Group implements WorldProvider {
    * ```
    */
   setLighting(lightEffect: LightEffect | null): this {
+    if (this._lightEffect === lightEffect) return this
+
     // Detach previous
     if (this._lightEffect) {
+      // Flatland owns the active effect lifecycle. Release any GPU resources
+      // before detaching so reusing the same instance later can safely init
+      // against its next renderer without leaking the previous allocation.
+      this._lightEffect.dispose()
       if (this._lightEffect._entity) {
         this._lightEffect._entity.destroy()
       }
@@ -952,12 +1033,17 @@ export class Flatland extends Group implements WorldProvider {
         materials: this._spriteMaterials,
         dirty: true,
         initialized: false,
+        surfaceSize: existingCtx?.surfaceSize ?? new Vector2(),
+        resizePending: false,
         renderer: existingCtx?.renderer ?? null,
         camera: existingCtx?.camera ?? null,
         scene: existingCtx?.scene ?? null,
         worldSize: existingCtx?.worldSize ?? new Vector2(),
         worldOffset: existingCtx?.worldOffset ?? new Vector2(),
       })
+      if (this._lastSyncedWidth > 0 && this._lastSyncedHeight > 0) {
+        this._queueLightEffectResize(this._lastSyncedWidth, this._lastSyncedHeight)
+      }
 
       // Register lighting systems on the schedule (before sprite systems)
       this._ensureLightingSystems()
@@ -980,6 +1066,8 @@ export class Flatland extends Group implements WorldProvider {
           materials: existingCtx?.materials ?? new Set(),
           dirty: true,
           initialized: false,
+          surfaceSize: existingCtx?.surfaceSize ?? new Vector2(this._lastSyncedWidth, this._lastSyncedHeight),
+          resizePending: false,
           renderer: existingCtx?.renderer ?? null,
           camera: existingCtx?.camera ?? null,
           scene: existingCtx?.scene ?? null,
@@ -1002,6 +1090,13 @@ export class Flatland extends Group implements WorldProvider {
       if (lctx) {
         lctx.dirty = true
       }
+    }
+  }
+
+  /** @internal Re-apply the active effect resolution scale. */
+  _markLightingResizeDirty(): void {
+    if (this._lastSyncedWidth > 0 && this._lastSyncedHeight > 0) {
+      this._queueLightEffectResize(this._lastSyncedWidth, this._lastSyncedHeight)
     }
   }
 
@@ -1074,6 +1169,8 @@ export class Flatland extends Group implements WorldProvider {
           materials: new Set(),
           dirty: false,
           initialized: false,
+          surfaceSize: new Vector2(this._lastSyncedWidth, this._lastSyncedHeight),
+          resizePending: false,
           renderer: null,
           camera: null,
           scene: null,
@@ -1272,10 +1369,10 @@ export class Flatland extends Group implements WorldProvider {
     // Auto-sync global uniforms from renderer
     this._syncGlobals(renderer)
 
-    // Auto-sync the camera aspect from the render surface (no-op once
-    // resize()/aspect take manual control). Must run before the world
-    // uniforms below read the camera bounds.
-    this._autoSyncSize(renderer)
+    // Keep render-surface dimensions current for the camera and lighting.
+    // A fixed aspect only pins the camera; an explicit resize() selects full
+    // manual surface control for both the camera and effects.
+    this._syncSurfaceSize(renderer)
 
     // Update LightingContext runtime fields before systems run
     const lctx = this._getLightingContext()
@@ -1456,8 +1553,11 @@ export class Flatland extends Group implements WorldProvider {
 
   /** Apply Flatland's 2D-friendly default without overriding authored output. */
   private _prepareRenderTarget(renderTarget: RenderTarget | null): RenderTarget | null {
-    if (renderTarget?.texture.colorSpace === NoColorSpace) {
-      renderTarget.texture.colorSpace = SRGBColorSpace
+    if (renderTarget) {
+      const textures = renderTarget.textures?.length ? renderTarget.textures : [renderTarget.texture]
+      for (const texture of textures) {
+        if (texture.colorSpace === NoColorSpace) texture.colorSpace = SRGBColorSpace
+      }
     }
     return renderTarget
   }
@@ -1474,6 +1574,7 @@ export class Flatland extends Group implements WorldProvider {
   resize(width: number, height: number): void {
     if (!this._isValidSize(width, height)) return
     this._autoAspect = false
+    this._autoSurfaceSize = false
     this._applyResize(width, height)
   }
 
@@ -1483,10 +1584,11 @@ export class Flatland extends Group implements WorldProvider {
   }
 
   /**
-   * Shared resize path for explicit resize() calls and the automatic
-   * per-render size sync. Dimensions are pre-validated by callers.
+   * Apply an explicit manual surface size. Dimensions are pre-validated.
    */
   private _applyResize(width: number, height: number): void {
+    this._lastSyncedWidth = width
+    this._lastSyncedHeight = height
     this._aspect = width / height
     this._updateCameraFrustum()
 
@@ -1495,24 +1597,32 @@ export class Flatland extends Group implements WorldProvider {
       this._renderTarget.setSize(width, height)
     }
 
-    // Forward resize to LightEffect (Forward+, etc.)
-    if (this._lightEffect?.enabled) {
-      this._lightEffect.resize(width, height)
-    }
+    this._queueLightEffectResize(width, height)
   }
 
   /**
-   * Auto-derive the aspect ratio from the render surface. Runs every
-   * render() while in auto mode (no explicit `aspect`, no resize()
-   * call): the render target's dimensions when rendering to texture,
-   * the renderer's viewport size otherwise. This is what makes a bare
-   * `<flatland>` in R3F track the canvas without a hand-rolled
-   * `useThree(s => s.size)` → resize() bridge — the renderer is already
-   * the source of truth for viewport-dependent state (`_syncGlobals`
-   * reads it each frame); the camera frustum follows the same truth.
+   * Queue a LightEffect resize for the lighting lifecycle system. Keeping
+   * resize in the system guarantees init() runs first and preserves the
+   * current surface size for effects attached after the first frame.
    */
-  private _autoSyncSize(renderer: WebGPURenderer): void {
-    if (!this._autoAspect) return
+  private _queueLightEffectResize(width: number, height: number): void {
+    const lctx = this._getLightingContext()
+    if (!lctx) return
+    const scale = this._lightEffect?.resolutionScale ?? 1
+    lctx.surfaceSize.set(Math.max(1, Math.floor(width * scale)), Math.max(1, Math.floor(height * scale)))
+    lctx.resizePending = true
+  }
+
+  /**
+   * Track the physical render surface every frame: the render target's texel
+   * dimensions when rendering to texture, otherwise the renderer's drawing
+   * buffer size (logical canvas size multiplied by pixel ratio).
+   * Camera aspect follows while auto mode is active; LightEffect sizing
+   * follows unless resize() selected full manual size control because GPU
+   * tile buffers remain surface-dependent when only camera aspect is pinned.
+   */
+  private _syncSurfaceSize(renderer: WebGPURenderer): void {
+    if (!this._autoSurfaceSize) return
 
     let width: number
     let height: number
@@ -1520,9 +1630,9 @@ export class Flatland extends Group implements WorldProvider {
       width = this._renderTarget.width
       height = this._renderTarget.height
     } else {
-      const size = renderer.getSize(this._tempVec2)
-      width = size.x
-      height = size.y
+      renderer.getDrawingBufferSize(this._drawingBufferSize)
+      width = this._drawingBufferSize.x
+      height = this._drawingBufferSize.y
     }
 
     // Skip unmeasured/invalid surfaces (0×0 first R3F commit, NaN) and
@@ -1533,7 +1643,11 @@ export class Flatland extends Group implements WorldProvider {
 
     this._lastSyncedWidth = width
     this._lastSyncedHeight = height
-    this._applyResize(width, height)
+    if (this._autoAspect) {
+      this._aspect = width / height
+      this._updateCameraFrustum()
+    }
+    this._queueLightEffectResize(width, height)
   }
 
   /**

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -467,11 +467,17 @@ export class Flatland extends Group implements WorldProvider {
    */
   set camera(value: OrthographicCamera) {
     const internalOwner = _flatlandInternalCameras.get(value)
+    const thisIsR3FManaged = '__r3f' in (this as Flatland & { __r3f?: unknown })
+    const ownerIsR3FManaged =
+      internalOwner !== undefined && '__r3f' in (internalOwner as Flatland & { __r3f?: unknown })
     // R3F restores a removed property from its memoized no-arg prototype,
-    // whose Flatland instance never renders. Restore this instance's managed
-    // camera for that sentinel, but allow cameras from another live Flatland
-    // to be deliberately shared between views.
-    if (internalOwner === this || (internalOwner && internalOwner._lastRenderTime < 0)) {
+    // whose Flatland instance is never reconciled or rendered. Only interpret
+    // that camera as a sentinel while assigning to an R3F-managed instance;
+    // vanilla Flatland instances can share an internal camera before either
+    // one renders.
+    const isR3FPrototypeCamera =
+      thisIsR3FManaged && internalOwner !== undefined && !ownerIsR3FManaged && internalOwner._lastRenderTime < 0
+    if (internalOwner === this || isR3FPrototypeCamera) {
       this._camera = this._internalCamera
       this._ownsCamera = true
       this._updateCameraFrustum()

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -930,6 +930,12 @@ export class Flatland extends Group implements WorldProvider {
    * Set the lighting effect for this Flatland instance.
    * The LightEffect produces a ColorTransformFn that is applied to all lit sprites.
    *
+   * Flatland owns the active effect's lifecycle while attached. Replacing it
+   * or passing `null` calls `dispose()` before detachment so GPU resources are
+   * released promptly. The effect instance remains reusable and will receive
+   * a fresh `init → resize → update` sequence when reattached; callers should
+   * not use effect-owned GPU resource handles while the effect is detached.
+   *
    * @param lightEffect - LightEffect instance (or null to disable lighting)
    * @returns this (for chaining)
    *

--- a/packages/three-flatland/src/ecs/systems/lightEffectSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/lightEffectSystem.ts
@@ -18,7 +18,7 @@ const _runtimeCtx = {
 } as unknown as LightEffectRuntimeContext
 
 /**
- * Run LightEffect lifecycle: lazy init + per-frame update.
+ * Run LightEffect lifecycle: lazy init, ordered surface resize, and update.
  *
  * Self-gating: no-ops if LightingContext doesn't exist, effect is disabled,
  * or runtime context (renderer/camera) is not yet available.
@@ -61,7 +61,16 @@ export function lightEffectSystem(world: World): void {
   // Lazy init on first render
   if (!ctx.initialized) {
     ctx.effect.init(_runtimeCtx)
+    ctx.effect._initialized = true
     ctx.initialized = true
+    ctx.resizePending = true
+  }
+
+  // Resize only after init. The pending bit also covers effects attached
+  // after the surface was measured and effects re-enabled after a resize.
+  if (ctx.resizePending && ctx.surfaceSize.x > 0 && ctx.surfaceSize.y > 0) {
+    ctx.effect.resize(ctx.surfaceSize.x, ctx.surfaceSize.y)
+    ctx.resizePending = false
   }
 
   // Per-frame update (tiling, SDF shadows, radiance cascades, etc.)

--- a/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.test.ts
+++ b/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.test.ts
@@ -154,6 +154,22 @@ describe('shadowPipelineSystem — occluder-dirty gate', () => {
     expect(occlusionPass.resize).toHaveBeenCalledWith(320, 180)
   })
 
+  it('does not resize either scaled shadow resource when rounding keeps their size unchanged', () => {
+    const { sdfGenerator, occlusionPass, setOccludersDirty } = setup(world)
+    const ctx = world.query(LightingContext)[0]!.get(LightingContext)!
+    ctx.surfaceSize.set(512, 512)
+    shadowPipelineSystem(world)
+
+    sdfGenerator.resize.mockClear()
+    occlusionPass.resize.mockClear()
+    setOccludersDirty(false)
+    ctx.surfaceSize.set(513, 513)
+    shadowPipelineSystem(world)
+
+    expect(sdfGenerator.resize).not.toHaveBeenCalled()
+    expect(occlusionPass.resize).not.toHaveBeenCalled()
+  })
+
   it('skips regen when occludersDirty=false and camera unchanged', () => {
     const { sdfGenerator, setOccludersDirty } = setup(world, { occludersDirty: true })
 

--- a/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.test.ts
+++ b/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { OrthographicCamera, Scene, NearestFilter, LinearFilter } from 'three'
+import { OrthographicCamera, Scene, NearestFilter, LinearFilter, Vector2 } from 'three'
 import { createWorld, universe } from 'koota'
 import type { World } from 'koota'
 import { shadowPipelineSystem } from './shadowPipelineSystem'
@@ -97,6 +97,7 @@ function setup(world: World, opts: SetupOpts = {}) {
   world.spawn(
     LightingContext({
       effect,
+      surfaceSize: new Vector2(800, 600),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       renderer: renderer as any,
       camera,
@@ -138,6 +139,19 @@ describe('shadowPipelineSystem — occluder-dirty gate', () => {
 
     expect(occlusionPass.render).toHaveBeenCalledTimes(1)
     expect(sdfGenerator.generate).toHaveBeenCalledTimes(1)
+  })
+
+  it('sizes shadows from the canonical surface without querying the renderer', () => {
+    const { sdfGenerator, occlusionPass } = setup(world)
+    const ctx = world.query(LightingContext)[0]!.get(LightingContext)!
+    ctx.surfaceSize.set(320, 180)
+    const renderer = ctx.renderer as unknown as ReturnType<typeof makeRenderer>
+
+    shadowPipelineSystem(world)
+
+    expect(renderer.getSize).not.toHaveBeenCalled()
+    expect(sdfGenerator.init).toHaveBeenCalledWith(160, 90)
+    expect(occlusionPass.resize).toHaveBeenCalledWith(320, 180)
   })
 
   it('skips regen when occludersDirty=false and camera unchanged', () => {

--- a/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.ts
@@ -106,6 +106,10 @@ export function shadowPipelineSystem(world: World): void {
   const sdfW = Math.max(1, Math.floor(surfaceWidth * scale))
   const sdfH = Math.max(1, Math.floor(surfaceHeight * scale))
 
+  // OcclusionPass applies this same scale internally and stores only the
+  // resulting physical RT dimensions. If an unscaled surface change rounds
+  // to the same sdfW/sdfH (for example 512 → 513 at 0.5), neither shadow
+  // resource changes size and a resize/regeneration would be redundant.
   if (!pipeline.initialized) {
     pipeline.sdfGenerator.init(sdfW, sdfH)
     pipeline.occlusionPass.resize(surfaceWidth, surfaceHeight)

--- a/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/shadowPipelineSystem.ts
@@ -10,7 +10,7 @@ import type { LightEffect } from '../../lights/LightEffect'
  *
  * Reads the active effect from `LightingContext`; if its class declares
  * `needsShadows`, allocates the JFA SDF generator + occluder pre-pass,
- * sizes them to the renderer, runs the pre-pass each frame, and writes
+ * sizes them to Flatland's canonical render surface, runs the pre-pass each frame, and writes
  * the resulting SDFGenerator handle back to `LightingContext.sdfGenerator`
  * so consumer systems (future shadow-sampling shaders, GI effects, etc.)
  * pick it up via the existing trait field.
@@ -30,13 +30,10 @@ import type { LightEffect } from '../../lights/LightEffect'
  *   object reference — no allocation, no cloning. Mutations happen in
  *   place (`pipeline.initialized = true`), bypassing `entity.set`'s
  *   `Changed()` wakeup since nothing queries this trait with Changed().
- * - A scratch `Vector2` is allocated once at module load for size
- *   reads, reused every frame.
  * - The fast path when shadows are active and size hasn't changed is
  *   two branch predictions, then the two render calls — no CPU work
  *   in JS beyond that.
  */
-const _sizeScratch = new Vector2()
 const _worldSizeScratch = new Vector2()
 
 export function shadowPipelineSystem(world: World): void {
@@ -99,24 +96,26 @@ export function shadowPipelineSystem(world: World): void {
     pipeline.occlusionPass = new OcclusionPass()
   }
 
-  // Size sync. `renderer.getSize(scratch)` avoids allocation; we only
-  // call init()/resize() on dimension change so the hot path is a
-  // compare-and-return.
-  renderer.getSize(_sizeScratch)
+  // Size from the active LightEffect processing surface (the physical render
+  // surface multiplied by effect.resolutionScale). Using the trait keeps shadow
+  // buffers in the same coordinate space as the effect-owned resources.
+  const surfaceWidth = ctx.surfaceSize.x
+  const surfaceHeight = ctx.surfaceSize.y
+  if (surfaceWidth <= 0 || surfaceHeight <= 0) return
   const scale = pipeline.occlusionPass.resolutionScale
-  const sdfW = Math.max(1, Math.floor(_sizeScratch.x * scale))
-  const sdfH = Math.max(1, Math.floor(_sizeScratch.y * scale))
+  const sdfW = Math.max(1, Math.floor(surfaceWidth * scale))
+  const sdfH = Math.max(1, Math.floor(surfaceHeight * scale))
 
   if (!pipeline.initialized) {
     pipeline.sdfGenerator.init(sdfW, sdfH)
-    pipeline.occlusionPass.resize(_sizeScratch.x, _sizeScratch.y)
+    pipeline.occlusionPass.resize(surfaceWidth, surfaceHeight)
     pipeline.width = sdfW
     pipeline.height = sdfH
     pipeline.initialized = true
     mustRegen = true
   } else if (sdfW !== pipeline.width || sdfH !== pipeline.height) {
     pipeline.sdfGenerator.resize(sdfW, sdfH)
-    pipeline.occlusionPass.resize(_sizeScratch.x, _sizeScratch.y)
+    pipeline.occlusionPass.resize(surfaceWidth, surfaceHeight)
     pipeline.width = sdfW
     pipeline.height = sdfH
     mustRegen = true

--- a/packages/three-flatland/src/ecs/traits.ts
+++ b/packages/three-flatland/src/ecs/traits.ts
@@ -341,6 +341,10 @@ export const LightingContext = trait(() => ({
   dirty: false as boolean,
   /** Whether the effect has been initialized (init() called). */
   initialized: false as boolean,
+  /** Effect processing dimensions after applying LightEffect.resolutionScale. */
+  surfaceSize: new Vector2(),
+  /** Whether the active effect needs a resize before its next update. */
+  resizePending: false as boolean,
   // Runtime context (set each frame before systems run)
   /** Renderer reference for GPU passes. */
   renderer: null as WebGPURenderer | null,

--- a/packages/three-flatland/src/flatland-resize.test.ts
+++ b/packages/three-flatland/src/flatland-resize.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { Vector2 } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
+import { Flatland } from './Flatland'
+
+/**
+ * Minimal renderer stub for exercising Flatland.render() headlessly.
+ * Only the members render() touches are provided; the size is mutable
+ * so tests can simulate R3F's measure lifecycle (0×0 first commit,
+ * real size after ResizeObserver fires, resizes later).
+ */
+function mockRenderer(width: number, height: number) {
+  const state = { width, height }
+  const renderer = {
+    getSize: (target: Vector2) => target.set(state.width, state.height),
+    getPixelRatio: () => 1,
+    getRenderTarget: () => null,
+    setRenderTarget: () => {},
+    setClearColor: () => {},
+    render: () => {},
+    autoClear: true,
+  } as unknown as WebGPURenderer
+  return { renderer, state }
+}
+
+describe('Flatland — resize()', () => {
+  it('sets the frustum from a non-square size: halfWidth === viewSize * aspect / 2', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    flatland.resize(1280, 720)
+
+    const aspect = 1280 / 720
+    expect(flatland.aspect).toBeCloseTo(aspect)
+    expect(flatland.camera.right).toBeCloseTo((800 * aspect) / 2)
+    expect(flatland.camera.left).toBeCloseTo(-(800 * aspect) / 2)
+    expect(flatland.camera.top).toBe(400)
+    expect(flatland.camera.bottom).toBe(-400)
+  })
+
+  it('ignores zero dimensions instead of latching a NaN aspect', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    flatland.resize(0, 0)
+
+    expect(flatland.aspect).toBe(1)
+    expect(Number.isFinite(flatland.camera.right)).toBe(true)
+
+    // A zero-size call must not disable the eventual real resize
+    flatland.resize(1280, 720)
+    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+  })
+
+  it('ignores NaN and negative dimensions', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    flatland.resize(NaN, 720)
+    flatland.resize(1280, NaN)
+    flatland.resize(-1280, 720)
+    flatland.resize(1280, 0)
+
+    expect(flatland.aspect).toBe(1)
+    expect(flatland.camera.right).toBe(400)
+  })
+})
+
+describe('Flatland — aspect property', () => {
+  it('pins the aspect and updates the frustum', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    flatland.aspect = 2
+
+    expect(flatland.camera.right).toBe(800)
+    expect(flatland.camera.left).toBe(-800)
+  })
+
+  it('rejects non-finite and non-positive values', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    flatland.aspect = NaN
+    flatland.aspect = 0
+    flatland.aspect = -1
+    flatland.aspect = Infinity
+
+    expect(flatland.aspect).toBe(1)
+  })
+})
+
+describe('Flatland — automatic aspect sync in render()', () => {
+  it('derives the aspect from the renderer size when never told otherwise', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.render(renderer)
+
+    const aspect = 1280 / 720
+    expect(flatland.aspect).toBeCloseTo(aspect)
+    expect(flatland.camera.right).toBeCloseTo((800 * aspect) / 2)
+  })
+
+  it('tracks renderer size changes across frames', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer, state } = mockRenderer(1280, 720)
+
+    flatland.render(renderer)
+    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+
+    state.width = 1920
+    state.height = 1080
+    flatland.render(renderer)
+    expect(flatland.aspect).toBeCloseTo(1920 / 1080)
+  })
+
+  it('does not latch a bad aspect from a 0x0 first commit (R3F pre-measure)', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer, state } = mockRenderer(0, 0)
+
+    flatland.render(renderer)
+    expect(flatland.aspect).toBe(1)
+    expect(Number.isFinite(flatland.camera.right)).toBe(true)
+
+    // Once the canvas is measured, the next frame picks up the real size
+    state.width = 1280
+    state.height = 720
+    flatland.render(renderer)
+    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+  })
+
+  it('stays manual after an explicit resize()', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.resize(800, 800)
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe(1)
+  })
+
+  it('stays manual when the aspect option is passed', () => {
+    const flatland = new Flatland({ viewSize: 800, aspect: 2 })
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe(2)
+  })
+
+  it('derives the aspect from the render target when rendering to texture', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.renderTarget = { width: 512, height: 256, setSize: () => {} } as never
+
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBeCloseTo(2)
+  })
+})

--- a/packages/three-flatland/src/flatland-resize.test.ts
+++ b/packages/three-flatland/src/flatland-resize.test.ts
@@ -493,12 +493,10 @@ describe('Flatland — LightEffect surface sizing', () => {
     expect(events).toEqual(['init', 'resize:1280x720', 'update', 'update'])
   })
 
-  it('allows two live Flatland instances to share an internal camera', () => {
+  it('allows vanilla Flatland instances to share an internal camera before rendering', () => {
     const source = new Flatland()
     const consumer = new Flatland()
-    const { renderer } = mockRenderer(1280, 720)
 
-    source.render(renderer)
     consumer.camera = source.camera
 
     expect(consumer.camera).toBe(source.camera)

--- a/packages/three-flatland/src/flatland-resize.test.ts
+++ b/packages/three-flatland/src/flatland-resize.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { Vector2 } from 'three'
+import { describe, it, expect, vi } from 'vitest'
+import { OrthographicCamera, Vector2 } from 'three'
+import { vec4 } from 'three/tsl'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'
+import { createLightEffect } from './lights/LightEffect'
 
 /**
  * Minimal renderer stub for exercising Flatland.render() headlessly.
@@ -9,18 +11,53 @@ import { Flatland } from './Flatland'
  * so tests can simulate R3F's measure lifecycle (0×0 first commit,
  * real size after ResizeObserver fires, resizes later).
  */
-function mockRenderer(width: number, height: number) {
+function mockRenderer(width: number, height: number, pixelRatio = 1) {
   const state = { width, height }
+  let getSizeCalls = 0
+  let getDrawingBufferSizeCalls = 0
   const renderer = {
-    getSize: (target: Vector2) => target.set(state.width, state.height),
-    getPixelRatio: () => 1,
+    getSize: (target: Vector2) => {
+      getSizeCalls++
+      return target.set(state.width, state.height)
+    },
+    getDrawingBufferSize: (target: Vector2) => {
+      getDrawingBufferSizeCalls++
+      return target.set(Math.floor(state.width * pixelRatio), Math.floor(state.height * pixelRatio))
+    },
+    getPixelRatio: () => pixelRatio,
     getRenderTarget: () => null,
     setRenderTarget: () => {},
     setClearColor: () => {},
     render: () => {},
     autoClear: true,
   } as unknown as WebGPURenderer
-  return { renderer, state }
+  return {
+    renderer,
+    state,
+    getSizeCalls: () => getSizeCalls,
+    getDrawingBufferSizeCalls: () => getDrawingBufferSizeCalls,
+  }
+}
+
+function lifecycleEffect(events: string[]) {
+  const Effect = createLightEffect({
+    name: 'resizeLifecycleTest',
+    schema: {} as const,
+    light: () => (ctx) => vec4(ctx.color.rgb, ctx.color.a),
+    init() {
+      events.push('init')
+    },
+    resize(width, height) {
+      events.push(`resize:${width}x${height}`)
+    },
+    update() {
+      events.push('update')
+    },
+    dispose() {
+      events.push('dispose')
+    },
+  })
+  return new Effect()
 }
 
 describe('Flatland — resize()', () => {
@@ -29,7 +66,7 @@ describe('Flatland — resize()', () => {
     flatland.resize(1280, 720)
 
     const aspect = 1280 / 720
-    expect(flatland.aspect).toBeCloseTo(aspect)
+    expect(flatland.resolvedAspect).toBeCloseTo(aspect)
     expect(flatland.camera.right).toBeCloseTo((800 * aspect) / 2)
     expect(flatland.camera.left).toBeCloseTo(-(800 * aspect) / 2)
     expect(flatland.camera.top).toBe(400)
@@ -40,12 +77,13 @@ describe('Flatland — resize()', () => {
     const flatland = new Flatland({ viewSize: 800 })
     flatland.resize(0, 0)
 
-    expect(flatland.aspect).toBe(1)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBe(1)
     expect(Number.isFinite(flatland.camera.right)).toBe(true)
 
     // A zero-size call must not disable the eventual real resize
     flatland.resize(1280, 720)
-    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
   })
 
   it('ignores NaN and negative dimensions', () => {
@@ -55,7 +93,8 @@ describe('Flatland — resize()', () => {
     flatland.resize(-1280, 720)
     flatland.resize(1280, 0)
 
-    expect(flatland.aspect).toBe(1)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBe(1)
     expect(flatland.camera.right).toBe(400)
   })
 })
@@ -76,7 +115,57 @@ describe('Flatland — aspect property', () => {
     flatland.aspect = -1
     flatland.aspect = Infinity
 
-    expect(flatland.aspect).toBe(1)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBe(1)
+  })
+
+  it('treats an invalid constructor aspect as automatic instead of latching it', () => {
+    const flatland = new Flatland({ viewSize: 800, aspect: 0 })
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
+    expect(Number.isFinite(flatland.camera.right)).toBe(true)
+  })
+
+  it('returns to automatic sizing after a fixed aspect or manual resize', () => {
+    const events: string[] = []
+    const flatland = new Flatland({ viewSize: 800, aspect: 2 })
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.resize(800, 800)
+    // R3F restores a removed prop from a fresh no-arg instance. Flatland's
+    // default getter must therefore expose the explicit auto sentinel.
+    flatland.aspect = new Flatland().aspect
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+  })
+
+  it('reports but never rewrites a user-supplied camera frustum', () => {
+    const camera = new OrthographicCamera(-30, 30, 15, -15, 0.1, 1000)
+    const flatland = new Flatland({ camera, viewSize: 800, aspect: 3 })
+    const { renderer } = mockRenderer(1280, 720)
+
+    expect(flatland.aspect).toBe(3)
+    expect(flatland.resolvedAspect).toBe(2)
+
+    flatland.aspect = 4
+    flatland.resize(400, 800)
+    flatland.aspect = 'auto'
+    flatland.render(renderer)
+
+    expect(camera.left).toBe(-30)
+    expect(camera.right).toBe(30)
+    expect(camera.top).toBe(15)
+    expect(camera.bottom).toBe(-15)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBe(2)
   })
 })
 
@@ -88,8 +177,19 @@ describe('Flatland — automatic aspect sync in render()', () => {
     flatland.render(renderer)
 
     const aspect = 1280 / 720
-    expect(flatland.aspect).toBeCloseTo(aspect)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBeCloseTo(aspect)
     expect(flatland.camera.right).toBeCloseTo((800 * aspect) / 2)
+  })
+
+  it('samples logical globals and the physical drawing buffer once per frame', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer, getSizeCalls, getDrawingBufferSizeCalls } = mockRenderer(1280, 720)
+
+    flatland.render(renderer)
+
+    expect(getSizeCalls()).toBe(1)
+    expect(getDrawingBufferSizeCalls()).toBe(1)
   })
 
   it('tracks renderer size changes across frames', () => {
@@ -97,12 +197,12 @@ describe('Flatland — automatic aspect sync in render()', () => {
     const { renderer, state } = mockRenderer(1280, 720)
 
     flatland.render(renderer)
-    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
 
     state.width = 1920
     state.height = 1080
     flatland.render(renderer)
-    expect(flatland.aspect).toBeCloseTo(1920 / 1080)
+    expect(flatland.resolvedAspect).toBeCloseTo(1920 / 1080)
   })
 
   it('does not latch a bad aspect from a 0x0 first commit (R3F pre-measure)', () => {
@@ -110,14 +210,30 @@ describe('Flatland — automatic aspect sync in render()', () => {
     const { renderer, state } = mockRenderer(0, 0)
 
     flatland.render(renderer)
-    expect(flatland.aspect).toBe(1)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBe(1)
     expect(Number.isFinite(flatland.camera.right)).toBe(true)
 
     // Once the canvas is measured, the next frame picks up the real size
     state.width = 1280
     state.height = 720
     flatland.render(renderer)
-    expect(flatland.aspect).toBeCloseTo(1280 / 720)
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
+  })
+
+  it('defers the first effect resize until a 0x0 surface becomes measurable', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer, state } = mockRenderer(0, 0)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.render(renderer)
+    expect(events).toEqual(['init', 'update'])
+
+    state.width = 1280
+    state.height = 720
+    flatland.render(renderer)
+    expect(events).toEqual(['init', 'update', 'resize:1280x720', 'update'])
   })
 
   it('stays manual after an explicit resize()', () => {
@@ -128,6 +244,7 @@ describe('Flatland — automatic aspect sync in render()', () => {
     flatland.render(renderer)
 
     expect(flatland.aspect).toBe(1)
+    expect(flatland.resolvedAspect).toBe(1)
   })
 
   it('stays manual when the aspect option is passed', () => {
@@ -142,10 +259,248 @@ describe('Flatland — automatic aspect sync in render()', () => {
   it('derives the aspect from the render target when rendering to texture', () => {
     const flatland = new Flatland({ viewSize: 800 })
     const { renderer } = mockRenderer(1280, 720)
-    flatland.renderTarget = { width: 512, height: 256, setSize: () => {} } as never
+    flatland.renderTarget = {
+      width: 512,
+      height: 256,
+      texture: { colorSpace: '' },
+      setSize: () => {},
+    } as never
 
     flatland.render(renderer)
 
-    expect(flatland.aspect).toBeCloseTo(2)
+    expect(flatland.aspect).toBe('auto')
+    expect(flatland.resolvedAspect).toBeCloseTo(2)
+  })
+
+  it('tracks render-target swaps without resizing user-owned targets', () => {
+    const flatland = new Flatland({ viewSize: 800 })
+    const { renderer } = mockRenderer(1280, 720)
+    const firstSetSize = vi.fn()
+    const secondSetSize = vi.fn()
+    flatland.renderTarget = {
+      width: 512,
+      height: 256,
+      texture: { colorSpace: '' },
+      setSize: firstSetSize,
+    } as never
+
+    flatland.render(renderer)
+    expect(flatland.resolvedAspect).toBeCloseTo(2)
+
+    flatland.renderTarget = {
+      width: 300,
+      height: 600,
+      texture: { colorSpace: '' },
+      setSize: secondSetSize,
+    } as never
+    flatland.render(renderer)
+
+    expect(flatland.resolvedAspect).toBeCloseTo(0.5)
+    expect(firstSetSize).not.toHaveBeenCalled()
+    expect(secondSetSize).not.toHaveBeenCalled()
+
+    flatland.renderTarget = null
+    flatland.render(renderer)
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
+  })
+})
+
+describe('Flatland — LightEffect surface sizing', () => {
+  it('initializes before the first resize and update', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const effect = lifecycleEffect(events)
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(effect)
+
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+    expect(effect._initialized).toBe(true)
+  })
+
+  it('sizes an effect attached after the surface was already measured', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.render(renderer)
+
+    flatland.setLighting(lifecycleEffect(events))
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+  })
+
+  it('resizes only when automatic surface dimensions change', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer, state } = mockRenderer(1280, 720)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.render(renderer)
+    flatland.render(renderer)
+    state.width = 1920
+    state.height = 1080
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update', 'update', 'resize:1920x1080', 'update'])
+  })
+
+  it('keeps effect sizing automatic when only the camera aspect is pinned', () => {
+    const events: string[] = []
+    const flatland = new Flatland({ aspect: 2 })
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe(2)
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+  })
+
+  it('uses physical drawing-buffer pixels consistently with render-target texels', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer } = mockRenderer(1280, 720, 2)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.render(renderer)
+    flatland.renderTarget = {
+      width: 2560,
+      height: 1440,
+      texture: { colorSpace: '' },
+      textures: [{ colorSpace: '' }],
+      setSize: () => {},
+    } as never
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:2560x1440', 'update', 'update'])
+  })
+
+  it('applies the effect-owned resolution scale without changing camera framing', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const effect = lifecycleEffect(events)
+    effect.resolutionScale = 0.5
+    const { renderer } = mockRenderer(1280, 720, 2)
+    flatland.setLighting(effect)
+
+    flatland.render(renderer)
+
+    expect(flatland.resolvedAspect).toBeCloseTo(1280 / 720)
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+  })
+
+  it('re-applies the current surface when resolutionScale changes at runtime', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const effect = lifecycleEffect(events)
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(effect)
+
+    flatland.render(renderer)
+    effect.resolutionScale = 0.5
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update', 'resize:640x360', 'update'])
+  })
+
+  it('ignores invalid effect resolution scales', () => {
+    const effect = lifecycleEffect([])
+
+    effect.resolutionScale = 0
+    effect.resolutionScale = -1
+    effect.resolutionScale = Number.NaN
+    effect.resolutionScale = Number.POSITIVE_INFINITY
+
+    expect(effect.resolutionScale).toBe(1)
+  })
+
+  it('resumes automatic effect sizing when a numeric aspect follows resize()', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(lifecycleEffect(events))
+
+    flatland.resize(800, 800)
+    flatland.aspect = 1
+    flatland.render(renderer)
+
+    expect(flatland.aspect).toBe(1)
+    expect(events).toEqual(['init', 'resize:1280x720', 'update'])
+  })
+
+  it('keeps explicit resize dimensions under manual surface control', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const { renderer } = mockRenderer(1280, 720)
+    flatland.setLighting(lifecycleEffect(events))
+    flatland.resize(800, 800)
+
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:800x800', 'update'])
+  })
+
+  it('delivers a resize missed while an effect was disabled before updating again', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const effect = lifecycleEffect(events)
+    const { renderer, state } = mockRenderer(1280, 720)
+    flatland.setLighting(effect)
+
+    flatland.render(renderer)
+    effect.enabled = false
+    state.width = 1920
+    state.height = 1080
+    flatland.render(renderer)
+    effect.enabled = true
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update', 'resize:1920x1080', 'update'])
+  })
+
+  it('disposes an effect before replacement so reattachment cannot leak its initialized resources', () => {
+    const firstEvents: string[] = []
+    const secondEvents: string[] = []
+    const flatland = new Flatland()
+    const first = lifecycleEffect(firstEvents)
+    const second = lifecycleEffect(secondEvents)
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.setLighting(first)
+    flatland.render(renderer)
+    flatland.setLighting(second)
+    flatland.render(renderer)
+    flatland.setLighting(first)
+    flatland.render(renderer)
+
+    expect(firstEvents).toEqual(['init', 'resize:1280x720', 'update', 'dispose', 'init', 'resize:1280x720', 'update'])
+    expect(secondEvents).toEqual(['init', 'resize:1280x720', 'update', 'dispose'])
+  })
+
+  it('keeps an idempotent lighting assignment attached without rebuilding', () => {
+    const events: string[] = []
+    const flatland = new Flatland()
+    const effect = lifecycleEffect(events)
+    const { renderer } = mockRenderer(1280, 720)
+
+    flatland.setLighting(effect)
+    flatland.render(renderer)
+    flatland.setLighting(effect)
+    flatland.render(renderer)
+
+    expect(events).toEqual(['init', 'resize:1280x720', 'update', 'update'])
+  })
+
+  it('allows two live Flatland instances to share an internal camera', () => {
+    const source = new Flatland()
+    const consumer = new Flatland()
+    const { renderer } = mockRenderer(1280, 720)
+
+    source.render(renderer)
+    consumer.camera = source.camera
+
+    expect(consumer.camera).toBe(source.camera)
   })
 })

--- a/packages/three-flatland/src/lights/ForwardPlusLighting.test.ts
+++ b/packages/three-flatland/src/lights/ForwardPlusLighting.test.ts
@@ -142,6 +142,18 @@ describe('ForwardPlusLighting', () => {
     expect(fp.tileCountXNode.value).toBe(Math.ceil(160 / TILE_SIZE))
   })
 
+  it('reinitializes when resized to the same dimensions after disposal', () => {
+    const fp = new ForwardPlusLighting()
+    fp.init(160, 160)
+
+    fp.dispose()
+    expect(fp.tileCountX).toBe(0)
+
+    fp.resize(160, 160)
+    expect(fp.tileCountX).toBe(Math.ceil(160 / TILE_SIZE))
+    expect(fp.tileCountXNode.value).toBe(Math.ceil(160 / TILE_SIZE))
+  })
+
   it('keeps the tile texture at TILE_TEXTURE_DIM² regardless of viewport', () => {
     // init() only updates uniforms + CPU bookkeeping — it never changes
     // the DataTexture's dimensions. Tile-in-texture indexing stays linear

--- a/packages/three-flatland/src/lights/ForwardPlusLighting.ts
+++ b/packages/three-flatland/src/lights/ForwardPlusLighting.ts
@@ -628,6 +628,12 @@ export class ForwardPlusLighting {
 
   dispose(): void {
     this._tileTexture.dispose()
+    // A disposed instance may be attached again at the same dimensions.
+    // Reset the active grid so resize() re-runs init(), republishes the
+    // devtools views, and update() stays inert until that happens.
+    this._tileCountX = 0
+    this._tileCountY = 0
+    this._tileCount = 0
     unregisterDebugArray('forwardPlus.lightCounts')
     unregisterDebugArray('forwardPlus.tileScores')
     unregisterDebugTexture('forwardPlus.tiles')

--- a/packages/three-flatland/src/lights/LightEffect.test.ts
+++ b/packages/three-flatland/src/lights/LightEffect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { LightEffect, createLightEffect } from './LightEffect'
 import type { LightEffectBuildContext } from './LightEffect'
 import type { ColorTransformFn } from '../materials/Sprite2DMaterial'
@@ -177,6 +177,44 @@ describe('LightEffect instances', () => {
 
     instance.enabled = false
     expect(instance.enabled).toBe(false)
+  })
+
+  it('should not report a runtime rebuild when constants are assigned before the shader is built', () => {
+    const Effect = createLightEffect({
+      name: 'constantBeforeBuild',
+      schema: { featureEnabled: () => false },
+      light: () => stubLightFn,
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const instance = new Effect()
+      instance.featureEnabled = true
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('should report a runtime rebuild after a constant has been captured by the shader', () => {
+    const Effect = createLightEffect({
+      name: 'constantAfterBuild',
+      schema: { featureEnabled: () => false },
+      light: () => stubLightFn,
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const instance = new Effect()
+      instance._buildLightFn(null as never, null as never, null as never, null)
+      instance.featureEnabled = true
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledWith(
+        '[three-flatland] constantAfterBuild.featureEnabled changed at runtime — triggers shader rebuild'
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })
 

--- a/packages/three-flatland/src/lights/LightEffect.ts
+++ b/packages/three-flatland/src/lights/LightEffect.ts
@@ -79,6 +79,7 @@ export interface LightEffectRuntimeContext {
 // Forward-declare Flatland to avoid circular import
 interface FlatlandLike {
   _markLightingDirty(): void
+  _markLightingResizeDirty?(): void
   /**
    * Re-run the attached LightEffect's `_buildLightFn` to capture
    * fresh constant values, re-wrap the result, and push it to every
@@ -246,6 +247,9 @@ export abstract class LightEffect {
   /** @internal Whether this effect is enabled. */
   private _enabled = true
 
+  /** @internal Scale applied to the physical surface before resize(). */
+  private _resolutionScale = 1
+
   /** @internal Whether init() has been called. */
   _initialized = false
 
@@ -326,6 +330,7 @@ export abstract class LightEffect {
           get: () => this._constants[name],
           set: (v: unknown) => {
             if (this._constants[name] === v) return
+            const requiresShaderRebuild = this._lightFn !== null
             this._constants[name] = v
             this._dirty = true
             // Cached `_lightFn` captures the previous constants by
@@ -342,7 +347,7 @@ export abstract class LightEffect {
             // flood the console — the source is still traceable from the
             // first occurrence.
             const warnKey = `${ctor.lightName}.${name}`
-            if (!_warnedConstantSetters.has(warnKey)) {
+            if (requiresShaderRebuild && !_warnedConstantSetters.has(warnKey)) {
               _warnedConstantSetters.add(warnKey)
               console.warn(`[three-flatland] ${warnKey} changed at runtime — triggers shader rebuild`)
             }
@@ -378,6 +383,22 @@ export abstract class LightEffect {
     }
   }
 
+  /**
+   * Processing-resolution multiplier for resources owned by this effect.
+   * The default `1` receives the full physical drawing-buffer size; `0.5`
+   * receives half-width/half-height dimensions while camera framing and the
+   * renderer output stay unchanged. Values must be finite and greater than 0.
+   */
+  get resolutionScale(): number {
+    return this._resolutionScale
+  }
+
+  set resolutionScale(value: number) {
+    if (!Number.isFinite(value) || value <= 0 || value === this._resolutionScale) return
+    this._resolutionScale = value
+    this._flatland?._markLightingResizeDirty?.()
+  }
+
   /** Whether this effect has been marked dirty since last clearDirty(). */
   get dirty(): boolean {
     return this._dirty
@@ -392,13 +413,18 @@ export abstract class LightEffect {
   // Lifecycle methods (overridden by subclasses that own GPU resources)
   // ============================================
 
-  /** Initialize GPU resources. Called lazily on first render. */
+  /** Initialize GPU resources. Called lazily before the first resize and update. */
   init(_ctx: LightEffectRuntimeContext): void {}
 
   /** Per-frame GPU passes (tiling, SDF, radiance cascades). */
   update(_ctx: LightEffectRuntimeContext): void {}
 
-  /** Handle resize. */
+  /**
+   * Handle processing-surface resize. Flatland derives this from the physical
+   * render surface multiplied by {@link resolutionScale}. Once a valid size
+   * exists, this is called after init and before the next update. An initial
+   * update may run first while a newly mounted canvas still reports 0×0.
+   */
   resize(_width: number, _height: number): void {}
 
   // ============================================

--- a/packages/three-flatland/src/lights/OcclusionPass.test.ts
+++ b/packages/three-flatland/src/lights/OcclusionPass.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { OcclusionPass } from './OcclusionPass'
 import { NearestFilter, LinearFilter } from 'three'
 
@@ -43,6 +43,19 @@ describe('OcclusionPass', () => {
     pass.resize(800, 600)
     // Same reference guaranteed because no setSize was issued.
     expect(pass.renderTarget).toBe(rt1)
+    pass.dispose()
+  })
+
+  it('is a no-op when a surface change rounds to the same physical size', () => {
+    const pass = new OcclusionPass()
+    pass.resize(512, 512)
+    const setSize = vi.spyOn(pass.renderTarget, 'setSize')
+
+    pass.resize(513, 513)
+
+    expect(pass.width).toBe(256)
+    expect(pass.height).toBe(256)
+    expect(setSize).not.toHaveBeenCalled()
     pass.dispose()
   })
 

--- a/packages/three-flatland/src/react/flatland-aspect.test.tsx
+++ b/packages/three-flatland/src/react/flatland-aspect.test.tsx
@@ -14,38 +14,50 @@ afterEach(() => {
   universe.reset()
 })
 
+async function createTestRoot(width: number, height: number) {
+  vi.stubGlobal('requestAnimationFrame', () => 0)
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+  const surface = { width, height }
+  const renderer = {
+    render() {},
+    setSize(nextWidth: number, nextHeight: number) {
+      surface.width = nextWidth
+      surface.height = nextHeight
+    },
+    getSize(target: Vector2) {
+      return target.set(surface.width, surface.height)
+    },
+    getDrawingBufferSize(target: Vector2) {
+      return target.set(surface.width, surface.height)
+    },
+    setPixelRatio() {},
+    getPixelRatio: () => 1,
+    getRenderTarget: () => null,
+    setRenderTarget() {},
+    setClearColor() {},
+    autoClear: true,
+    hasInitialized: () => true,
+  }
+  const canvas = { width: 0, height: 0 } as OffscreenCanvas
+  const root = createRoot(canvas)
+  await root.configure({
+    renderer,
+    frameloop: 'never',
+    size: { width, height, top: 0, left: 0 },
+  })
+  return { renderer, root, surface }
+}
+
+async function unmountTestRoot(root: ReturnType<typeof createRoot>): Promise<void> {
+  await act(async () => {
+    root.unmount()
+    await Promise.resolve()
+  })
+}
+
 describe('React Flatland surface sizing', () => {
   it('restores the auto sentinel when an aspect prop is removed and survives a 0x0 first commit', async () => {
-    vi.stubGlobal('requestAnimationFrame', () => 0)
-    vi.stubGlobal('cancelAnimationFrame', () => {})
-    const surface = { width: 0, height: 0 }
-    const renderer = {
-      render() {},
-      setSize(width: number, height: number) {
-        surface.width = width
-        surface.height = height
-      },
-      getSize(target: Vector2) {
-        return target.set(surface.width, surface.height)
-      },
-      getDrawingBufferSize(target: Vector2) {
-        return target.set(surface.width, surface.height)
-      },
-      setPixelRatio() {},
-      getPixelRatio: () => 1,
-      getRenderTarget: () => null,
-      setRenderTarget() {},
-      setClearColor() {},
-      autoClear: true,
-      hasInitialized: () => true,
-    }
-    const canvas = { width: 0, height: 0 } as OffscreenCanvas
-    const root = createRoot(canvas)
-    await root.configure({
-      renderer,
-      frameloop: 'never',
-      size: { width: 0, height: 0, top: 0, left: 0 },
-    })
+    const { renderer, root, surface } = await createTestRoot(0, 0)
 
     const flatlandRef = createRef<Flatland>()
     await act(async () => {
@@ -73,43 +85,11 @@ describe('React Flatland surface sizing', () => {
     expect(flatlandRef.current!.resolvedAspect).toBeCloseTo(1280 / 720)
     expect(flatlandRef.current!.camera.right).toBeCloseTo((800 * (1280 / 720)) / 2)
 
-    await act(async () => {
-      root.unmount()
-      await Promise.resolve()
-    })
+    await unmountTestRoot(root)
   })
 
   it('restores its managed camera when a custom camera prop is removed', async () => {
-    vi.stubGlobal('requestAnimationFrame', () => 0)
-    vi.stubGlobal('cancelAnimationFrame', () => {})
-    const surface = { width: 1280, height: 720 }
-    const renderer = {
-      render() {},
-      setSize(width: number, height: number) {
-        surface.width = width
-        surface.height = height
-      },
-      getSize(target: Vector2) {
-        return target.set(surface.width, surface.height)
-      },
-      getDrawingBufferSize(target: Vector2) {
-        return target.set(surface.width, surface.height)
-      },
-      setPixelRatio() {},
-      getPixelRatio: () => 1,
-      getRenderTarget: () => null,
-      setRenderTarget() {},
-      setClearColor() {},
-      autoClear: true,
-      hasInitialized: () => true,
-    }
-    const canvas = { width: 0, height: 0 } as OffscreenCanvas
-    const root = createRoot(canvas)
-    await root.configure({
-      renderer,
-      frameloop: 'never',
-      size: { width: 1280, height: 720, top: 0, left: 0 },
-    })
+    const { renderer, root } = await createTestRoot(1280, 720)
 
     const customCamera = new OrthographicCamera(-10, 10, 10, -10)
     const flatlandRef = createRef<Flatland>()
@@ -129,9 +109,6 @@ describe('React Flatland surface sizing', () => {
     expect(flatlandRef.current!.resolvedAspect).toBeCloseTo(1280 / 720)
     expect(flatlandRef.current!.camera.right).toBeCloseTo((800 * (1280 / 720)) / 2)
 
-    await act(async () => {
-      root.unmount()
-      await Promise.resolve()
-    })
+    await unmountTestRoot(root)
   })
 })

--- a/packages/three-flatland/src/react/flatland-aspect.test.tsx
+++ b/packages/three-flatland/src/react/flatland-aspect.test.tsx
@@ -1,0 +1,137 @@
+import { act, createRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrthographicCamera, Vector2 } from 'three'
+import { createRoot, extend } from '@react-three/fiber/webgpu'
+import { universe } from 'koota'
+import type { WebGPURenderer } from 'three/webgpu'
+import { Flatland } from '../Flatland'
+
+extend({ Flatland })
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  universe.reset()
+})
+
+describe('React Flatland surface sizing', () => {
+  it('restores the auto sentinel when an aspect prop is removed and survives a 0x0 first commit', async () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0)
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    const surface = { width: 0, height: 0 }
+    const renderer = {
+      render() {},
+      setSize(width: number, height: number) {
+        surface.width = width
+        surface.height = height
+      },
+      getSize(target: Vector2) {
+        return target.set(surface.width, surface.height)
+      },
+      getDrawingBufferSize(target: Vector2) {
+        return target.set(surface.width, surface.height)
+      },
+      setPixelRatio() {},
+      getPixelRatio: () => 1,
+      getRenderTarget: () => null,
+      setRenderTarget() {},
+      setClearColor() {},
+      autoClear: true,
+      hasInitialized: () => true,
+    }
+    const canvas = { width: 0, height: 0 } as OffscreenCanvas
+    const root = createRoot(canvas)
+    await root.configure({
+      renderer,
+      frameloop: 'never',
+      size: { width: 0, height: 0, top: 0, left: 0 },
+    })
+
+    const flatlandRef = createRef<Flatland>()
+    await act(async () => {
+      root.render(<flatland ref={flatlandRef} viewSize={800} aspect={2} />)
+      await Promise.resolve()
+    })
+    expect(flatlandRef.current!.aspect).toBe(2)
+    expect(flatlandRef.current!.camera.right).toBe(800)
+
+    await act(async () => {
+      root.render(<flatland ref={flatlandRef} viewSize={800} />)
+      await Promise.resolve()
+    })
+    expect(flatlandRef.current!.aspect).toBe('auto')
+
+    flatlandRef.current!.render(renderer as unknown as WebGPURenderer)
+    // An unmeasured surface preserves the last valid ratio instead of
+    // replacing it with NaN/Infinity or inventing a new frustum.
+    expect(flatlandRef.current!.resolvedAspect).toBe(2)
+    expect(Number.isFinite(flatlandRef.current!.camera.right)).toBe(true)
+
+    surface.width = 1280
+    surface.height = 720
+    flatlandRef.current!.render(renderer as unknown as WebGPURenderer)
+    expect(flatlandRef.current!.resolvedAspect).toBeCloseTo(1280 / 720)
+    expect(flatlandRef.current!.camera.right).toBeCloseTo((800 * (1280 / 720)) / 2)
+
+    await act(async () => {
+      root.unmount()
+      await Promise.resolve()
+    })
+  })
+
+  it('restores its managed camera when a custom camera prop is removed', async () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0)
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    const surface = { width: 1280, height: 720 }
+    const renderer = {
+      render() {},
+      setSize(width: number, height: number) {
+        surface.width = width
+        surface.height = height
+      },
+      getSize(target: Vector2) {
+        return target.set(surface.width, surface.height)
+      },
+      getDrawingBufferSize(target: Vector2) {
+        return target.set(surface.width, surface.height)
+      },
+      setPixelRatio() {},
+      getPixelRatio: () => 1,
+      getRenderTarget: () => null,
+      setRenderTarget() {},
+      setClearColor() {},
+      autoClear: true,
+      hasInitialized: () => true,
+    }
+    const canvas = { width: 0, height: 0 } as OffscreenCanvas
+    const root = createRoot(canvas)
+    await root.configure({
+      renderer,
+      frameloop: 'never',
+      size: { width: 1280, height: 720, top: 0, left: 0 },
+    })
+
+    const customCamera = new OrthographicCamera(-10, 10, 10, -10)
+    const flatlandRef = createRef<Flatland>()
+    await act(async () => {
+      root.render(<flatland ref={flatlandRef} camera={customCamera} viewSize={800} />)
+      await Promise.resolve()
+    })
+    expect(flatlandRef.current!.camera).toBe(customCamera)
+
+    await act(async () => {
+      root.render(<flatland ref={flatlandRef} viewSize={800} />)
+      await Promise.resolve()
+    })
+    flatlandRef.current!.render(renderer as unknown as WebGPURenderer)
+
+    expect(flatlandRef.current!.camera).not.toBe(customCamera)
+    expect(flatlandRef.current!.resolvedAspect).toBeCloseTo(1280 / 720)
+    expect(flatlandRef.current!.camera.right).toBeCloseTo((800 * (1280 / 720)) / 2)
+
+    await act(async () => {
+      root.unmount()
+      await Promise.resolve()
+    })
+  })
+})

--- a/packages/three-flatland/src/render-target-color.test.ts
+++ b/packages/three-flatland/src/render-target-color.test.ts
@@ -43,6 +43,7 @@ function createRenderer(initialTarget: RenderTarget | null = null) {
     getPixelRatio: () => 1,
     getRenderTarget: () => currentTarget,
     getSize: (target: Vector2) => target.set(640, 360),
+    getDrawingBufferSize: (target: Vector2) => target.set(640, 360),
     render: vi.fn((_scene: Scene, _camera: Camera) => undefined),
     setClearColor: vi.fn(),
     setRenderTarget,
@@ -68,6 +69,15 @@ describe('Flatland render-target color management', () => {
     new Flatland({ renderTarget: target })
 
     expect(target.texture.colorSpace).toBe(SRGBColorSpace)
+  })
+
+  it('defaults every untagged MRT attachment to sRGB', () => {
+    const target = new RenderTarget(64, 64, { count: 2 })
+
+    new Flatland({ renderTarget: target })
+
+    expect(target.textures).toHaveLength(2)
+    expect(target.textures.every((texture) => texture.colorSpace === SRGBColorSpace)).toBe(true)
   })
 
   it('preserves an explicit linear HDR target', () => {

--- a/packages/three-flatland/src/shadow-pipeline.test.ts
+++ b/packages/three-flatland/src/shadow-pipeline.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { RenderTarget, Vector2 } from 'three'
+import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'
 import { createLightEffect } from './lights/LightEffect'
 import { ShadowPipeline, LightingContext } from './ecs/traits'
@@ -23,6 +25,19 @@ const LitWithShadows = createLightEffect({
 function getPipeline(flatland: Flatland) {
   const entities = flatland.world.query(ShadowPipeline)
   return entities.length > 0 ? entities[0]!.get(ShadowPipeline) : null
+}
+
+function mockRenderer(width: number, height: number) {
+  return {
+    getSize: (target: Vector2) => target.set(width, height),
+    getDrawingBufferSize: (target: Vector2) => target.set(width, height),
+    getPixelRatio: () => 1,
+    getRenderTarget: () => null,
+    setRenderTarget: () => {},
+    setClearColor: () => {},
+    render: () => {},
+    autoClear: true,
+  } as unknown as WebGPURenderer
 }
 
 describe('shadowPipelineSystem + ShadowPipeline trait', () => {
@@ -65,10 +80,40 @@ describe('shadowPipelineSystem + ShadowPipeline trait', () => {
         return t
       },
     } as unknown as typeof lctx.renderer
+    lctx.surfaceSize.set(1920, 1080)
     lctx.camera = flatland.camera
     lctx.scene = null
     shadowPipelineSystem(flatland.world)
     expect(pipeline!.sdfGenerator).toBe(sdfBefore)
+  })
+
+  it('resizes the live shadow pipeline when render() observes render-target swaps', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const flatland = new Flatland()
+    flatland.setLighting(new LitWithShadows())
+    const pipeline = getPipeline(flatland)!
+    const sdfInit = vi.spyOn(pipeline.sdfGenerator!, 'init').mockImplementation(() => {})
+    const sdfResize = vi.spyOn(pipeline.sdfGenerator!, 'resize').mockImplementation(() => {})
+    vi.spyOn(pipeline.sdfGenerator!, 'generate').mockImplementation(() => {})
+    const occlusionResize = vi.spyOn(pipeline.occlusionPass!, 'resize').mockImplementation(() => {})
+    vi.spyOn(pipeline.occlusionPass!, 'render').mockImplementation(() => {})
+    const renderer = mockRenderer(1280, 720)
+
+    flatland.renderTarget = new RenderTarget(512, 256)
+    flatland.render(renderer)
+
+    expect(sdfInit).toHaveBeenCalledWith(256, 128)
+    expect(occlusionResize).toHaveBeenCalledWith(512, 256)
+    expect(pipeline.width).toBe(256)
+    expect(pipeline.height).toBe(128)
+
+    flatland.renderTarget = new RenderTarget(300, 600)
+    flatland.render(renderer)
+
+    expect(sdfResize).toHaveBeenCalledWith(150, 300)
+    expect(occlusionResize).toHaveBeenLastCalledWith(300, 600)
+    expect(pipeline.width).toBe(150)
+    expect(pipeline.height).toBe(300)
   })
 
   it('switching from shadow → no-shadow tears down on next system tick', () => {
@@ -84,6 +129,7 @@ describe('shadowPipelineSystem + ShadowPipeline trait', () => {
         return t
       },
     } as unknown as typeof lctx.renderer
+    lctx.surfaceSize.set(256, 256)
     lctx.camera = flatland.camera
     lctx.scene = null
     shadowPipelineSystem(flatland.world)
@@ -117,6 +163,7 @@ describe('shadowPipelineSystem + ShadowPipeline trait', () => {
         return t
       },
     } as unknown as typeof lctx.renderer
+    lctx.surfaceSize.set(256, 256)
     lctx.camera = flatland.camera
     lctx.scene = null
 
@@ -144,6 +191,7 @@ describe('shadowPipelineSystem + ShadowPipeline trait', () => {
         return t
       },
     } as unknown as typeof lctx.renderer
+    lctx.surfaceSize.set(256, 256)
     lctx.camera = flatland.camera
     lctx.scene = null
     shadowPipelineSystem(flatland.world)

--- a/scripts/sync-examples.ts
+++ b/scripts/sync-examples.ts
@@ -11,6 +11,7 @@
  * What gets synced:
  *   examples/three/template/GemBackground.ts → examples/three/<slug>/GemBackground.ts
  *   examples/react/template/GemBackground.tsx → examples/react/<slug>/GemBackground.tsx
+ *   examples/_shared/rendererColorManagement.ts → every example directory
  *   examples/_shared/rendererFallback.ts → every example directory
  *   examples/_shared/WebGPUFallback.tsx → every React example directory
  *
@@ -49,10 +50,12 @@ type SyncedFile = {
 const SYNCED_FILES: Record<Variant, readonly SyncedFile[]> = {
   three: [
     { source: 'examples/three/template/GemBackground.ts', target: 'GemBackground.ts' },
+    { source: 'examples/_shared/rendererColorManagement.ts', target: 'rendererColorManagement.ts' },
     { source: 'examples/_shared/rendererFallback.ts', target: 'rendererFallback.ts' },
   ],
   react: [
     { source: 'examples/react/template/GemBackground.tsx', target: 'GemBackground.tsx' },
+    { source: 'examples/_shared/rendererColorManagement.ts', target: 'rendererColorManagement.ts' },
     { source: 'examples/_shared/rendererFallback.ts', target: 'rendererFallback.ts' },
     { source: 'examples/_shared/WebGPUFallback.tsx', target: 'WebGPUFallback.tsx' },
   ],

--- a/skills/flatland-r3f/SKILL.md
+++ b/skills/flatland-r3f/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flatland-r3f
-description: Use when integrating three-flatland with React Three Fiber — registering classes with extend(), rendering sprites declaratively in JSX, Flatland child routing, post-processing via addEffect, resize/render wiring in useFrame/useThree, or avoiding imperative R3F anti-patterns
+description: Use when integrating three-flatland with React Three Fiber — registering classes with extend(), rendering sprites declaratively in JSX, Flatland child routing, post-processing via addEffect, automatic render-surface sizing and fixed-aspect overrides, or avoiding imperative R3F anti-patterns
 ---
 
 # Flatland R3F Integration Skill
@@ -45,17 +45,12 @@ extend({ Flatland, Sprite2D })
 ```tsx
 function Scene() {
   const flatlandRef = useRef<Flatland>(null)
-  const { gl, size } = useThree()
+  const renderer = useThree((state) => state.renderer)
 
-  // Handle resize
-  useEffect(() => {
-    flatlandRef.current?.resize(size.width, size.height)
-  }, [size.width, size.height])
-
-  // Render loop — Flatland.render() handles everything
+  // Flatland.render() derives camera and effect dimensions from the physical drawing buffer.
   useFrame(() => {
-    flatlandRef.current?.render(gl)
-  })
+    flatlandRef.current?.render(renderer)
+  }, { phase: 'render' })
 
   return (
     <flatland
@@ -72,7 +67,7 @@ function Scene() {
 ### 3. Complete Example
 
 ```tsx
-import { Suspense, useRef, useEffect } from 'react'
+import { Suspense, useRef } from 'react'
 import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
 import { Flatland, Sprite2D, TextureLoader } from 'three-flatland/react'
 
@@ -82,15 +77,11 @@ extend({ Flatland, Sprite2D })
 function Scene() {
   const texture = useLoader(TextureLoader, '/sprites/knight.png')
   const flatlandRef = useRef<Flatland>(null)
-  const { gl, size } = useThree()
-
-  useEffect(() => {
-    flatlandRef.current?.resize(size.width, size.height)
-  }, [size.width, size.height])
+  const renderer = useThree((state) => state.renderer)
 
   useFrame(() => {
-    flatlandRef.current?.render(gl)
-  })
+    flatlandRef.current?.render(renderer)
+  }, { phase: 'render' })
 
   return (
     <flatland ref={flatlandRef} viewSize={300} clearColor={0x1a1a2e}>
@@ -101,7 +92,7 @@ function Scene() {
 
 export default function App() {
   return (
-    <Canvas gl={{ antialias: false }}>
+    <Canvas renderer={{ antialias: false }}>
       <Suspense fallback={null}>
         <Scene />
       </Suspense>
@@ -149,12 +140,8 @@ For post-processing effects, use `addEffect()`:
 import { crtComplete, vignette } from 'three-flatland/react'
 
 function PostProcessingScene() {
-  const { gl, size } = useThree()
+  const renderer = useThree((state) => state.renderer)
   const flatlandRef = useRef<Flatland>(null)
-
-  useEffect(() => {
-    flatlandRef.current?.resize(size.width, size.height)
-  }, [size.width, size.height])
 
   // Add effects once
   useEffect(() => {
@@ -166,8 +153,8 @@ function PostProcessingScene() {
   }, [])
 
   useFrame(() => {
-    flatlandRef.current?.render(gl)
-  })
+    flatlandRef.current?.render(renderer)
+  }, { phase: 'render' })
 
   return (
     <flatland ref={flatlandRef} viewSize={300} clearColor={0x1a1a2e}>
@@ -184,14 +171,14 @@ import { PostProcessing } from 'three/webgpu'
 import { pass, uv } from 'three/tsl'
 
 function ManualPostProcessing() {
-  const { gl } = useThree()
+  const renderer = useThree((state) => state.renderer)
   const flatlandRef = useRef<Flatland>(null)
 
   useEffect(() => {
     const flatland = flatlandRef.current
     if (!flatland) return
 
-    const postProcessing = new PostProcessing(gl)
+    const postProcessing = new PostProcessing(renderer)
     const scenePass = pass(flatland.scene, flatland.camera)
     postProcessing.outputNode = crtComplete(scenePass, uv(), { curvature: 0.15 })
 
@@ -200,11 +187,11 @@ function ManualPostProcessing() {
     return () => {
       postProcessing.dispose?.()
     }
-  }, [gl])
+  }, [renderer])
 
   useFrame(() => {
-    flatlandRef.current?.render(gl)
-  }, 1)
+    flatlandRef.current?.render(renderer)
+  }, { phase: 'render' })
 
   return (
     <flatland ref={flatlandRef} viewSize={300} clearColor={0x1a1a2e}>
@@ -223,7 +210,11 @@ function ManualPostProcessing() {
 | `new Flatland({...})` | `<flatland viewSize={300}>` |
 | `flatland.add(sprite)` | `<sprite2D>` as child of `<flatland>` |
 | `flatland.render(renderer)` | Manual via `useFrame` |
-| `flatland.resize(w, h)` | Manual via `useEffect` + `useThree().size` |
+| `renderer.setSize(w, h)` | `<Canvas>` owns renderer size; do not add a Flatland resize bridge |
+| `new Flatland({ aspect: 1 })` | `<flatland aspect={1}>` pins camera framing while effects follow the real surface |
+| `flatland.aspect = locked ? 1 : 'auto'` | `<flatland aspect={locked ? 1 : 'auto'}>` restores auto mode declaratively |
+| `flatland.resize(w, h)` | `flatlandRef.current?.resize(w, h)` is the explicit manual-sizing escape hatch |
+| `lighting.resolutionScale = 0.5` | `<defaultLightEffect resolutionScale={0.5}>` lowers only effect-owned processing resources |
 
 ---
 
@@ -234,6 +225,7 @@ function ManualPostProcessing() {
 ```tsx
 // BAD: Creates Flatland imperatively, bypasses R3F's scene graph
 function Bad() {
+  const renderer = useThree((state) => state.renderer)
   const flatland = useMemo(() => {
     const fl = new Flatland({ viewSize: 300 })
     const sprite = new Sprite2D({ texture })
@@ -242,7 +234,7 @@ function Bad() {
   }, [])
 
   useFrame(() => {
-    flatland.render(gl)
+    flatland.render(renderer)
   })
 
   return null  // Nothing in the JSX tree
@@ -257,15 +249,11 @@ extend({ Flatland, Sprite2D })
 
 function Good() {
   const flatlandRef = useRef<Flatland>(null)
-  const { gl, size } = useThree()
-
-  useEffect(() => {
-    flatlandRef.current?.resize(size.width, size.height)
-  }, [size.width, size.height])
+  const renderer = useThree((state) => state.renderer)
 
   useFrame(() => {
-    flatlandRef.current?.render(gl)
-  })
+    flatlandRef.current?.render(renderer)
+  }, { phase: 'render' })
 
   return (
     <flatland ref={flatlandRef} viewSize={300}>

--- a/skills/flatland-r3f/SKILL.md
+++ b/skills/flatland-r3f/SKILL.md
@@ -33,7 +33,7 @@ All classes in Flatland extend three.js base classes, so they can be registered 
 ### 1. Register with extend()
 
 ```tsx
-import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
+import { Canvas, extend, useFrame, useLoader, useThree } from '@react-three/fiber/webgpu'
 import { Flatland, Sprite2D } from 'three-flatland/react'
 
 // Register Flatland and its children with R3F

--- a/tools/preview/src/AnimationPreviewPip.tsx
+++ b/tools/preview/src/AnimationPreviewPip.tsx
@@ -288,9 +288,7 @@ export function AnimationPreviewPip(props: AnimationPreviewPipProps) {
   const currentName = frames[currentFrameIndex]
   const rect = currentName ? rectsByName[currentName] : undefined
   const frame =
-    rect && atlasSize
-      ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h, atlasW: atlasSize.w, atlasH: atlasSize.h }
-      : null
+    rect && atlasSize ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h, atlasW: atlasSize.w, atlasH: atlasSize.h } : null
   // Event tag for the current playhead frame, if any. Keyed by frame
   // index (as string, matching the sidecar storage shape). The
   // editor's timeline uses the same lookup pattern.

--- a/tools/tsl-test/src/index.ts
+++ b/tools/tsl-test/src/index.ts
@@ -518,9 +518,7 @@ export function nagaFailure(error: unknown): string {
     const output = typeof stderr === 'string' ? stderr.trim() : ''
     if (output) return `Naga rejected emitted WGSL:\n${output}`
   }
-  return error instanceof Error
-    ? `Naga validation failed: ${error.message}`
-    : 'Naga failed without diagnostic output'
+  return error instanceof Error ? `Naga validation failed: ${error.message}` : 'Naga failed without diagnostic output'
 }
 
 export async function validateShaderSources(shaders: ShaderSource[]): Promise<void> {


### PR DESCRIPTION
### **User description**
## Summary

Make the active render surface the default source of truth for Flatland camera framing and surface-dependent lighting resources.

This expands the original aspect-ratio fix into the complete, reviewed behavior needed by vanilla Three.js and React Three Fiber:

- derive automatic camera aspect from the active render target or physical renderer drawing buffer;
- keep logical viewport uniforms and renderer DPR independent from physical effect-buffer sizing;
- add `LightEffect.resolutionScale` as an explicit per-effect quality/performance control;
- guarantee `init → resize → update` for late, disabled, replaced, and reattached effects;
- preserve authored custom cameras, including deliberate camera sharing between live Flatland instances;
- restore Flatland's managed camera when R3F removes a conditional `camera` prop;
- keep explicit linear/HDR render targets intact and apply the final output transform only for screen presentation;
- default unauthored render-target attachments to sRGB;
- normalize every paired React/Three example to explicit sRGB output with no tone mapping;
- run both lighting examples at `resolutionScale = 0.5` without changing their camera or canvas DPR;
- update starter templates, the Breakout mini, docs, and the packaged R3F skill to use automatic sizing;
- make type-aware Nx lint build and hash dependency production inputs first.

## Breaking change

`Flatland` no longer keeps a square `aspect = 1` frustum until the application calls `resize()`. The default now follows the render surface.

If square framing was intentional, pass `aspect: 1` or assign `flatland.aspect = 1`. Remove manual resize bridges when framing should follow the canvas. Assign `aspect = 'auto'` to restore automatic framing; `resize(width, height)` remains the full manual surface-size escape hatch.

The committed changeset records this as a `minor` bump for the current `0.x` core release, with patch bumps for the affected preset, starter, and skill packages.

## Sizing contract

| Control | Camera | Whole canvas | Effect buffers | Logical viewport globals |
| --- | --- | --- | --- | --- |
| Renderer/R3F DPR | unchanged framing | scales | scales with physical drawing buffer | logical size + DPR stay separate |
| `effect.resolutionScale` | unchanged | unchanged | scales only that effect | unchanged |
| numeric `aspect` | pins framing | unchanged | continues following surface | unchanged |
| `resize(w, h)` | manual framing | unchanged | manual dimensions | unchanged |
| `aspect = 'auto'` | follows surface | unchanged | follows surface | unchanged |

## Validation

- Core: 84 test files, 959 tests, no type errors.
- Shader compiler gate: all production TSL graphs compile through the WGSL and GLSL validation harness.
- Focused Nx gate: core plus React/Three lighting examples and dependencies pass build, typecheck, lint, and test with cache disabled.
- Paired example gate: all 26 React/Three routes render live with a canvas, no Vite overlay, and no fresh warning/error logs.
- Repository checks: formatter, generated example-helper sync, React subpath sync, and `git diff --check` pass.
- Opus 5 High adversarial review completed. Valid findings around effect reattachment, idempotent assignment, shared cameras, Nx cache inputs, and example resolution parity were fixed and regression-tested. The claimed missing DPR coverage was independently rejected because a DPR-2 physical/logical test already exists.

## Commit structure

1. `fix(three-flatland): derive the camera aspect from the render surface`
2. `fix(three-flatland)!: complete automatic surface sizing`
3. `fix(examples): normalize paired renderer output`
4. `refactor(starters): adopt automatic Flatland sizing`
5. `docs(flatland): document automatic surface sizing`
6. `fix(nx): build dependencies before type-aware lint`
7. `chore(tooling): format preview and shader test sources`

The branch was rebuilt from fresh `main`; the previous merge-heavy/bot-generated history is gone.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Flatland.render derives camera aspect and effect surface size from the active render target or drawing buffer, handling 0×0 and unchanged sizes safely.

- LightEffect gains `resolutionScale`; lifecycle becomes deterministic `init → resize → update`, with disposal on replacement.

- Shadow pipeline and lighting context consume the canonical `surfaceSize` trait instead of querying the renderer each frame.

- R3F restores managed camera/aspect after prop removal; examples, templates, and docs adopt automatic sizing and explicit sRGB/no tone mapping.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flatland.render()"] --> B["_syncSurfaceSize"]
  B --> C["Auto aspect"] --> E["Camera frustum"]
  B --> D["Queue LightEffect resize"] --> F["init → resize → update"]
  B --> G["Drawing buffer / render target"]
  H["resolutionScale"] --> D
  I["R3F prop removal"] --> J["Restore managed camera/aspect"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>Flatland.ts</strong><dd><code>Auto-sync aspect and surface sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-21f17b5c32cefd0d7d0538c5aa02ab63cb4d9fa66de67d6d8a9486bc27c590a0">+229/-14</a></td>

</tr>

<tr>
  <td><strong>LightEffect.ts</strong><dd><code>Add resolutionScale and lifecycle semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-34406e174456186bc3bfa5900d3eb68177ace28766a6a452423112b4a3534a41">+29/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lightEffectSystem.ts</strong><dd><code>Enforce init before resize and update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-f773976c9c8b3dca773485afa1221f168421a77fab4e77672a264460e7f3c48c">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shadowPipelineSystem.ts</strong><dd><code>Use canonical surfaceSize for shadow buffers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-daf9183ba9d4f702f7155adb159f4b8079942013b72ab1cb1668cee85c0de9fb">+11/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>traits.ts</strong><dd><code>Extend LightingContext with surface size fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-aaf8d35fd193ef1adfe40189618c3e582bfb94efd198c2470f40be6e2cde552f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DefaultLightEffect.ts</strong><dd><code>Remove renderer-based init sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-0214bda86d6a899e1123f66f8b003a70542582bd51e8451f9c3724bc7b12ee49">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong><dd><code>Shared sRGB/no-tone-mapping color config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-4101ccb69d335eda866a817578f90ea0dc2c5b35125514cd9ab05bcbcdcb2166">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Use auto sizing and resolutionScale in React example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-e708a0e6ac83cb2f2ebce1647af3880f3058e400943858d0ec736b0d3566e406">+12/-75</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong><dd><code>Use auto sizing and resolutionScale in Three example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-048b3b77b6d2c818cb56f3394881b59cb16e7cbc09a5bfd2c0b1e7ca1e5d7449">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Remove resize bridge; set explicit color pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5146169bb8e5bc25fed94e032bec8d8c7a45f97ac8857823a7b97e99e5d96122">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong><dd><code>Remove manual resize; set explicit color pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-0b4089c5f946215f7b433931974d22d8f0b4b8a38548453e815d9ad067cb8d3d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ForwardPlusLighting.ts</strong><dd><code>Reset grid after disposal for reattachment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-8019588ef49afa1a373363689444c123ca554f95152e83ee387081232774e5cf">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>flatland-resize.test.ts</strong><dd><code>Test automatic surface sizing and lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-89ef4a816922b0035c021b3ee6c5b0295ccc84e89a964f78d681e2492dd32413">+506/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flatland-aspect.test.tsx</strong><dd><code>Test R3F aspect and camera restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-2e51ec0280ed914d3591c1c7f0704c004e5dc877aa8772d0fb881bea79ec8d4d">+137/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>sync-examples.ts</strong><dd><code>Sync renderer color management to examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-6774c73853ad521afb317dd119df4202a70deefd5721cd993f55aa59f60378d4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nx.json</strong><dd><code>Make lint depend on production inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>SKILL.md</strong><dd><code>Replace resize wiring with automatic sizing guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-fc47a7fd0f5179aead10b82f327a1270b54814d8443f017e5c01f0440b3283d9">+28/-40</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flatland.mdx</strong><dd><code>Document automatic surface sizing and resolutionScale</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5d4f1fe2a15abecc4fdb52872bf5082b04a5ad4055fd30b1eebf6d8ab59aad85">+24/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lighting-setup.mdx</strong><dd><code>Update lighting setup for auto sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-14a79ebaed1158381495fb81b65bb1b457693eb6b209d6da4f8c5a1f0118c963">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auto-three-flatland-3rvrwel.md</strong><dd><code>Changeset for render surface authority</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-665c9aad1d92b868deafa90bc16d6a5c8d901c4aa8ca75744bb896a271fb9ccc">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>61 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shadows-setup.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-af9880c8917c041192ad9dcd08238cda32ba01b1bc6cdc2afc1a035aa46d57f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-71141f6ecd7b390892ab69e38d1807560778d759eecc3179918f1942edb18e23">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-d4c68c63989e2085425768f2f3bd9ebdd59559e1de79b5c12750f70f32688a49">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-e8f830f0bdffabda69271c61d34d4602db26a039a57833b5c8dc457bad2626b6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-086942e139a5b3c049ec7b4ff092c392d255feb16610e1821baf3886d6276fe3">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-2043c2dc94473f0a6086ebbd975602a99a6b18a01888b5ca50e71f271ca3e11e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-04ebfbf093e8b72ce51f749492fd7021ad180d79cc3597c973bd156b9778c051">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-32fe881dded68ee6bd9796ddc7779a643983d2c9e52ab7899641a01decfc8ff7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-8322529777300428692b75cd88b682a3d9b6aab7f2eb754d9a3c39916f72a4bc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-490e970460e0bd93a31151043e0a6758071f63134d149eca224552356ddfd766">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-1cc235e4df1fda2b2e0716ad8f0a6e62ebc94b507ed4fae61bac6b4cd18fe81c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5e6f30be9ef31bafa2ef31e3c5e0aba2e41c709e56182e20d405645fba1b763c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-a7ea7a1028b44e8c9f9df4a0d9781598a14cf62cfefba30a914645c25cdb3d88">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-38aab057fda211ac393d3495331229646b060f6e6ac843a867ce574bca65c174">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-87a7de9ee405dce258fcace9aa4ba6f778b32254d40bbd3aecb58492971c0fdf">+19/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-80de7e9e75da34b3fb79ee37c633e340ae8d0d1d07848601ec4faf07f3465e92">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5a660fda38386a35b17f96b13451bb548ba764461769e01b224d21ff89b2cb13">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-708797ea4efa16640b990f0e548fdb9bec8d64fb9f67024617e97067fb22c9b5">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-16e899cfecf2bc7a314fb26fe0a83c1d4ac28356559ed9bb721faf1a06edec80">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-8f227480edd2086dc56400e687f358ef6381f758d6a09975dfaebe3cd75b32df">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c5def5a70bd3b06bb8aab10296d177095dad57b24c2576765e42f8142674cb28">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-fac05547e9a3f2a330838d661d0493a136db9785224b22fe2d15c4990ec7833d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-a7ac396348738934d58043ed287045d6c867d51846b50bdcb10df472e82fc67f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-083c9f79b91828ed38b68d57948c65c42cdfed26ad3497a4d782493e89f9f5ca">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-a0d3c274d26d3f4ba1d3199613674e5f3abf81706f43af80e51500821f6a81ee">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-12c45748fbc3a1189e3e9998c6c073e795c871bd98a9b247dcbcc385b331e9d8">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-73007fd26d03622df299a01c0808bde4fd0fff7d0691e6a6e78ff3a2430ed67d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-12cc6be9a1a6f480b16634489fcd2796c9fff7ad9824eecff536f101a2c40a85">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c41509ea205b10761c95bd3c935992e74ad1c8828a81956ab6b6730efdacf45f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-1aa7b950637d17c6967528bb4f4c876e7cc4118101761c378906975caf32e234">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-1f939652ec5729906f1d965c647e38ddc4278fd0f5a0f3c5a4030ea8dba5fbb8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-fcd777bf46bb3c8a54278a9ec6eb8d83ac3f31e6f97dfc2b7241d3f9184ca2de">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-1dfee2ecdbe11f584bd914136c99cd88b83cb54910b4586ac0bea3097aec9bf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-8388215dc0fce73dce11fb75fd0612c53f66212cd32fad72c6028c1dfcec6382">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-f9963ca7b377a07c20c193932b97fc20f5a8dee8e7d272fc8160c4b76b578b9d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-7f7263bce32373efb7ccb8d8784ac9d739a05164709bcb342e5fb66380728106">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-a18f45bca7b8bffcd727653a743c270d9405cd753962eec451a2174762c6ec7f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-bda40151a15844e8a76d70116fadd352783f81283f1ae61aa12523d0a2814198">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-54edc7bf1af64dbc2bd3e1cd4c9134475e11e76f8d69634a8b4265bd0bb75316">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5886e823f8218f9a7f69c3b13f3039e802bcfc8d3d194b849609f50f7913f58c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-d6416a6282a5e5d3cacfd861904a4433e186c9f57182f540cd020204cedade53">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-d7e4714d62d24b28b4bae636a86085aa8d492df36d52880af2d1546fb87a9a4b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-ec02ce784835b7b67c0d03c9f5095368b91a5e94735cefdc2ac997f223ccd297">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-5a6e59e6f4d5218911c2dec5852a0c4b7a8608e04f61c303c257ed62bb0e9b55">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-2aaa08cd54a799fce0233f2dbe1f19db313254b05f42e3cf9e379703cdb4f7b1">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-ace114363bf27d43cbd30fb97d7fbb4977339edd2943ff0edf05f9427b67f7eb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-fc100e906074349280b526f13b533099a15caec9d5783ad5cf7385663f57eb23">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-210ce4e5104e1b42461b1e7b7f2dc7c6b22cb8f7c54c67d2b9668ebd08ff0b38">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-ba449ed5df830f3be78056c3ee67ab6220755db2bb84ef564a85ec2654cd116e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-1bc73e1b79718f2255bd646f7f73a2b67243c77f257a79644c8c1e8a546c1a01">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rendererColorManagement.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-debad8fd4b2c76f536c95090300a35432b559c9b7f7f609955f11196b9cb13ad">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Game.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-e67ab134e663044bf064b0a1232eaca9a4947dfcedf3f5e92e1a491a49e92e91">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-bb82daa1fe0f2ae59f5b49ac584104d0be00819eca3ebc0d288037b9dbf919e4">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shadowPipelineSystem.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c2c409028357628644f5f6a76148e164ed724171fa92ca51d4ee9d3ee009c1c1">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ForwardPlusLighting.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-34c89b96352c5410411702b2e168b037367ae9dc1cbeb7b7b4612802114ac209">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LightEffect.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-00d1005086ebdd718ca49d68731069e30ac6206545dacb7bba60bb1da6e16c11">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>render-target-color.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c1948985d084ace79f3877af6be173711619f9cb0c4f8f1174fd05c536fbc0f1">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shadow-pipeline.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c6a1aee439b3b9e05037fcdcef4ef4a22a4aab7f4ce9a47e7eb21b7acdc95055">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AnimationPreviewPip.tsx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-c210a7dfd61bce525348f5dc5a3155a40ba8039ea7bb052d110ac36d9c98b459">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/181/files#diff-592e60fae330cb3f70c833d6793f01bcc41fed7945eda0ec7a8d8ec125a9f32b">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flatland now automatically synchronizes camera, lighting, render targets, and effects with the renderer’s drawing surface.
  * Added automatic, numeric, and restorable camera aspect settings, plus effective aspect reporting.
  * Added configurable lighting effect resolution scaling and safer effect replacement and disposal.
  * Render-target textures now consistently use sRGB color handling.

* **Bug Fixes**
  * Improved resizing behavior for render targets, shadows, shared cameras, and zero-sized surfaces.
  * Corrected lighting and shadow resource updates after disposal or replacement.

* **Documentation**
  * Updated Flatland, lighting, shadows, templates, and React guidance for automatic sizing and color management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->