### PR TITLE
feat(uikit): native a11y Phase 0 — screen-space core

### DIFF
--- a/packages/uikit/src/a11y/activation.ts
+++ b/packages/uikit/src/a11y/activation.ts
@@ -53,7 +53,9 @@ export function dispatchActivation(component: Component, event: A11yActivationEv
 
   component.dispatchEvent({ type: 'activate', ...event })
 
-  if (event.source !== 'pointer') {
+  // onActivate may have synchronously disabled the component (vanilla signal path) — don't fire the
+  // compat synthetic click into a now-disabled control (would double-act with a legacy onClick).
+  if (event.source !== 'pointer' && component.properties.value.disabled !== true) {
     component.getWorldPosition(activationPoint)
     const click: ThreeMouseEvent = {
       distance: 0,

--- a/packages/uikit/src/a11y/activation.ts
+++ b/packages/uikit/src/a11y/activation.ts
@@ -1,0 +1,31 @@
+import type { Intersection } from 'three'
+
+/**
+ * The modality that triggered an activation. The cross-mode truth: pointer clicks delegate TO
+ * activation, not the reverse, so controller / gaze / switch activation in Modes 3–4 reuse the
+ * exact same path with zero per-widget code.
+ */
+export type A11yActivationSource =
+  | 'pointer'
+  | 'keyboard'
+  | 'screen-reader'
+  | 'voice'
+  | 'xr-controller'
+  | 'gaze'
+  | 'hand'
+  | 'switch'
+
+/**
+ * A semantic activation event dispatched as three's `'activate'`. Geometry is present ONLY when
+ * the source actually has it (`pointer` / `xr-controller`); a keyboard/AT activation carries no
+ * fake mouse coordinates — that honesty is finding #8 of the spec's adversarial review.
+ */
+export type A11yActivationEvent = {
+  source: A11yActivationSource
+  /** DOM event / XRInputSourceEvent when available. */
+  nativeEvent?: unknown
+  /** Real geometry when `source` is `'pointer'` / `'xr-controller'`; absent otherwise. */
+  intersection?: Intersection
+  handedness?: 'left' | 'right' | 'none'
+  stopPropagation?: () => void
+}

--- a/packages/uikit/src/a11y/activation.ts
+++ b/packages/uikit/src/a11y/activation.ts
@@ -1,4 +1,8 @@
+import { Vector3 } from 'three'
 import type { Intersection } from 'three'
+import type { Component } from '../components/component.js'
+import type { ThreeMouseEvent } from '../events.js'
+import { announce } from './announce/announcer.js'
 
 /**
  * The modality that triggered an activation. The cross-mode truth: pointer clicks delegate TO
@@ -28,4 +32,44 @@ export type A11yActivationEvent = {
   intersection?: Intersection
   handedness?: 'left' | 'right' | 'none'
   stopPropagation?: () => void
+}
+
+const activationPoint = /* @__PURE__ */ new Vector3()
+const noop = (): void => {}
+
+/**
+ * Dispatch a semantic activation on a component (spec §2). Fires `'activate'` through the existing
+ * handler chain — so `onActivate` from props / classes / star props / kit `defaultOverrides` all
+ * run via the exact computedHandlers → addEventListener path already in component.ts — then a
+ * compat synthetic `'click'` (marked `synthetic` so onClick-only code keeps working for keyboard/AT
+ * activation, skipped for real pointer clicks that already ran), then announces the activation /
+ * deactivation message chosen by the current toggle state.
+ */
+export function dispatchActivation(component: Component, event: A11yActivationEvent): void {
+  const properties = component.properties.value
+  if (properties.disabled === true) {
+    return
+  }
+
+  component.dispatchEvent({ type: 'activate', ...event })
+
+  if (event.source !== 'pointer') {
+    component.getWorldPosition(activationPoint)
+    const click: ThreeMouseEvent = {
+      distance: 0,
+      point: activationPoint.clone(),
+      object: component,
+      synthetic: true,
+      source: event.source,
+      nativeEvent: event.nativeEvent,
+      stopPropagation: event.stopPropagation ?? noop,
+    }
+    component.dispatchEvent({ type: 'click', ...click })
+  }
+
+  const wasToggled = properties.ariaChecked ?? properties.ariaPressed
+  const message = wasToggled ? properties.deactivationMessage : properties.activationMessage
+  if (typeof message === 'string' && message.length > 0) {
+    announce(message, { source: component, kind: 'activation' })
+  }
 }

--- a/packages/uikit/src/a11y/announce/announcer.ts
+++ b/packages/uikit/src/a11y/announce/announcer.ts
@@ -1,0 +1,87 @@
+import { signal, type ReadonlySignal } from '@preact/signals-core'
+import type { Component } from '../../components/component.js'
+import { createDomLiveRegionBackend } from './backends/dom-live-region.js'
+
+export type Politeness = 'polite' | 'assertive'
+
+export type Announcement = {
+  message: string
+  politeness: Politeness
+  /** The component the message is about — lets spatial backends pan audio / anchor captions. */
+  source?: Component
+  kind?: 'activation' | 'focus' | 'status'
+}
+
+/**
+ * A destination for a11y announcements. The default is a DOM `aria-live` region; XR/game modes
+ * add in-world captions, spatial earcons, controller haptics, or speech synthesis — one live
+ * region is a browser-mode backend, not the whole system (adversarial finding #9).
+ */
+export interface AnnouncementBackend {
+  announce(a: Announcement): void
+  dispose?(): void
+}
+
+const backends = new Set<AnnouncementBackend>()
+let triedDefault = false
+
+/** Register an announcement backend; returns an unregister function that disposes it. */
+export function registerAnnouncementBackend(backend: AnnouncementBackend): () => void {
+  backends.add(backend)
+  return () => {
+    if (backends.delete(backend)) {
+      backend.dispose?.()
+    }
+  }
+}
+
+/**
+ * Speak a message through every registered backend. In a DOM env the default off-screen live
+ * region auto-registers on first use (unless the app registered its own backend first); SSR /
+ * no-DOM is a silent no-op.
+ */
+export function announce(message: string, opts?: Partial<Omit<Announcement, 'message'>>): void {
+  if (!triedDefault && backends.size === 0 && typeof document !== 'undefined') {
+    triedDefault = true
+    registerAnnouncementBackend(createDomLiveRegionBackend())
+  }
+  if (backends.size === 0) {
+    return
+  }
+  const announcement: Announcement = {
+    message,
+    politeness: opts?.politeness ?? 'polite',
+    source: opts?.source,
+    kind: opts?.kind,
+  }
+  for (const backend of backends) {
+    backend.announce(announcement)
+  }
+}
+
+/** User a11y preferences read by backends + the focus-reveal policy. */
+export type A11yPreferences = {
+  captions: boolean
+  earcons: boolean
+  haptics: boolean
+  speech: boolean
+  monoAudio: boolean
+  reducedMotion: boolean
+}
+
+const preferences = /* @__PURE__ */ signal<A11yPreferences>({
+  captions: false,
+  earcons: false,
+  haptics: false,
+  speech: false,
+  monoAudio: false,
+  reducedMotion: false,
+})
+
+export function setA11yPreferences(prefs: Partial<A11yPreferences>): void {
+  preferences.value = { ...preferences.value, ...prefs }
+}
+
+export function getA11yPreferences(): ReadonlySignal<A11yPreferences> {
+  return preferences
+}

--- a/packages/uikit/src/a11y/announce/backends/dom-live-region.ts
+++ b/packages/uikit/src/a11y/announce/backends/dom-live-region.ts
@@ -1,0 +1,55 @@
+import type { Announcement, AnnouncementBackend } from '../announcer.js'
+
+const offScreenStyle =
+  'border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;white-space:nowrap;padding:0;width:1px;position:absolute;'
+
+/**
+ * Default browser backend: one off-screen `aria-live` region per politeness level, mounted on
+ * `document.body`. Clears the text then sets it ~100 ms later so an identical repeat message
+ * still re-announces (react-three-a11y's trick, framework-free — no zustand).
+ */
+export function createDomLiveRegionBackend(): AnnouncementBackend {
+  const regions = new Map<string, HTMLElement>()
+  const timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  const ensure = (politeness: string): HTMLElement => {
+    let element = regions.get(politeness)
+    if (element == null) {
+      element = document.createElement('div')
+      element.setAttribute('aria-live', politeness)
+      element.setAttribute('aria-atomic', 'true')
+      element.style.cssText = offScreenStyle
+      document.body.appendChild(element)
+      regions.set(politeness, element)
+    }
+    return element
+  }
+
+  return {
+    announce(a: Announcement) {
+      const element = ensure(a.politeness)
+      const pending = timers.get(a.politeness)
+      if (pending != null) {
+        clearTimeout(pending)
+      }
+      element.textContent = ''
+      timers.set(
+        a.politeness,
+        setTimeout(() => {
+          element.textContent = a.message
+          timers.delete(a.politeness)
+        }, 100)
+      )
+    },
+    dispose() {
+      for (const timer of timers.values()) {
+        clearTimeout(timer)
+      }
+      timers.clear()
+      for (const element of regions.values()) {
+        element.remove()
+      }
+      regions.clear()
+    },
+  }
+}

--- a/packages/uikit/src/a11y/focus.ts
+++ b/packages/uikit/src/a11y/focus.ts
@@ -1,0 +1,32 @@
+import type { Signal } from '@preact/signals-core'
+
+/**
+ * Mirrors a hidden DOM element's focus state into a `hasFocus` signal and notifies on change.
+ * Moved verbatim from `text/input/hidden-input.ts` (which re-exports it) so every component's
+ * hidden a11y element — not just `Input` — can drive the base-class `hasFocus` conditional.
+ */
+export function setupUpdateHasFocus(
+  element: HTMLElement,
+  hasFocusSignal: Signal<boolean>,
+  onFocusChange: (focus: boolean) => void,
+  abortSignal: AbortSignal
+) {
+  if (abortSignal.aborted) {
+    return
+  }
+  hasFocusSignal.value = document.activeElement === element
+  const listener = () => {
+    const hasFocus = document.activeElement === element
+    if (hasFocus == hasFocusSignal.value) {
+      return
+    }
+    hasFocusSignal.value = hasFocus
+    onFocusChange(hasFocus)
+  }
+  element.addEventListener('focus', listener)
+  element.addEventListener('blur', listener)
+  abortSignal.addEventListener('abort', () => {
+    element.removeEventListener('focus', listener)
+    element.removeEventListener('blur', listener)
+  })
+}

--- a/packages/uikit/src/a11y/focus.ts
+++ b/packages/uikit/src/a11y/focus.ts
@@ -28,5 +28,11 @@ export function setupUpdateHasFocus(
   abortSignal.addEventListener('abort', () => {
     element.removeEventListener('focus', listener)
     element.removeEventListener('blur', listener)
+    // Removing a focused element (role → undefined, or dispose) fires no blur, so the signal would
+    // stay stuck true and onFocusChange(false) never run — reset it here on teardown.
+    if (hasFocusSignal.value) {
+      hasFocusSignal.value = false
+      onFocusChange(false)
+    }
   })
 }

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -1,0 +1,329 @@
+import { abortableEffect } from '../utils.js'
+import { parseNumberValue } from '../properties/values.js'
+import type { Component } from '../components/component.js'
+import type { RootContext } from '../context.js'
+import { setupUpdateHasFocus } from './focus.js'
+
+export type A11yRole =
+  | 'button'
+  | 'togglebutton'
+  | 'link'
+  | 'checkbox'
+  | 'switch'
+  | 'radio'
+  | 'tab'
+  | 'slider'
+  | 'image'
+  | 'content'
+  | 'listbox'
+  | 'landmark'
+
+// opacity:0 + pointer-events:none but REAL-SIZED — Mode 2 projection positions the element, so no
+// left:-1000vw here. The per-root CONTAINER is what sits off-screen until a projection registers.
+const A11Y_ELEMENT_STYLE =
+  'position:absolute;opacity:0;pointer-events:none;margin:0;border:0;padding:0;'
+const TRANSPARENT_SVG = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+const INTERACTIVE_ROLES = new Set<A11yRole>([
+  'button',
+  'togglebutton',
+  'link',
+  'checkbox',
+  'switch',
+  'radio',
+  'tab',
+  'slider',
+])
+const warnedRoles = /* @__PURE__ */ new Set<string>()
+const missingLabelWarned = /* @__PURE__ */ new WeakSet<object>()
+
+/**
+ * Create the hidden native DOM element for a role (spec §1.2). Native `<button>`/`<a>`/
+ * `<input type=range>`/`<img>`/`<p>` so Enter/Space/AT activation and arrow-key handling come for
+ * free. Unimplemented roles (`listbox` P2, `landmark` P3) warn once and fall back to content.
+ */
+export function createHtmlA11yElement(role: A11yRole): HTMLElement {
+  let element: HTMLElement
+  switch (role) {
+    case 'button':
+      element = document.createElement('button')
+      break
+    case 'togglebutton':
+      element = document.createElement('button')
+      element.setAttribute('aria-pressed', 'false')
+      break
+    case 'checkbox':
+    case 'switch':
+    case 'radio':
+      element = document.createElement('button')
+      element.setAttribute('role', role)
+      element.setAttribute('aria-checked', 'false')
+      break
+    case 'tab':
+      element = document.createElement('button')
+      element.setAttribute('role', 'tab')
+      break
+    case 'link':
+      element = document.createElement('a')
+      break
+    case 'slider': {
+      const input = document.createElement('input')
+      input.type = 'range'
+      element = input
+      break
+    }
+    case 'image': {
+      const img = document.createElement('img')
+      img.src = TRANSPARENT_SVG
+      element = img
+      break
+    }
+    case 'content':
+      element = document.createElement('p')
+      break
+    default:
+      if (!warnedRoles.has(role)) {
+        warnedRoles.add(role)
+        console.warn(`[uikit a11y] role "${role}" is not implemented yet; using content semantics.`)
+      }
+      element = document.createElement('p')
+      break
+  }
+  element.style.cssText = A11Y_ELEMENT_STYLE
+  return element
+}
+
+// ——— per-root a11y container (one <div data-uikit-a11y> on document.body, refCounted) ———
+
+type RootA11yContainer = { element: HTMLElement; refCount: number }
+const rootContainers = /* @__PURE__ */ new WeakMap<RootContext, RootA11yContainer>()
+
+function acquireRootContainer(root: RootContext): HTMLElement {
+  let entry = rootContainers.get(root)
+  if (entry == null) {
+    const element = document.createElement('div')
+    element.setAttribute('data-uikit-a11y', '')
+    // Off-screen until a Mode 2 projection positions it (documented degraded fallback, §3.3).
+    element.style.cssText = 'position:absolute;top:0;left:-1000vw;'
+    document.body.appendChild(element)
+    entry = { element, refCount: 0 }
+    rootContainers.set(root, entry)
+  }
+  entry.refCount += 1
+  return entry.element
+}
+
+function releaseRootContainer(root: RootContext): void {
+  const entry = rootContainers.get(root)
+  if (entry == null) {
+    return
+  }
+  entry.refCount -= 1
+  if (entry.refCount <= 0) {
+    entry.element.remove()
+    rootContainers.delete(root)
+  }
+}
+
+// Minimal structural shape both a Component's properties and Input's share.
+type A11yNameSource = {
+  readonly value: { ariaLabel?: string; ariaDescription?: string }
+}
+
+/**
+ * Shared aria name/description sync, used by both the hidden a11y elements and Input's hidden
+ * `<input>` (fixing Input's previously-nameless element).
+ */
+export function setupAriaAttributes(
+  properties: A11yNameSource,
+  element: HTMLElement,
+  abortSignal: AbortSignal
+): void {
+  abortableEffect(() => {
+    const label = properties.value.ariaLabel
+    if (label != null) {
+      element.setAttribute('aria-label', label)
+    } else {
+      element.removeAttribute('aria-label')
+    }
+  }, abortSignal)
+  abortableEffect(() => {
+    const description = properties.value.ariaDescription
+    if (description != null) {
+      element.setAttribute('aria-description', description)
+    } else {
+      element.removeAttribute('aria-description')
+    }
+  }, abortSignal)
+}
+
+/**
+ * Reactive orchestrator (spec §1.2), called once from the Component constructor unless the
+ * component owns its own hidden element (Input/Textarea). One abortableEffect keyed on the
+ * component's `role`: null → no element (zero cost); set/changed → create the element, append it
+ * into the per-root container, wire aria sync + activation + focus routing; cleanup removes it and
+ * releases the container. SSR-safe.
+ */
+export function setupComponentA11y(component: Component, abortSignal: AbortSignal): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  abortableEffect(() => {
+    const role = component.properties.value.role
+    if (role == null) {
+      return
+    }
+    const element = createHtmlA11yElement(role)
+    const root = component.root.peek()
+    acquireRootContainer(root).appendChild(element)
+    component.a11yElement = element
+
+    const scoped = new AbortController()
+
+    setupAriaAttributes(component.properties, element, scoped.signal)
+    setupRoleState(component, element, role, scoped.signal)
+
+    const onClick = (nativeEvent: Event): void => {
+      nativeEvent.preventDefault()
+      component.activate({ source: 'screen-reader', nativeEvent })
+    }
+    element.addEventListener('click', onClick)
+
+    if (role === 'slider') {
+      const input = element as HTMLInputElement
+      const onInput = (): void => {
+        component.properties.peek().onA11yValueChange?.(input.valueAsNumber)
+      }
+      input.addEventListener('input', onInput)
+      scoped.signal.addEventListener('abort', () => input.removeEventListener('input', onInput))
+    }
+
+    setupUpdateHasFocus(
+      element,
+      component.hasFocus,
+      (focus) => component.properties.peek().onFocusChange?.(focus),
+      scoped.signal
+    )
+
+    warnMissingLabel(component, role)
+
+    return () => {
+      scoped.abort()
+      element.removeEventListener('click', onClick)
+      element.remove()
+      if (component.a11yElement === element) {
+        component.a11yElement = undefined
+      }
+      releaseRootContainer(root)
+    }
+  }, abortSignal)
+}
+
+function setupRoleState(
+  component: Component,
+  element: HTMLElement,
+  role: A11yRole,
+  abortSignal: AbortSignal
+): void {
+  const properties = component.properties
+  const nativeFormEl =
+    element instanceof HTMLButtonElement || element instanceof HTMLInputElement ? element : undefined
+
+  abortableEffect(() => {
+    const disabled = properties.value.disabled === true
+    const tabIndexProp = properties.value.tabIndex
+    element.tabIndex = disabled
+      ? -1
+      : tabIndexProp != null
+        ? parseNumberValue(tabIndexProp)
+        : role === 'content'
+          ? -1
+          : 0
+  }, abortSignal)
+
+  abortableEffect(() => {
+    const disabled = properties.value.disabled === true
+    if (nativeFormEl != null) {
+      nativeFormEl.disabled = disabled
+    }
+    if (disabled) {
+      element.setAttribute('aria-disabled', 'true')
+    } else {
+      element.removeAttribute('aria-disabled')
+    }
+  }, abortSignal)
+
+  if (role === 'checkbox' || role === 'switch' || role === 'radio') {
+    abortableEffect(() => {
+      element.setAttribute('aria-checked', properties.value.ariaChecked ? 'true' : 'false')
+    }, abortSignal)
+  }
+  if (role === 'togglebutton') {
+    abortableEffect(() => {
+      element.setAttribute('aria-pressed', properties.value.ariaPressed ? 'true' : 'false')
+    }, abortSignal)
+  }
+  if (role === 'tab') {
+    abortableEffect(() => {
+      element.setAttribute('aria-selected', properties.value.ariaSelected ? 'true' : 'false')
+    }, abortSignal)
+  }
+  abortableEffect(() => {
+    const expanded = properties.value.ariaExpanded
+    if (expanded != null) {
+      element.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+    } else {
+      element.removeAttribute('aria-expanded')
+    }
+  }, abortSignal)
+  if (role === 'link') {
+    abortableEffect(() => {
+      const href = properties.value.href
+      if (href != null) {
+        element.setAttribute('href', href)
+      } else {
+        element.removeAttribute('href')
+      }
+    }, abortSignal)
+  }
+  if (role === 'slider') {
+    const input = element as HTMLInputElement
+    const setRange = (attr: 'min' | 'max' | 'step', value: unknown): void => {
+      if (value != null) {
+        input[attr] = String(parseNumberValue(value as Parameters<typeof parseNumberValue>[0]))
+      }
+    }
+    abortableEffect(() => setRange('min', properties.value.ariaValueMin), abortSignal)
+    abortableEffect(() => setRange('max', properties.value.ariaValueMax), abortSignal)
+    abortableEffect(() => setRange('step', properties.value.ariaValueStep), abortSignal)
+    abortableEffect(() => {
+      const now = properties.value.ariaValueNow
+      if (now != null) {
+        input.value = String(parseNumberValue(now))
+      }
+    }, abortSignal)
+    abortableEffect(() => {
+      const text = properties.value.ariaValueText
+      if (text != null) {
+        input.setAttribute('aria-valuetext', text)
+      } else {
+        input.removeAttribute('aria-valuetext')
+      }
+    }, abortSignal)
+  }
+}
+
+function warnMissingLabel(component: Component, role: A11yRole): void {
+  if (!INTERACTIVE_ROLES.has(role)) {
+    return
+  }
+  if (component.properties.peek().ariaLabel != null) {
+    return
+  }
+  if (missingLabelWarned.has(component)) {
+    return
+  }
+  missingLabelWarned.add(component)
+  console.warn(
+    `[uikit a11y] interactive role "${role}" has no ariaLabel — it is nameless to assistive tech.`
+  )
+}

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -173,7 +173,10 @@ export function setupComponentA11y(component: Component, abortSignal: AbortSigna
       return
     }
     const element = createHtmlA11yElement(role)
-    const root = component.root.peek()
+    // Read reactively: if the component is reparented to a different root (diegetic reparenting,
+    // Modes 3–4), this effect re-runs — teardown releases the old root's container, the re-run
+    // acquires the new one — so the hidden element follows the component instead of stranding.
+    const root = component.root.value
     acquireRootContainer(root).appendChild(element)
     component.a11yElement = element
 

--- a/packages/uikit/src/a11y/index.ts
+++ b/packages/uikit/src/a11y/index.ts
@@ -1,0 +1,17 @@
+export type { A11yActivationSource, A11yActivationEvent } from './activation.js'
+export { dispatchActivation } from './activation.js'
+export type { A11yRole } from './hidden-element.js'
+export { createHtmlA11yElement, setupComponentA11y, setupAriaAttributes } from './hidden-element.js'
+export type {
+  Politeness,
+  Announcement,
+  AnnouncementBackend,
+  A11yPreferences,
+} from './announce/announcer.js'
+export {
+  announce,
+  registerAnnouncementBackend,
+  setA11yPreferences,
+  getA11yPreferences,
+} from './announce/announcer.js'
+export { createDomLiveRegionBackend } from './announce/backends/dom-live-region.js'

--- a/packages/uikit/src/components/component.ts
+++ b/packages/uikit/src/components/component.ts
@@ -359,6 +359,23 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
     }
     setupPointerEvents(this, hasNonUikitChildren)
 
+    // Pointer clicks delegate to semantic activation (skipping the shim's own synthetic click), so
+    // kit widgets that move behavior onto onActivate work for pointer + AT + XR with no extra code.
+    // Registered BEFORE the prop-handler binding below so onActivate runs ahead of a legacy onClick
+    // on pointer — matching keyboard/AT ordering (activate is the cross-mode truth) — and passes the
+    // original click's stopPropagation through so onActivate can halt propagation to overlays/parents.
+    this.addEventListener('click', (event) => {
+      if (event.synthetic) {
+        return
+      }
+      this.activate({
+        source: 'pointer',
+        intersection: event,
+        nativeEvent: event.nativeEvent,
+        stopPropagation: event.stopPropagation,
+      })
+    })
+
     abortableEffect(() => {
       const { value } = this.handlers
       for (const key in value) {
@@ -398,15 +415,6 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
         this.removeEventListener('childadded', listener)
       )
     }
-
-    // Pointer clicks delegate to semantic activation (skipping the shim's own synthetic click), so
-    // kit widgets that move behavior onto onActivate work for pointer + AT + XR with no extra code.
-    this.addEventListener('click', (event) => {
-      if (event.synthetic) {
-        return
-      }
-      this.activate({ source: 'pointer', intersection: event, nativeEvent: event.nativeEvent })
-    })
 
     // Hidden a11y element for this component's role (Mode 1). Input/Textarea own theirs.
     if (!config?.ownsHiddenA11yElement) {

--- a/packages/uikit/src/components/component.ts
+++ b/packages/uikit/src/components/component.ts
@@ -35,6 +35,8 @@ import { FlexNode, type Inset } from '../flex/node.js'
 import type { OrderInfo } from '../order.js'
 import { allAliases } from '../properties/alias.js'
 import { type Conditionals, createConditionals } from '../properties/conditional.js'
+import { dispatchActivation, type A11yActivationEvent } from '../a11y/activation.js'
+import { setupComponentA11y } from '../a11y/hidden-element.js'
 import {
   type BaseOutProperties,
   type InProperties,
@@ -116,6 +118,10 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
   readonly paddingInset = signal<Inset | undefined>(undefined)
   readonly maxScrollPosition = signal<Partial<Vector2Tuple>>([undefined, undefined])
   readonly root: Signal<RootContext>
+  /** Live when a role gives this component a hidden a11y element; drives the `focus` conditional. */
+  readonly hasFocus: Signal<boolean>
+  /** The hidden focusable DOM element for this component's role (Mode 1), if any. */
+  a11yElement: HTMLElement | undefined = undefined
   readonly parentContainer = signal<Container | undefined>(undefined)
   readonly isAttached = signal(false)
   readonly isRootAttached: Signal<boolean> = computed(
@@ -139,6 +145,7 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
       renderContext?: RenderContext
       dynamicHandlers?: Signal<EventHandlersProperties | undefined>
       hasFocus?: Signal<boolean>
+      ownsHiddenA11yElement?: boolean
       isPlaceholder?: Signal<boolean>
       defaultOverrides?: InProperties<OutProperties>
       hasNonUikitChildren?: boolean
@@ -163,12 +170,14 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
 
     this.root = buildRootContext(this, config?.renderContext)
 
+    this.hasFocus = config?.hasFocus ?? signal(false)
+
     //properties
     const conditionals = createConditionals(
       this.root,
       this.hoveredList,
       this.activeList,
-      config?.hasFocus,
+      this.hasFocus,
       config?.isPlaceholder
     )
     this.properties = new PropertiesImplementation<OutProperties>(
@@ -389,6 +398,35 @@ export class Component<OutProperties extends BaseOutProperties = BaseOutProperti
         this.removeEventListener('childadded', listener)
       )
     }
+
+    // Pointer clicks delegate to semantic activation (skipping the shim's own synthetic click), so
+    // kit widgets that move behavior onto onActivate work for pointer + AT + XR with no extra code.
+    this.addEventListener('click', (event) => {
+      if (event.synthetic) {
+        return
+      }
+      this.activate({ source: 'pointer', intersection: event, nativeEvent: event.nativeEvent })
+    })
+
+    // Hidden a11y element for this component's role (Mode 1). Input/Textarea own theirs.
+    if (!config?.ownsHiddenA11yElement) {
+      setupComponentA11y(this, this.abortSignal)
+    }
+  }
+
+  /** Semantic activation entry point (spec §2) — keyboard/AT/XR call this; pointer clicks delegate. */
+  activate(event?: Partial<A11yActivationEvent>): void {
+    dispatchActivation(this, { source: 'keyboard', ...event })
+  }
+
+  /** Focus this component's hidden a11y element (Mode 1). Overridden by Input/Textarea. */
+  focus(): void {
+    this.a11yElement?.focus()
+  }
+
+  /** Blur this component's hidden a11y element. Overridden by Input/Textarea. */
+  blur(): void {
+    this.a11yElement?.blur()
   }
 
   raycast(raycaster: Raycaster, intersects: Intersection[]): unknown {

--- a/packages/uikit/src/components/input.ts
+++ b/packages/uikit/src/components/input.ts
@@ -22,6 +22,7 @@ import {
   setupHtmlInputElement,
   setupUpdateHasFocus,
 } from '../text/input/hidden-input.js'
+import { setupAriaAttributes } from '../a11y/hidden-element.js'
 import type { RenderContext } from '../context.js'
 import type { NumberValue } from '../properties/values.js'
 export const inputOutPropertiesSchema = /* @__PURE__ */ defineSchema(() =>
@@ -111,6 +112,8 @@ export class Input<
       defaults: inputDefaults as WithSignal<OutProperties>,
       dynamicHandlers: selectionHandlers,
       hasFocus,
+      // The hidden <input> is Input's own a11y element — don't let the base build a second one.
+      ownsHiddenA11yElement: true,
       isPlaceholder: computed(() => this.currentSignal.value.length === 0),
       ...inputConfig,
       defaultOverrides: {
@@ -188,6 +191,8 @@ export class Input<
     )
 
     setupHtmlInputElement(this.properties, this.element, this.currentSignal, this.abortSignal)
+    // The hidden <input> IS Input's a11y element — sync its accessible name (it had none before).
+    setupAriaAttributes(this.properties, this.element, this.abortSignal)
 
     setupUpdateHasFocus(
       this.element,

--- a/packages/uikit/src/components/input.ts
+++ b/packages/uikit/src/components/input.ts
@@ -191,8 +191,16 @@ export class Input<
     )
 
     setupHtmlInputElement(this.properties, this.element, this.currentSignal, this.abortSignal)
-    // The hidden <input> IS Input's a11y element — sync its accessible name (it had none before).
+    // The hidden <input> IS Input's a11y element — sync its accessible name (it had none before) and
+    // expose it as a11yElement so generic a11y code (focus managers, Mode 2 projection) discovers it
+    // the same as a base component's hidden element.
     setupAriaAttributes(this.properties, this.element, this.abortSignal)
+    this.a11yElement = this.element
+    this.abortSignal.addEventListener('abort', () => {
+      if (this.a11yElement === this.element) {
+        this.a11yElement = undefined
+      }
+    })
 
     setupUpdateHasFocus(
       this.element,

--- a/packages/uikit/src/components/text.ts
+++ b/packages/uikit/src/components/text.ts
@@ -63,6 +63,7 @@ export class Text<
       hasFocus?: Signal<boolean>
       defaults?: WithSignal<OutProperties>
       isPlaceholder?: Signal<boolean>
+      ownsHiddenA11yElement?: boolean
     }
   ) {
     super(inputProperties, initialClasses, {

--- a/packages/uikit/src/events.ts
+++ b/packages/uikit/src/events.ts
@@ -1,5 +1,5 @@
 import type { Intersection, Object3DEventMap } from 'three'
-import type { A11yActivationEvent } from './a11y/activation.js'
+import type { A11yActivationEvent, A11yActivationSource } from './a11y/activation.js'
 
 declare module 'three' {
   interface Object3DEventMap {
@@ -27,6 +27,11 @@ export type ThreeMouseEvent = Intersection & {
   nativeEvent?: unknown
   stopPropagation?: () => void
   stopImmediatePropagation?: () => void
+  /** Set when a11y activation synthesized this click (keyboard / AT / XR). Geometry-sensitive
+   *  onClick handlers should ignore synthetic clicks, and the base Component's pointer delegation
+   *  skips them to avoid re-entrancy. */
+  synthetic?: boolean
+  source?: A11yActivationSource
 }
 
 export type ThreePointerEvent = ThreeMouseEvent & { pointerId?: number }

--- a/packages/uikit/src/events.ts
+++ b/packages/uikit/src/events.ts
@@ -1,7 +1,9 @@
 import type { Intersection, Object3DEventMap } from 'three'
+import type { A11yActivationEvent } from './a11y/activation.js'
 
 declare module 'three' {
   interface Object3DEventMap {
+    activate: A11yActivationEvent
     childadded: { child: Object3D }
     childremoved: { child: Object3D }
     click: ThreeMouseEvent
@@ -30,6 +32,7 @@ export type ThreeMouseEvent = Intersection & {
 export type ThreePointerEvent = ThreeMouseEvent & { pointerId?: number }
 
 export type EventHandlersProperties = {
+  onActivate?: (event: Object3DEventMap['activate']) => void
   onClick?: (event: Object3DEventMap['click']) => void
   onContextMenu?: (event: Object3DEventMap['contextmenu']) => void
   onDblClick?: (event: Object3DEventMap['dblclick']) => void

--- a/packages/uikit/src/index.ts
+++ b/packages/uikit/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ScrollListenersProperties as ScrollListeners,
 } from './listeners.js'
 export * from './components/index.js'
+export * from './a11y/index.js'
 export {
   type ColorRepresentation,
   readReactive,

--- a/packages/uikit/src/properties/schema.ts
+++ b/packages/uikit/src/properties/schema.ts
@@ -214,6 +214,59 @@ const eventHandlerShape = /* @__PURE__ */ defineSchema(() => ({
   onPointerCancel: functionSchema.optional(),
 }))
 
+// Accessibility semantics + spatial props — see planning/superpowers/specs/uikit-native-a11y.md §1.3.
+// All optional and signal-accepting (via propertyValueSchema), spread into baseOutPropertyShape so
+// every component inherits them; kit widgets bind `computed(...)` through defaultOverrides.
+const a11yPropertyShape = /* @__PURE__ */ defineSchema(() => ({
+  // semantics (Mode 1)
+  role: enumSchema([
+    'button',
+    'togglebutton',
+    'link',
+    'checkbox',
+    'switch',
+    'radio',
+    'tab',
+    'slider',
+    'image',
+    'content',
+    'listbox',
+    'landmark',
+  ]).optional(),
+  ariaLabel: string().optional(),
+  ariaDescription: string().optional(),
+  tabIndex: numberValueSchema.optional(),
+  disabled: boolean().optional(),
+  href: string().optional(),
+  ariaChecked: boolean().optional(),
+  ariaPressed: boolean().optional(),
+  ariaExpanded: boolean().optional(),
+  ariaSelected: boolean().optional(),
+  ariaValueMin: numberValueSchema.optional(),
+  ariaValueMax: numberValueSchema.optional(),
+  ariaValueNow: numberValueSchema.optional(),
+  ariaValueStep: numberValueSchema.optional(),
+  ariaValueText: string().optional(),
+  ariaItemCount: numberValueSchema.optional(),
+  ariaActiveIndex: numberValueSchema.optional(),
+  ariaActiveLabel: string().optional(),
+  activationMessage: string().optional(),
+  deactivationMessage: string().optional(),
+  // spatial semantics (Modes 3–4)
+  a11yOrder: numberValueSchema.optional(),
+  a11yGroup: string().optional(),
+  a11ySpatialLabel: string().optional(),
+  a11yPositionDescription: string().optional(),
+  a11yReachable: boolean().optional(),
+  a11yVisibilityOverride: enumSchema(['visible', 'hidden']).optional(),
+  // handlers
+  onFocusChange: functionSchema.optional(),
+  onActivate: functionSchema.optional(),
+  onA11yValueChange: functionSchema.optional(),
+  onA11yActiveIndexChange: functionSchema.optional(),
+  onA11yActivate: functionSchema.optional(),
+}))
+
 const panelShape = /* @__PURE__ */ defineSchema(() => ({
   borderTopLeftRadius: lengthValueSchema.optional(),
   borderTopRightRadius: lengthValueSchema.optional(),
@@ -310,6 +363,7 @@ export const baseOutPropertyShape = /* @__PURE__ */ defineSchema(
       ]).optional(),
       pointerEventsOrder: numberValueSchema.optional(),
       ...eventHandlerShape,
+      ...a11yPropertyShape,
       onScroll: functionSchema.optional(),
       onHoverChange: functionSchema.optional(),
       onActiveChange: functionSchema.optional(),

--- a/packages/uikit/src/tests/a11y-activation.test.ts
+++ b/packages/uikit/src/tests/a11y-activation.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Container, Input } from '../index.js'
+
+/**
+ * The semantic activation contract (spec §2), the load-bearing cross-mode path. Regression cover for
+ * the Codex Phase-0 review: onActivate must actually be wired (it was dead), pointer and keyboard
+ * must fire onActivate → onClick in the SAME order, the compat synthetic click must be marked
+ * synthetic, a synchronous disable inside onActivate must suppress that compat click, and Input must
+ * expose its hidden <input> as a11yElement.
+ */
+
+function mount(properties: ConstructorParameters<typeof Container>[0]): Container {
+  const container = new Container(properties)
+  new Object3D().add(container)
+  return container
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  // Input/Text kick off a default-font fetch on construction; there is no server in tests, so pin
+  // fetch to a never-settling promise to keep the async font load from logging ECONNREFUSED noise.
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('semantic activation', () => {
+  it('wires a prop onActivate — activate() invokes it (regression: onActivate was never bound)', () => {
+    const onActivate = vi.fn()
+    const c = mount({ role: 'button', ariaLabel: 'Go', onActivate })
+    try {
+      c.activate()
+      expect(onActivate).toHaveBeenCalledTimes(1)
+      expect(onActivate.mock.calls[0]![0]).toMatchObject({ type: 'activate', source: 'keyboard' })
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('fires onActivate before onClick for BOTH keyboard and pointer (cross-mode order)', () => {
+    // Keyboard/AT: activate() → onActivate, then the compat synthetic click → onClick.
+    const keyboard: Array<string> = []
+    const kb = mount({
+      role: 'button',
+      ariaLabel: 'K',
+      onActivate: () => keyboard.push('activate'),
+      onClick: () => keyboard.push('click'),
+    })
+    try {
+      kb.activate()
+      expect(keyboard).toEqual(['activate', 'click'])
+    } finally {
+      kb.dispose()
+    }
+
+    // Pointer: a real (non-synthetic) click delegates to activate BEFORE the legacy onClick runs.
+    const pointer: Array<string> = []
+    const pt = mount({
+      role: 'button',
+      ariaLabel: 'P',
+      onActivate: () => pointer.push('activate'),
+      onClick: () => pointer.push('click'),
+    })
+    try {
+      pt.dispatchEvent({ type: 'click' } as never)
+      expect(pointer).toEqual(['activate', 'click'])
+    } finally {
+      pt.dispose()
+    }
+  })
+
+  it('emits a compat synthetic click (marked synthetic) for non-pointer activation', () => {
+    const clicks: Array<{ synthetic?: boolean; source?: string }> = []
+    const c = mount({ role: 'button', ariaLabel: 'Go', onClick: (e) => clicks.push(e as never) })
+    try {
+      c.activate() // keyboard
+      expect(clicks).toHaveLength(1)
+      expect(clicks[0]!.synthetic).toBe(true)
+      expect(clicks[0]!.source).toBe('keyboard')
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('does not fire the compat click when onActivate synchronously disables the component', () => {
+    const disabled = signal(false)
+    const calls: Array<string> = []
+    const c = mount({
+      role: 'button',
+      ariaLabel: 'Go',
+      disabled,
+      onActivate: () => {
+        disabled.value = true
+        calls.push('activate')
+      },
+      onClick: () => calls.push('click'),
+    })
+    try {
+      c.activate()
+      // onActivate ran and disabled the control mid-activation → the compat click is suppressed.
+      expect(calls).toEqual(['activate'])
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('is a no-op when the component is already disabled', () => {
+    const onActivate = vi.fn()
+    const onClick = vi.fn()
+    const c = mount({ role: 'button', ariaLabel: 'Go', disabled: true, onActivate, onClick })
+    try {
+      c.activate()
+      expect(onActivate).not.toHaveBeenCalled()
+      expect(onClick).not.toHaveBeenCalled()
+    } finally {
+      c.dispose()
+    }
+  })
+})
+
+describe('Input exposes its hidden input as a11yElement', () => {
+  it('sets a11yElement to the hidden <input> (regression: it was left undefined)', () => {
+    const input = new Input({ ariaLabel: 'Search' })
+    new Object3D().add(input)
+    try {
+      expect(input.a11yElement).toBe(input.element)
+      expect(input.element.tagName).toBe('INPUT')
+    } finally {
+      input.dispose()
+    }
+  })
+})

--- a/packages/uikit/src/tests/a11y-announcer.test.ts
+++ b/packages/uikit/src/tests/a11y-announcer.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  announce,
+  registerAnnouncementBackend,
+  type Announcement,
+  type AnnouncementBackend,
+} from '../a11y/announce/announcer.js'
+import { createDomLiveRegionBackend } from '../a11y/announce/backends/dom-live-region.js'
+
+/**
+ * The announcement registry + the default DOM live-region backend (spec §6). The registry is a
+ * module singleton, so every test registers its OWN backend and unregisters it, and none of them
+ * lets the global `announce()` auto-register the default DOM backend on an empty registry (which
+ * would persist for the rest of the file). The re-announce / lifecycle behaviour is driven on the
+ * DOM backend directly.
+ */
+
+afterEach(() => {
+  // Belt-and-suspenders: clear any live regions a backend (or a stray auto-register) left behind.
+  for (const region of document.body.querySelectorAll('[aria-live]')) {
+    region.remove()
+  }
+})
+
+describe('announcement registry', () => {
+  it('is a silent no-op without a DOM and with no backend (SSR guard)', () => {
+    // First test in the file: module state is pristine — no backend, auto-register untried. With
+    // `document` undefined the auto-register is skipped and there are no backends, so this must do
+    // nothing rather than throw.
+    vi.stubGlobal('document', undefined)
+    try {
+      expect(() => announce('nobody hears this')).not.toThrow()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('routes a message to every registered backend, carrying politeness/kind', () => {
+    const received: Array<Announcement> = []
+    const unregister = registerAnnouncementBackend({ announce: (a) => received.push(a) })
+    try {
+      announce('saved', { politeness: 'assertive', kind: 'status' })
+      announce('plain') // politeness defaults to polite
+      expect(received).toHaveLength(2)
+      expect(received[0]).toMatchObject({
+        message: 'saved',
+        politeness: 'assertive',
+        kind: 'status',
+      })
+      expect(received[1]).toMatchObject({ message: 'plain', politeness: 'polite' })
+    } finally {
+      unregister()
+    }
+  })
+
+  it('unregister stops delivery and disposes the backend exactly once', () => {
+    // A sentinel keeps the registry non-empty, so the `announce('after')` below routes to a live
+    // registry rather than tripping the empty-registry DOM auto-register.
+    const removeSentinel = registerAnnouncementBackend({ announce: () => {} })
+    const received: Array<string> = []
+    const dispose = vi.fn()
+    const backend: AnnouncementBackend = { announce: (a) => received.push(a.message), dispose }
+    const unregister = registerAnnouncementBackend(backend)
+    try {
+      announce('before')
+      unregister()
+      announce('after')
+
+      expect(received).toEqual(['before'])
+      expect(dispose).toHaveBeenCalledTimes(1)
+      // Idempotent: a second unregister must not dispose again.
+      unregister()
+      expect(dispose).toHaveBeenCalledTimes(1)
+    } finally {
+      removeSentinel()
+    }
+  })
+})
+
+describe('DOM live-region backend', () => {
+  // The backend clears text then re-sets it ~100ms later; happy-dom's real timer is used (vitest's
+  // fake timers do not intercept it reliably), so the settle is awaited rather than fast-forwarded.
+  const SETTLE_MS = 130
+
+  it('clears then sets text ~100ms later so an identical repeat still re-announces', async () => {
+    const backend = createDomLiveRegionBackend()
+    try {
+      backend.announce({ message: 'downloading', politeness: 'polite' })
+      const region = document.body.querySelector('[aria-live="polite"]')
+      expect(region).not.toBeNull()
+      expect(region!.getAttribute('aria-atomic')).toBe('true')
+      // Cleared immediately; the text only lands after the settle.
+      expect(region!.textContent).toBe('')
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
+      expect(region!.textContent).toBe('downloading')
+
+      // Same message again: clears, then re-sets — the repeat re-announces.
+      backend.announce({ message: 'downloading', politeness: 'polite' })
+      expect(region!.textContent).toBe('')
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
+      expect(region!.textContent).toBe('downloading')
+    } finally {
+      backend.dispose?.()
+    }
+  })
+
+  it('keeps a separate region per politeness level', () => {
+    const backend = createDomLiveRegionBackend()
+    try {
+      backend.announce({ message: 'gentle', politeness: 'polite' })
+      backend.announce({ message: 'urgent', politeness: 'assertive' })
+      expect(document.body.querySelector('[aria-live="polite"]')).not.toBeNull()
+      expect(document.body.querySelector('[aria-live="assertive"]')).not.toBeNull()
+    } finally {
+      backend.dispose?.()
+    }
+  })
+
+  it('dispose removes its regions and a pending settle never resurrects them', async () => {
+    const backend = createDomLiveRegionBackend()
+    backend.announce({ message: 'pending', politeness: 'assertive' })
+    expect(document.body.querySelector('[aria-live="assertive"]')).not.toBeNull()
+
+    expect(() => backend.dispose?.()).not.toThrow()
+    expect(document.body.querySelector('[aria-live="assertive"]')).toBeNull()
+    // Whether or not the cancelled timer fires, the removed region must not reappear.
+    await new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
+    expect(document.body.querySelector('[aria-live="assertive"]')).toBeNull()
+  })
+})

--- a/packages/uikit/src/tests/a11y-hidden-element.test.ts
+++ b/packages/uikit/src/tests/a11y-hidden-element.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Container } from '../index.js'
+import { createHtmlA11yElement, type A11yRole } from '../a11y/hidden-element.js'
+
+/**
+ * A Component only resolves its properties (and thus mounts its a11y element) once it is
+ * root-attached — `isRootAttached` is false for a bare `new Container()`. Parenting it under a
+ * scene flips `isAttached`, exactly as `order.test`'s `createRoot` does.
+ */
+function mount(properties: ConstructorParameters<typeof Container>[0]): Container {
+  const container = new Container(properties)
+  new Object3D().add(container)
+  return container
+}
+
+/**
+ * The hidden DOM element (spec §1.2): the role → native-element table, plus the
+ * `setupComponentA11y` lifecycle exercised through a real `Container` — mount on role, reactive
+ * teardown on role → null, zero orphans across construct+dispose (the StrictMode shape), aria /
+ * disabled sync, and pointer-free activation when the element is clicked by assistive tech.
+ */
+
+beforeAll(async () => {
+  await loadYoga()
+})
+
+afterEach(() => {
+  // Safety net: a test that forgot to dispose would otherwise leak its container into the next.
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('createHtmlA11yElement — role → native element', () => {
+  const cases: Array<[A11yRole, string, Array<[string, string]>]> = [
+    ['button', 'BUTTON', []],
+    ['togglebutton', 'BUTTON', [['aria-pressed', 'false']]],
+    [
+      'checkbox',
+      'BUTTON',
+      [
+        ['role', 'checkbox'],
+        ['aria-checked', 'false'],
+      ],
+    ],
+    [
+      'switch',
+      'BUTTON',
+      [
+        ['role', 'switch'],
+        ['aria-checked', 'false'],
+      ],
+    ],
+    [
+      'radio',
+      'BUTTON',
+      [
+        ['role', 'radio'],
+        ['aria-checked', 'false'],
+      ],
+    ],
+    ['tab', 'BUTTON', [['role', 'tab']]],
+    ['link', 'A', []],
+    ['content', 'P', []],
+  ]
+
+  it.each(cases)('role %s → <%s> with the right attributes', (role, tag, attrs) => {
+    const el = createHtmlA11yElement(role)
+    expect(el.tagName).toBe(tag)
+    for (const [name, value] of attrs) {
+      expect(el.getAttribute(name)).toBe(value)
+    }
+    // Every hidden element is visually gone but still in the accessibility tree.
+    expect(el.style.opacity).toBe('0')
+    expect(el.style.pointerEvents).toBe('none')
+  })
+
+  it('role slider → <input type=range>', () => {
+    const el = createHtmlA11yElement('slider') as HTMLInputElement
+    expect(el.tagName).toBe('INPUT')
+    expect(el.type).toBe('range')
+  })
+
+  it('role image → <img> with a transparent source', () => {
+    const el = createHtmlA11yElement('image') as HTMLImageElement
+    expect(el.tagName).toBe('IMG')
+    expect(el.getAttribute('src')).toContain('svg')
+  })
+
+  it('an unimplemented role (listbox) warns once and falls back to <p> content', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(createHtmlA11yElement('listbox').tagName).toBe('P')
+      createHtmlA11yElement('listbox') // second time: already warned, stays quiet
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})
+
+describe('setupComponentA11y — Component-driven hidden element', () => {
+  it('mounts a hidden element inside a per-root [data-uikit-a11y] container', () => {
+    const c = mount({ role: 'button', ariaLabel: 'Play' })
+    try {
+      const container = document.querySelector('[data-uikit-a11y]')
+      expect(container).not.toBeNull()
+      const el = c.a11yElement
+      expect(el).toBeDefined()
+      expect(el!.tagName).toBe('BUTTON')
+      expect(el!.getAttribute('aria-label')).toBe('Play')
+      expect(container!.contains(el!)).toBe(true)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('creates the element only once a role is set; role → null removes it and its container', () => {
+    const role = signal<A11yRole | undefined>(undefined)
+    const c = mount({ role })
+    try {
+      // No role → zero cost: no element, no container.
+      expect(c.a11yElement).toBeUndefined()
+      expect(document.querySelectorAll('[data-uikit-a11y]')).toHaveLength(0)
+
+      role.value = 'button'
+      expect(c.a11yElement?.tagName).toBe('BUTTON')
+      expect(document.querySelectorAll('[data-uikit-a11y]')).toHaveLength(1)
+
+      role.value = undefined
+      expect(c.a11yElement).toBeUndefined()
+      expect(document.querySelectorAll('[data-uikit-a11y]')).toHaveLength(0)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('leaves zero orphan elements or containers across repeated construct+dispose (StrictMode)', () => {
+    for (let i = 0; i < 2; i++) {
+      const c = mount({ role: 'button', ariaLabel: 'X' })
+      expect(document.querySelectorAll('[data-uikit-a11y]')).toHaveLength(1)
+      expect(document.querySelectorAll('[data-uikit-a11y] button')).toHaveLength(1)
+      c.dispose()
+      expect(document.querySelectorAll('[data-uikit-a11y]')).toHaveLength(0)
+      expect(document.querySelectorAll('button')).toHaveLength(0)
+    }
+  })
+
+  it('syncs aria-label reactively on signal writes', () => {
+    const ariaLabel = signal<string | undefined>('First')
+    const c = mount({ role: 'button', ariaLabel })
+    try {
+      expect(c.a11yElement!.getAttribute('aria-label')).toBe('First')
+      ariaLabel.value = 'Second'
+      expect(c.a11yElement!.getAttribute('aria-label')).toBe('Second')
+      ariaLabel.value = undefined
+      expect(c.a11yElement!.hasAttribute('aria-label')).toBe(false)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('disabled sets the native disabled flag, aria-disabled, and tabIndex -1', () => {
+    const disabled = signal(true)
+    const c = mount({ role: 'button', ariaLabel: 'Go', disabled })
+    try {
+      const el = c.a11yElement as HTMLButtonElement
+      expect(el.disabled).toBe(true)
+      expect(el.getAttribute('aria-disabled')).toBe('true')
+      expect(el.tabIndex).toBe(-1)
+
+      disabled.value = false
+      expect(el.disabled).toBe(false)
+      expect(el.hasAttribute('aria-disabled')).toBe(false)
+      expect(el.tabIndex).toBe(0)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('a click on the hidden element activates the component as a screen-reader source', () => {
+    const c = mount({ role: 'button', ariaLabel: 'Go' })
+    try {
+      const activate = vi.spyOn(c, 'activate')
+      c.a11yElement!.click()
+      expect(activate).toHaveBeenCalledTimes(1)
+      expect(activate.mock.calls[0]![0]).toMatchObject({ source: 'screen-reader' })
+    } finally {
+      c.dispose()
+    }
+  })
+})

--- a/packages/uikit/src/tests/schema.test.ts
+++ b/packages/uikit/src/tests/schema.test.ts
@@ -89,6 +89,26 @@ describe('property schemas', () => {
     expect(InputPropertiesSchema.safeParse({ text: 'not allowed' }).success).to.equal(false)
   })
 
+  it('accepts native a11y props chain-wide and still rejects unknown keys and bad roles', () => {
+    // a11yPropertyShape is spread into the base out-shape, so every component inherits it.
+    expect(
+      ContainerPropertiesSchema.safeParse({
+        role: 'button',
+        ariaLabel: 'Play',
+        ariaChecked: true,
+        tabIndex: 0,
+        disabled: false,
+        hover: { backgroundColor: 'red' },
+      }).success
+    ).to.equal(true)
+    // The role enum is closed…
+    expect(ContainerPropertiesSchema.safeParse({ role: 'not-a-real-role' }).success).to.equal(false)
+    // …and strictness still bites unknown keys sitting next to valid a11y props.
+    expect(
+      ContainerPropertiesSchema.safeParse({ ariaLabel: 'x', notAnAriaProp: true }).success
+    ).to.equal(false)
+  })
+
   it('constructs core Video with schema-valid props outside the browser', () => {
     const props = { src: 'movie.mp4', objectFit: 'cover' as const, keepAspectRatio: false }
     expect(ComponentPropertiesSchemas.Video.safeParse(props).success).to.equal(true)

--- a/packages/uikit/src/text/input/hidden-input.ts
+++ b/packages/uikit/src/text/input/hidden-input.ts
@@ -56,28 +56,6 @@ export function setupHtmlInputElement(
   abortableEffect(() => element.setAttribute('type', properties.value.type), abortSignal)
 }
 
-export function setupUpdateHasFocus(
-  element: HTMLElement,
-  hasFocusSignal: Signal<boolean>,
-  onFocusChange: (focus: boolean) => void,
-  abortSignal: AbortSignal
-) {
-  if (abortSignal.aborted) {
-    return
-  }
-  hasFocusSignal.value = document.activeElement === element
-  const listener = () => {
-    const hasFocus = document.activeElement === element
-    if (hasFocus == hasFocusSignal.value) {
-      return
-    }
-    hasFocusSignal.value = hasFocus
-    onFocusChange(hasFocus)
-  }
-  element.addEventListener('focus', listener)
-  element.addEventListener('blur', listener)
-  abortSignal.addEventListener('abort', () => {
-    element.removeEventListener('focus', listener)
-    element.removeEventListener('blur', listener)
-  })
-}
+// Moved to a11y/focus.ts so every component's hidden a11y element (not just Input) can drive
+// `hasFocus`; re-exported here so existing importers keep working.
+export { setupUpdateHasFocus } from '../../a11y/focus.js'

--- a/packages/uikit/src/utils.ts
+++ b/packages/uikit/src/utils.ts
@@ -103,6 +103,9 @@ export function loadResourceWithParams<P, R, A extends Array<unknown>>(
 }
 
 const eventHandlerKeys: Array<keyof EventHandlersProperties> = [
+  // onActivate binds to the semantic 'activate' event dispatched by dispatchActivation — without it
+  // here, computedHandlers never wires prop/class/defaultOverride onActivate and the handler is dead.
+  'onActivate',
   'onClick',
   'onContextMenu',
   'onDblClick',

--- a/planning/superpowers/plans/uikit-a11y-horde-execution.md
+++ b/planning/superpowers/plans/uikit-a11y-horde-execution.md
@@ -1,0 +1,198 @@
+# uikit a11y — horde execution: order, split, models, loop prompt
+
+**Drives:** `uikit-a11y-phase-{0..4}-*.md` against `specs/uikit-native-a11y.md`.
+**Shape:** stacked PRs per phase (repo's stacked-epic pattern), worktree `uikit-fork`, conventional commits.
+**Authorship note:** this is the planner's independent orchestration analysis, built on the horde playbook (`~/.claude/skills/horde`). Where it lands on calls a stakeholder once floated (serialized foundation, Sonnet-wide fan-out, cross-vendor review at load-bearing units), it does so on the merits stated below; where it differs (Fable-high for delicate delegable units, orchestrator-implements-P0, orchestrator-owns-commits, Spark as escalation-only), the difference is deliberate.
+
+---
+
+## 1. Dependency-correct order
+
+```
+Phase 0 (core)  ─────────────►  SERIALIZED. Orchestrator implements it personally. Nothing dispatches before its gate.
+   │
+Phase 1 (projection + toolbar dogfood)
+   │     T1.1 math core (Fable-high) → T1.2 react wiring ∥ T1.3 dogfood (Sonnet)
+   │
+Phase 2 (widgets)   T2.1–T2.8 fan out (Sonnet ×8, disjoint widget dirs, same tree)
+   │                T2.L listbox (Fable-high, hot file) may run DURING the fan-out — different package
+   │                T2.G grid dogfood after T2.L; T2.B bento after fan-out
+   │
+Phase 3 (diegetic)  T3.0 scene (Sonnet) → T3.1 ∥ T3.2 (Fable-high) → T3.3 manager (Fable-high, serialized)
+   │                → T3.4 ∥ T3.5 (Sonnet)
+   │
+Phase 4 (XR)        T4.0 XR binding + emulate harness (Sonnet, sharp brief) → T4.1 session+controller-ray (Fable-high)
+                    → T4.2a–d backends ∥ T4.3 gaze ∥ T4.4 metadata (Sonnet fan-out) → T4.5 overlay → T4.6 XAUR sweep (orchestrator)
+```
+
+**Why P0 is orchestrator-implemented, not dispatched:** every later unit consumes its API surface (`activate`, schema props, hidden-element lifecycle, `hasFocus` hoist). It is the single unit where (a) brief-transmission loss is most expensive, (b) the full spec context already lives in the orchestrator's head, and (c) an API-shape mistake multiplies across every subsequent worker. The playbook's "the orchestrator does the hardest parts" applies literally. Fallback if orchestrator context is running hot: dispatch to Fable-high with the Phase-0 plan as the brief and review line-by-line.
+
+**Why phases stack rather than interleave:** Phases 1–4 each mutate the a11y core's behavior (projection rewires element positioning; visibility rewires exposure; the manager rewires focus routing). Interleaving invites cross-phase races on `hidden-element.ts`. The listbox (T2.L) is the one sanctioned overlap because it adds a role rather than changing shared behavior.
+
+## 2. Parallel vs serial — by file contention, not optics
+
+**Serialized (one writer, named owner per phase):** `properties/schema.ts`, `components/component.ts`, `events.ts`, `a11y/hidden-element.ts`, `a11y/activation.ts`, `a11y/focus-manager.ts`, `a11y/projection.ts`, `react/build.tsx`. A fan-out worker needing to touch these STOPS and reports — that need means the core API is wrong, which is an orchestrator decision, not a worker workaround.
+
+**Genuinely disjoint (fan out, same tree — different files is enough because the orchestrator owns all commits):**
+- Phase 2: eight `packages/uikit-default/src/<widget>/` dirs + their tests.
+- Phase 4: `a11y/announce/backends/*.ts`, `a11y/adapters/gaze.ts`, spatial-metadata queries.
+- Dogfood examples (`uikit-lucide/example`, `examples/react/uikit`, `examples/three/uikit`) — parallel with each other once their API dependency lands.
+
+**Worktree isolation:** not worth the tax here. The fan-out units are file-disjoint within one tree, and the serialized units can't be parallelized anyway; a cold pnpm/turbo rebuild per worktree buys nothing. Skip it unless a Spark-escalation retry wants a scratch tree.
+
+**Append-only contention:** `a11y/index.ts` + `src/index.ts` export lines — the orchestrator applies these at commit time; workers list needed exports in their report instead of editing.
+
+## 3. Model routing (with reasoning)
+
+Roles per the horde playbook: **Sonnet** = wide mechanical fan-out. **Fable at `high` effort** (never xhigh — it overthinks; dispatch via Workflow `agent(..., {model:'fable', effort:'high'})`, the Agent tool has no effort param) = delicate, correctness-critical units where plausible-but-wrong is expensive. **Codex GPT** = adversarial review, run by the orchestrator directly via `codex exec` (never wrapped in a Sonnet agent). **Spark** = escalation implementor only, Sonnet-wrapped, after honest repeated Sonnet failure. **Orchestrator (Opus)** = briefs, diagnosis-to-minimal-repro, every load-bearing gate, all commits, and the P0 implementation itself.
+
+| Unit | Route | Reasoning |
+|---|---|---|
+| P0 all (schema, activation, Component, hidden-element, announcer) | **Orchestrator** | The floor; see §1. Failure mode: API-shape error propagating epic-wide |
+| P1 T1.1 projection math core + oracle fixtures | **Fable-high** | Silent-wrong geometry passes wrong-oracle tests; orchestrator independently re-derives 2–3 fixture expectations before accepting |
+| P1 T1.2 react wiring, T1.3 toolbar dogfood | Sonnet | Mechanical against a frozen API; probes are the guard |
+| P2 T2.1–T2.8 widget bindings | Sonnet ×8 | Pattern-stamping from the spec table; per-widget tests discriminate |
+| P2 T2.L listbox, T2.G grid dogfood | **Fable-high** | ARIA APG grammar (activedescendant/posinset) — wrong-but-plausible semantics that pass unit tests is the named failure mode of this epic |
+| P2 T2.B bento pair | Sonnet | Labels + one explicit vanilla projection call |
+| P3 T3.0 scene | Sonnet | Example plumbing |
+| P3 T3.1 visibility, T3.2 spatial-nav, T3.3 focus manager | **Fable-high** each | Classification edge-cases, ordering hysteresis, and a focus-policy state machine whose bug class is a *silent focus trap* |
+| P3 T3.4 switch-scan, T3.5 probes | Sonnet | Timer mechanics with spec'd algorithms; scripted probes |
+| P4 T4.0 XR binding + emulate harness | Sonnet (escalate to Fable-high after 2 honest failures) | Integration wiring with a crisp end-to-end accept gate (scripted select → onActivate) |
+| P4 T4.1 session awareness + controller-ray | **Fable-high** | Input-stream discrimination + session lifecycle; the original spec's blind spot lives here |
+| P4 T4.2a–d backends, T4.3 gaze, T4.4 metadata, T4.5 overlay | Sonnet fan-out | Isolated modules, mocked-API contracts |
+| P4 T4.6 XAUR sweep | **Orchestrator + Codex** | Compliance judgment, not code |
+| Stuck units (any phase) | Spark via Sonnet wrapper | Different-model retry, not throughput; wrapper owns gates + Sonnet fallback |
+
+**Adversarial review points** — orchestrator runs `codex exec` directly, in the background, at each phase boundary:
+
+```
+codex exec -s read-only -o /tmp/codex-a11y-p<N>.md \
+  '<review brief: git diff <base>..HEAD; hunt list per phase>' < /dev/null
+```
+
+Hunt lists: P0 = API shape + schema surface; P2 = ARIA semantics vs WAI-ARIA APG; P3 = focus-policy state machine (trap/echo-loop hunt); P4 = XR focus/input model (the reviewer's original home turf). If codex is unavailable: proceed loudly without a review; never substitute a same-family model as the cross-vendor verdict. Treat findings as signals to re-derive ground truth, not automatic verdicts.
+
+## 4. Commit & floor ownership
+
+- **Orchestrator commits everything.** Fan-out workers implement, run their gates, and report staged-diff + evidence; nothing reaches the branch until the orchestrator has re-run the load-bearing gate and committed (atomic, conventional message, repo git identity, no AI attribution). Uncommitted unit output is disposable — that is what makes wide dispatch safe.
+- **The load-bearing gate is the user-facing artifact, not the suite.** For this epic: the AT-visible outcome — accessible names in the live a11y tree, focus-ring pixels, live-region text, rect overlap — probed in a real browser. Green vitest with an unchanged a11y tree = silent no-op = not done (the dominant fan-out failure).
+- Every brief carries the playbook's seven parts; report-back format: file:line of changes, pasted gate output, user-facing proof (probe log/screenshot), staged diff, honest Fully-implemented / Blocked / Workaround per sub-unit.
+
+## 5. Live in-product probes (machine gates)
+
+Browser automation (chrome-devtools MCP / claude-in-chrome / vitexec) against the vite dev servers. Canonical assertions:
+
+```js
+// P1 toolbar — names + count
+const btns = [...document.querySelectorAll('[data-uikit-a11y] button')]
+console.assert(btns.length === 3 && btns.every(b => (b.getAttribute('aria-label') ?? b.textContent).trim().length > 0))
+
+// P1 — focus routing + ring: send real Tab keypresses, then
+console.assert(document.activeElement?.closest('[data-uikit-a11y]') != null)
+// pixel-probe the projected rect border for the ring color (canvas readback via the example's debug hook)
+
+// P1 — announcer: keyboard-Enter the Copy button, poll ~300ms
+console.assert(document.querySelector('[aria-live]').textContent.includes('Copied'))
+
+// P1/P2 — rect overlap (example exposes window.__uikitA11yDebug.rectFor(id) in dev)
+console.assert(iou(btn.getBoundingClientRect(), window.__uikitA11yDebug.rectFor('copy-manifest')) >= 0.9)
+
+// P2 grid — ONE tab stop; ArrowRight ×3 advances aria-activedescendant posinset; Enter mutates
+// selected-count text AND fires the live region. Multi-event rule: assert accumulation across
+// ≥2 arrow presses, not a single event (a broken impl passes single-event tests).
+
+// P3 — scripted camera via debug hook: drive the pose across ≥2 frames, assert tabindex/aria-hidden
+// transitions per visibility policy, and the announce on offscreen focus.
+
+// P4 — emulated XR (@pmndrs/xr emulate): scripted ray dwell ≥ debounce → manager focus (pixel probe);
+// select → onActivate source 'xr-controller'; document.activeElement UNCHANGED in-session.
+
+// Leak/StrictMode probe (every phase): remount the app twice, then
+console.assert(document.querySelectorAll('[data-uikit-a11y]').length === EXPECTED_ROOTS)
+```
+
+**Not machine-probable — say so, don't fake it:** real headset SR behavior, haptic feel, spatial-audio localization, visionOS/Quest system AT, on-device AR DOM Overlay, macOS Voice Control. These are manual-checklist rows (P4.6 + matrix manual halves): release-blocking sign-offs, never loop gates. XR *logic* rows run on the emulated harness.
+
+## 6. The loop prompt (paste to drive the epic)
+
+```
+You are orchestrating the uikit a11y epic in worktree .claude/worktrees/uikit-fork.
+Load the `horde` skill FIRST and hold its discipline for the whole run.
+AUTHORITATIVE DOCS: planning/superpowers/specs/uikit-native-a11y.md (design truth),
+planning/superpowers/plans/uikit-a11y-phase-{0..4}-*.md (task truth),
+planning/superpowers/plans/uikit-a11y-horde-execution.md (routing: order, split, models).
+
+DIVISION: You implement Phase 0 yourself — it is the floor. From Phase 1 on, dispatch
+per the routing table: Sonnet for the mechanical fan-out, Fable at effort HIGH (never
+xhigh; via Workflow agent()) for the units the table marks delicate, Spark (Sonnet-wrapped
+codex exec) only as escalation after two honest Sonnet failures on the same unit.
+Every dispatch is a seven-part brief: context, exact task (files + signatures from the
+plan), method (TDD red-first), gates with numbers, tailored DO-NOTs, anti-stall clause,
+report-back format. Executors execute — put the anti-delegation clause in every brief:
+"you are the worker; do not spawn sub-agents, do not invoke planning skills, implement
+yourself."
+
+LOOP until the stop condition:
+1. Pick the earliest phase not gate-green. Dispatch its ready tasks per the routing table,
+   respecting the one-writer rule on the serialized hot files (schema.ts, component.ts,
+   events.ts, a11y core, react/build.tsx). Workers report staged diffs — THEY DO NOT COMMIT.
+2. VERIFY, DON'T TRUST — on every report: diff what actually changed (fixtures/tests/configs
+   especially), re-run the phase gate YOURSELF:
+     pnpm --filter @three-flatland/uikit typecheck && pnpm lint && pnpm test -- packages/uikit/src/tests
+   and run the phase's LIVE PROBE yourself in a real browser (horde doc §5) — the user-facing
+   a11y artifact (AT tree, focus-ring pixels, live-region text, rect IoU) is the load-bearing
+   gate; green vitest with an unchanged a11y tree is a silent no-op, not done. Then YOU commit
+   (atomic, conventional, repo identity, no AI attribution).
+3. A11y gates, every iteration: zero interactive components without an accessible name;
+   focus routes to hasFocus AND the visual ring renders; announcer emits on activation;
+   projected rect IoU ≥ 0.9 (phases ≥1); StrictMode double-mount leaves zero orphans;
+   plus every machine row of the spec §11 matrix the current phase claims.
+4. At each phase boundary run the cross-vendor review YOURSELF, in the background:
+     codex exec -s read-only -o /tmp/codex-a11y-p<N>.md '<review brief: git diff <base>..HEAD;
+     hunt: P0 API shape / P2 ARIA-vs-APG / P3 focus-trap state machine / P4 XR focus model>' < /dev/null
+   Read the verdict yourself; triage EVERY finding fix-now or written stakeholder-deferral
+   (acceptance criteria are the gate — no silent drops). If codex is down, proceed loudly
+   without a review; never substitute a same-family model as the cross-vendor verdict.
+5. On failure: reproduce and bisect to a minimal repro YOURSELF, then redispatch with the
+   confirmed mechanism (facts, not hypotheses). Two failed redispatches → Spark escalation
+   or take it over.
+6. Tech debt met en route is fixed in the same change (iron law) unless a named workstream
+   owns it — the kits' tsup DTS-worker OOM is owned by the tsdown migration; typecheck is
+   the build gate, don't chase it.
+
+DO-NOTS (tailor into every brief; each is a real failure class):
+- Do NOT edit tests/fixtures/probes/acceptance rows to make them pass — fix code or block honestly.
+- Do NOT ship wrong ARIA (no aria-checked on role=button, no invented roles, no tabindex>0);
+  check the spec table / WAI-ARIA APG before writing attributes.
+- Do NOT claim done without pasted gate output AND the user-facing proof; "compiles and tests
+  pass" without an observable a11y-tree change is a no-op, not done.
+- Do NOT touch files outside your named scope; never edit the serialized hot files from a
+  fan-out task — stop and report. Do NOT run repo-wide formatters, lint --fix, git clean/reset/
+  checkout-dot/stash, or delete anything outside your named files.
+- Do NOT claim "pre-existing" without checking the baseline first.
+- Do NOT add runtime dependencies (@pmndrs/xr stays example/dev-side, duck-typed at runtime),
+  GLSL, WebGLRenderer/WebGLRenderTarget, or a THREE group for a11y.
+- Do NOT weaken zod schemas or any-cast around the property system to silence types.
+- Do NOT write interaction tests that a broken implementation also passes — multi-event paths
+  (≥2 arrow presses, ≥2 camera frames) with accumulation asserts.
+- Do NOT mark manual acceptance-matrix rows as passed from any automated run.
+- Do NOT break ported-package constructor signatures (upstream signatures + R3F args are sanctioned).
+
+STOP CONDITION: all five phase gates green ON YOUR OWN RE-RUN, twice consecutively with no
+intervening change; every machine row of the spec §11 matrix green via live probe or emulated-XR
+run; every manual row holds a written checklist entry (pending sign-off) or stakeholder-authorized
+deferral; all cross-vendor findings triaged fix-or-deferral; stacked PRs open in merge order with
+probe evidence (probe logs + focus-ring screenshots/gifs) attached. Then report: per-phase gate
+evidence, matrix state, open deferrals, PR stack. If context runs low BEFORE the stop condition,
+write the durable handoff (next action, in-flight state, bars, queue, environment) into
+planning/superpowers/plans/uikit-a11y-horde-execution.md and say so — do not let the state die
+with the session.
+```
+
+## 7. Repo norms this plan inherits
+
+- **Atomic commits, don't hold** — orchestrator commits each verified unit as it lands.
+- **Examples pair rule** — bento/wall-panel changes land in `examples/react/uikit` AND `examples/three/uikit`, or not at all.
+- **E2E rationing** — live probes gate phases; vitest carries the inner loop.
+- **Acceptance criteria are the gate** — deferrals are written and stakeholder-authorized, never implied.
+- **Conventional commits** — releases cut from commit history; no hand-written changesets.

--- a/planning/superpowers/plans/uikit-a11y-phase-0-core.md
+++ b/planning/superpowers/plans/uikit-a11y-phase-0-core.md
@@ -1,0 +1,73 @@
+# uikit a11y — Phase 0: screen-space core (Mode 1 semantics + activation + announcer)
+
+**Spec:** `planning/superpowers/specs/uikit-native-a11y.md` §1, §2, §6 (DOM backend only)
+**Packages touched:** `packages/uikit` only. **Serialized foundation — implemented by the orchestrator personally (see horde-execution §1); everything else depends on these files.**
+**Ships as:** one PR, conventional commits per task (`feat(uikit): …`), committed by the orchestrator.
+
+## Hot files (this phase owns them; no other agent edits them concurrently)
+
+- `packages/uikit/src/properties/schema.ts`
+- `packages/uikit/src/components/component.ts`
+- `packages/uikit/src/events.ts`
+- `packages/uikit/src/components/input.ts`, `packages/uikit/src/components/textarea.ts`
+- `packages/uikit/src/text/input/hidden-input.ts`
+- `packages/uikit/src/index.ts`
+- new: `packages/uikit/src/a11y/*`
+
+## Tasks
+
+### T0.1 — schema: `a11yPropertyShape`
+
+- File: `packages/uikit/src/properties/schema.ts`
+- Add `a11yPropertyShape` exactly as spec §1.3 (semantics group + spatial group + handlers), spread into `baseOutPropertyShape` after `eventHandlerShape`. Add `onActivate` to `eventHandlerShape` is WRONG — it goes in `a11yPropertyShape`; but `events.ts` gains the `activate` entry in `Object3DEventMap` and `EventHandlersProperties.onActivate` so `computedHandlers`/`keyToEventName` route it (`'activate'` is already the lowercased slice of `onActivate`).
+- Hoist from `packages/uikit/src/components/input.ts`: remove `tabIndex`/`onFocusChange` from `inputOutPropertiesSchema` + `InputOutProperties` (now inherited); keep `inputDefaults.tabIndex = 0`.
+- **Accept:** `pnpm --filter @three-flatland/uikit typecheck` green; existing `schema.test.ts` green; new test: `ContainerPropertiesSchema.parse({ role: 'button', ariaLabel: 'x', focus: { backgroundColor: 'red' } })` passes, unknown key still throws (strict).
+
+### T0.2 — `a11y/focus.ts` (move) + `a11y/activation.ts`
+
+- Move `setupUpdateHasFocus` from `text/input/hidden-input.ts` → `a11y/focus.ts`; `hidden-input.ts` re-imports. No behavior change.
+- `a11y/activation.ts`: `A11yActivationSource`, `A11yActivationEvent` (spec §2), and `dispatchActivation(component, event)` helper implementing steps 1–4 of §2 (disabled guard → dispatch `'activate'` → compat synthetic `'click'` marked `{ synthetic: true, source }`, skipped for `source:'pointer'` → announce activation/deactivation message).
+- `events.ts`: `Object3DEventMap` gains `activate: A11yActivationEvent`; `EventHandlersProperties` gains `onActivate`.
+- **Accept:** unit test — component with `onActivate` + `onClick` props: `activate({source:'keyboard'})` fires both, click event has `synthetic: true`; `activate({source:'pointer'})` fires `onActivate` only (no shim); disabled component fires neither.
+
+### T0.3 — `Component` wiring
+
+- File: `packages/uikit/src/components/component.ts`
+- `readonly hasFocus: Signal<boolean> = config?.hasFocus ?? signal(false)` (assign before `createConditionals`; pass it in place of `config?.hasFocus`).
+- `activate(event?: Partial<A11yActivationEvent>): void` → `dispatchActivation(this, { source: 'keyboard', ...event })`.
+- Internal pointer delegation: constructor registers a `'click'` listener that, when `!event.synthetic`, calls `this.activate({ source: 'pointer', intersection: event, nativeEvent: event.nativeEvent })`.
+- Config gains `ownsHiddenA11yElement?: boolean`; constructor tail: `if (!config?.ownsHiddenA11yElement) setupComponentA11y(this, this.abortSignal)`.
+- `focus()` / `blur()` on base (focus/blur hidden element if present; no-op otherwise).
+- `Input`/`Textarea`: pass `ownsHiddenA11yElement: true`; `Input` drops its own `hasFocus` field (inherits); add `setupAriaAttributes(this.properties, this.element, this.abortSignal)` beside the existing `setupHtmlInputElement` call (fixes the nameless hidden input).
+- **Accept:** clone/copy tests still green (`clone.test.ts`); Input focus/selection tests unaffected; new test: `hasFocus.value = true` on a Container with `focus:{backgroundColor}` flips the resolved property.
+
+### T0.4 — `a11y/hidden-element.ts`
+
+- Implement `createHtmlA11yElement`, `setupComponentA11y`, `setupAriaAttributes` per spec §1.2. Roles in this phase: `button`, `togglebutton`, `link`, `checkbox`, `switch`, `radio`, `tab`, `slider`, `image`, `content` (`listbox` + `landmark` land in Phase 2/3 — the enum ships complete now, unimplemented roles warn once and fall back to `content` semantics).
+- Element style: `position:absolute; opacity:0; pointer-events:none; margin:0; border:0; padding:0` — **no** `left:-1000vw` here; positioning is Phase 1's job. Until a projection is registered for the root, the per-root container itself sits off-screen (`left:-1000vw`) — the documented fallback lives at container level, elements are always rect-positioned relative to it.
+- Per-root container WeakMap + refCount per spec §1.2.
+- Element `'click'` → `component.activate({ source: 'screen-reader', nativeEvent })`; slider `'input'` → `onA11yValueChange(valueAsNumber)`.
+- Dev-mode one-shot warn: interactive role with no `ariaLabel`.
+- **Accept:** unit tests (happy-dom `Window`, pattern from `svg-shared-set.test.ts`): role→tag/attrs table; role null→set→null lifecycle leaves zero elements; abort cleanup; double construct+dispose (StrictMode shape) leaves zero elements/containers; aria sync flips on signal writes; disabled sets `disabled`/`aria-disabled` + tabIndex −1; activation routes through T0.2 chain.
+
+### T0.5 — `a11y/announce/` (registry + DOM backend)
+
+- `announcer.ts`: `Announcement`, `AnnouncementBackend`, `registerAnnouncementBackend`, `announce` per spec §6. `setA11yPreferences` store (signal-backed plain module) with `captions/earcons/haptics/speech/monoAudio/reducedMotion` — only `reducedMotion` consumed this phase (stored for later).
+- `backends/dom-live-region.ts`: default backend, lazy singleton, clip-rect styles, clear-then-set 100 ms.
+- **Accept:** unit — two `announce('x')` calls re-announce (spy on textContent mutations); custom backend registered receives announcements; unregister stops it; no-DOM env no-ops.
+
+### T0.6 — exports + docs stub
+
+- `packages/uikit/src/a11y/index.ts` re-exports; add to `packages/uikit/src/index.ts`.
+- TSDoc per repo style (terse, WHAT-first).
+- **Accept:** `pnpm --filter @three-flatland/uikit build` green (note: if the tsup DTS-worker OOM from the tsdown-migration workstream hits, that failure is owned there — cross-reference, don't chase; typecheck is the gate).
+
+## Phase gate (orchestrator re-runs personally)
+
+```
+pnpm --filter @three-flatland/uikit typecheck
+pnpm lint
+pnpm test -- packages/uikit/src/tests
+```
+
+Plus: adversarial review pass (cross-vendor) on the activation model (§2) and the schema surface — API-shape mistakes here are the most expensive in the epic. Acceptance-matrix rows targeted: #5, #17 (unit-level).

--- a/planning/superpowers/plans/uikit-a11y-phase-1-projection.md
+++ b/planning/superpowers/plans/uikit-a11y-phase-1-projection.md
@@ -1,0 +1,39 @@
+# uikit a11y — Phase 1: projection (Mode 2) + toolbar dogfood
+
+**Spec:** `uikit-native-a11y.md` §3; dogfood §12
+**Depends on:** Phase 0 merged (or stacked on its branch).
+**Packages:** `packages/uikit` (new file + react touch), `packages/uikit-default` (Button role only), `packages/uikit-lucide/example`.
+
+## Tasks
+
+### T1.1 — `a11y/projection.ts`
+
+- `setupA11yProjection(root, { camera, renderer, isPerceivable? })` per spec §3: registers into `root.root.peek().onFrameSet`; per frame, for each a11y element under the root (the per-root container tracks its members), compute the panel screen AABB:
+  - corners = `(±size[0]/2, ±size[1]/2, 0) × pixelSize` through `globalPanelMatrix` → world → `.project(camera)` → NDC → canvas client coords (offset by `renderer.domElement.getBoundingClientRect()`, cached per frame).
+  - Write `left/top/width/height` (px, `transform` not layout — use `translate`/`width`/`height` style writes) only when changed > 1px epsilon.
+  - Container becomes `position:fixed` (or absolute w/ page offset) overlaying the canvas; container off-screen fallback (Phase 0) is replaced once a projection registers.
+  - Off-frustum/degenerate → `element.style.visibility = 'hidden'` this phase (full `a11yVisibility` policy is Phase 3); restore when back.
+- Pure-math core extracted as `computeA11yScreenRect(globalPanelMatrix, size, pixelSize, camera, viewport): {x,y,w,h} | null` — unit-testable without DOM.
+- **Accept:** unit tests against known camera/panel setups: fronto-parallel panel rect matches analytic expectation ±1px; 30°/60° tilted panels produce enclosing AABBs (matrix-math oracle in test); behind-camera returns null. Perf micro-bench (local-only assert per repo CI posture): 200 elements ≤ 0.2 ms/frame average over 500 frames.
+
+### T1.2 — React auto-wiring
+
+- File: `packages/uikit/src/react/build.tsx` (and/or the `Fullscreen` path in `react/index.tsx`).
+- In `useSetup` (root components only — guard `component.root.peek().component === component` like the frame pump): `useThree` camera + `gl.domElement`, `useEffect` → `setupA11yProjection(component, { camera, renderer: gl })`, dispose on cleanup. Camera identity change re-runs.
+- Dev warn (one-shot per root) when a role exists under a root with no projection — implemented in Phase 0's container, verified here.
+- **Accept:** icon-browser example boots with zero code changes and the container overlays the canvas (probe: container bounding rect ≈ canvas rect).
+
+### T1.3 — Button role + toolbar dogfood
+
+- `packages/uikit-default/src/button/index.ts`: `role: 'button'` in `defaultOverrides` (behavior stays on user `onClick` until Phase 2 migrates widgets to `onActivate`; Button itself has no built-in behavior).
+- `packages/uikit-lucide/example/App.tsx`: `ariaLabel` on the three toolbar buttons (`Select all ${filtered.length} icons`, `Copy manifest`, `Clear selection`) and the search `Input` (`Search icons by name or tag`); `activationMessage` on Copy (`Copied N icons` — dynamic via signal-free re-render, acceptable); `focus={{ borderColor: colors.ring ?? colors.primary, borderWidth: 2 }}` on all three.
+- **Accept — live in-product probe (browser automation, machine gate):** against `pnpm --filter @three-flatland/uikit-lucide... dev` (vite serve of the example):
+  1. `document.querySelectorAll('[data-uikit-a11y] button').length === 3` and every one has non-empty computed accessible name.
+  2. Tab sequence reaches input → buttons; on each focus, `document.activeElement` advances AND a screenshot diff / pixel probe shows the ring color on the focused button (read the panel color via canvas pixel at the projected rect border).
+  3. Enter on "Select all" mutates the `N selected` text; live region (`[aria-live]`) textContent becomes the activation message after Copy.
+  4. Rect overlap: for each button, `element.getBoundingClientRect()` ∩ its uikit panel screen rect (recomputed in-page from the component's `globalPanelMatrix`/`size` via a `window.__uikitA11yDebug` hook exposed by the example in dev) ≥ 90% IoU.
+- Acceptance-matrix rows: #2, #3(machine half), #5, #9(fronto-parallel), #17 (live).
+
+## Phase gate
+
+Unit + typecheck + lint (as Phase 0) **plus the live probe script green**, run by the orchestrator itself. Manual VoiceOver spot-check (name/role announced on the three buttons) — recorded in the matrix checklist, not merge-blocking.

--- a/planning/superpowers/plans/uikit-a11y-phase-2-widgets.md
+++ b/planning/superpowers/plans/uikit-a11y-phase-2-widgets.md
@@ -1,0 +1,47 @@
+# uikit a11y — Phase 2: kit widget bindings + virtualized listbox + bento
+
+**Spec:** `uikit-native-a11y.md` §7, §8; dogfood §12
+**Depends on:** Phase 0 (activation API) merged; Phase 1 for the live probes.
+**Parallelism:** per-widget tasks are file-disjoint → fan out wide. T2.L (listbox) touches `packages/uikit/src/a11y/hidden-element.ts` → assign to the core owner or serialize after fan-out.
+
+## Fan-out tasks (each: one widget dir in `packages/uikit-default/src/`, one unit test, one commit)
+
+Common contract for every widget task:
+- Move behavior from `onClick` to `onActivate` in `defaultOverrides` (same closure body; activation now covers pointer + keyboard + AT + future XR).
+- Add `role` + aria-state `computed(...)` bindings per the spec §7 table.
+- Unit test (happy-dom): construct widget, assert hidden element tag/role/attrs; drive `element.click()` → state toggles through existing controlled/uncontrolled path; flip state signal → aria attribute updates.
+- Do NOT touch `packages/uikit/src/*` — if the core API is insufficient, STOP and report; do not work around.
+
+| Task | Widget | Specifics |
+|---|---|---|
+| T2.1 | `checkbox/` | `role:'checkbox'`, `ariaChecked: computed(() => this.currentSignal.value ?? false)` |
+| T2.2 | `switch/` | `role:'switch'`, `ariaChecked` |
+| T2.3 | `radio-group/` | `RadioGroupItem`: `role:'radio'`, `ariaChecked` via `searchFor(this, RadioGroup, …)` compare |
+| T2.4 | `tabs/` | `TabsTrigger`: `role:'tab'`, `ariaSelected` (reuse its `active` computed) |
+| T2.5 | `accordion/` | trigger: `role:'button'`, `ariaExpanded` from item open state |
+| T2.6 | `slider/` | `role:'slider'`, `ariaValueNow/Min/Max/Step` (defaults 0/100/1 from existing props), `onA11yValueChange` → the same clamp/step/set path the pointer drag uses |
+| T2.7 | `toggle/` + `toggle-group/` | `role:'togglebutton'`, `ariaPressed` |
+| T2.8 | `input/` + `textarea/` kit wrappers | verify inherited `ariaLabel` reaches the hidden input (no new code expected; test only) |
+
+Out of scope (explicitly deferred, spec §7): `pagination`, `menubar`, `dialog`, `alert-dialog`, `tooltip`.
+
+## T2.L — listbox role (`packages/uikit/src/a11y/hidden-element.ts`)
+
+- Implement role `'listbox'` per spec §8: focusable wrapper + single managed `role="option"` child (`aria-posinset/aria-setsize/aria-selected`, textContent = `ariaActiveLabel`), `aria-activedescendant` wiring, keydown grammar → `onA11yActiveIndexChange({ move })` / `onA11yActivate(index)`.
+- **Accept:** unit — keydown sequences produce the right `move` values; posinset/setsize/label sync from signals; Enter/Space call `onA11yActivate` with current index; the wrapper is the ONLY tab stop.
+
+## T2.G — icon-grid dogfood (`packages/uikit-lucide/example/App.tsx`)
+
+- Scroll `Container` gains `role:'listbox'`, `ariaLabel`, `ariaItemCount={filtered.length}`, `ariaActiveIndex`/`ariaActiveLabel` from new `activeIdx` state; `onA11yActiveIndexChange` maps `move` using live `columns`, clamps, scrolls via `scrollPosition` signal to keep the row in view, sets a visual highlight on the active chip (border pulse using existing selected styling); `onA11yActivate` → `toggle(name)` + `announce(...)`.
+- **Accept — live probe:** one tab stop for the grid; ArrowRight ×3 updates `aria-activedescendant` target's posinset and scrolls when crossing rows; Enter toggles selection (selected count text mutates) and the live region announces; grid still 60fps-scrolls (no per-arrow React storm — active index state only).
+- Matrix row #6.
+
+## T2.B — bento examples (`examples/react/uikit/App.tsx` + `examples/three/uikit/`)
+
+- Labels on every interactive control (Tabs, Sliders, Switch, Checkbox, RadioGroup, Buttons, Input) in BOTH paired examples (repo rule: pairs or neither). Vanilla example also demonstrates `setupA11yProjection(root, { camera, renderer })` explicitly — it is the vanilla-wiring documentation.
+- **Accept — live probe on the react bento:** every `[data-uikit-a11y] :is(button,input,a)` has an accessible name (zero anonymous); Tab traverses ≥ 10 controls; arrow keys on the slider's range input change the rendered slider fill (probe `ariaValueNow` + a pixel sample); checkbox Space-toggles.
+- Matrix rows #1(machine half), #2.
+
+## Phase gate
+
+Full unit suite + typecheck + lint + BOTH live probes (toolbar probe from Phase 1 re-run as regression, grid probe, bento probe). Cross-vendor adversarial review focused on **ARIA semantic correctness** (right role, right state attr, no aria-checked on plain buttons, listbox grammar vs WAI-ARIA APG) — wrong semantics that "pass tests" are this phase's failure mode. Manual VoiceOver pass over bento recorded in the matrix.

--- a/planning/superpowers/plans/uikit-a11y-phase-3-diegetic.md
+++ b/planning/superpowers/plans/uikit-a11y-phase-3-diegetic.md
@@ -1,0 +1,46 @@
+# uikit a11y — Phase 3: diegetic 3D (Mode 3) — visibility, spatial nav, focus-reveal
+
+**Spec:** `uikit-native-a11y.md` §4, §5.1 (manager core lands here), §5.2 (switch-scan only)
+**Depends on:** Phases 0–2. The moving-camera pieces need a world-space dogfood: add a small "wall panel" scene to the bento pair (a uikit root on a rotated plane in world space, orbit controls) — build it FIRST (T3.0), everything probes against it.
+**Parallelism:** T3.1 (visibility) and T3.2 (spatial-nav) are separate new files but both feed T3.3 (manager); run T3.1 ∥ T3.2, then T3.3 serialized, then T3.4/T3.5 ∥.
+
+## Tasks
+
+### T3.0 — world-space dogfood scene
+
+- Extend `examples/react/uikit` + `examples/three/uikit` (pair rule) with a secondary world-space root: a settings panel on a "wall" (rotated/translated), OrbitControls, a second panel positioned initially behind the camera. Expose `window.__uikitA11yDebug` hooks (camera setter for scripted probes).
+- **Accept:** scene renders in both examples; probe can script the camera.
+
+### T3.1 — `a11y/visibility.ts`
+
+- `computedA11yVisibility(component, camera, options?)` + `createRaycastOcclusionProbe(scene, { budgetPerFrame })` per spec §4.1. Runs piggybacked on the Mode-2 frame pass (projection.ts calls a per-element classify step; no separate loop).
+- Policy application in `hidden-element.ts`/`projection.ts`: `visible` → focusable; `offscreen`/`occluded` → exposed, `tabIndex -1` unless reveal policy active, `aria-description` gains position phrase; `behind-camera`/`too-small` → `aria-hidden="true"`; `hidden` → per Phase 0. `a11yVisibilityOverride` respected.
+- Screen-space roots (`Fullscreen`) short-circuit `visible|hidden`.
+- **Accept:** unit — classification table across scripted camera/panel matrices (in-frustum, off-left, behind, 4px projected, override); budgeted probe round-robins (spy counts ≤ budget); default-unoccluded when probe absent.
+
+### T3.2 — `a11y/spatial-nav.ts`
+
+- Ordering per spec §4.2: group sort by camera-distance of group bounding centers; in-group by `a11yOrder ?? projected reading order` with hysteresis (re-sort only when an item moves > H px projected, H default 24). `role:'landmark'` containers define groups implicitly (`a11yGroup` default = landmark's `ariaLabel`).
+- `focusDirectional` half-plane nearest-neighbor over projected positions.
+- DOM re-append sync (only when container holds no focus).
+- **Accept:** unit — deterministic order for a fixed scene; hysteresis holds order under ±10px jitter; directional picks match hand-computed fixtures; re-append skipped while an element has focus.
+
+### T3.3 — `a11y/focus-manager.ts` + focus-reveal
+
+- `A11yFocusManager` per spec §5.1 (focused signal → component `hasFocus`; DOM mirror when not in XR; `getA11yFocusManager(root)` lazy singleton per root) and `FocusRevealPolicy` per §4.3 (default `announce`: position phrase from `a11yPositionDescription` ?? camera-relative octant; `reveal` only calls app `onReveal`; `reducedMotion` pref forces `announce`).
+- Canvas keyboard bindings (non-XR): when the canvas (or a root's container) has focus, ArrowKeys/Home/End → manager nav — opt-in via `enableKeyboardSceneNav(root)`.
+- Component.focus()/blur() route through the manager when one exists (spec §1.4.4).
+- **Accept:** unit — focusNext honors §4.2 order and visibility policy; focusing offscreen component under `announce` emits an announcement containing a direction word; under `skip` it is skipped; `reveal` invokes `onReveal` exactly once; manager dispose restores DOM-only focus behavior; no focus ping-pong when DOM mirror focus event echoes back (guard: manager writes are idempotent).
+
+### T3.4 — `a11y/adapters/switch-scan.ts`
+
+- Auto-advance scanning over `manager.focusables` (interval configurable, default 1200 ms; row-column mode per `a11yGroup`), external trigger API `switchPress()` → `activateFocused({source:'switch'})`. Keyboard binding option (Space as switch) for desktop testing.
+- **Accept:** unit with fake timers — advance order matches focusables; press activates; pause/resume; interval configurable (Game Accessibility Guidelines: configurable timing).
+
+### T3.5 — live probes on the wall-panel scene
+
+- Scripted camera: rotate wall panel out of frustum → its elements lose focusability, tabbing skips them, focusing via manager announces direction (matrix #7, #10); occlusion stub (`isPerceivable` returning false for one panel) → skipped/announced (#8); tilted wall panel rect IoU ≥ 90% (#9); switch-scan traverses and activates (#13); reduced-motion pref blocks `reveal` (#16 partial).
+
+## Phase gate
+
+Unit + typecheck + lint + Phase-1/2 probe regressions + T3.5 probes, orchestrator-run. Adversarial review target: the focus-policy state machine (silent focus traps, echo loops between DOM focus and manager focus) — this is the phase where a subtle bug ships a trap.

--- a/planning/superpowers/plans/uikit-a11y-phase-4-xr.md
+++ b/planning/superpowers/plans/uikit-a11y-phase-4-xr.md
@@ -1,0 +1,55 @@
+# uikit a11y — Phase 4: immersive XR (Mode 4) — adapters, backends, DOM Overlay, emulated-XR harness
+
+**Spec:** `uikit-native-a11y.md` §5, §6 (remaining backends), §10 (XAUR compliance), §11 rows 11–15
+**Depends on:** Phase 3 (focus manager is the substrate).
+**Foundation fact (verified 2026-07-12):** `@pmndrs/xr` core ships **zero a11y** (input/setup only: controllers, hands, pointers, teleport, hit-test, emulate, store) and is built on the `@pmndrs/pointer-events` uikit already consumes. This phase INTEGRATES with it as the XR input plumbing and supplies the missing AT layer. uikit has zero XR binding today — T4.0 establishes the dogfood binding.
+**Parallelism:** backends (T4.2a–d) are file-disjoint → fan out. Adapters: controller-ray (hard: pointer-events stream discrimination + session lifecycle) serialized with the manager owner; gaze + spatial-metadata are parallelizable after T4.1.
+
+## Tasks
+
+### T4.0 — XR dogfood binding + emulated-XR test harness
+
+- Wire the wall-panel example pair for XR: `@react-three/xr` (`<XR>` store + `createXRStore`) in `examples/react/uikit`, `@pmndrs/xr` in `examples/three/uikit` — dev/example dependencies only; the uikit package gains no XR dependency. This is the first uikit XR binding — controllers/hands become pointer-events rays that hit the panels with no uikit change (that's the integration claim; this task proves it).
+- Harness: `@pmndrs/xr`'s `emulate` (IWER-based) as the emulation runtime, driven from a Playwright project under the existing `test:e2e` setup: boots the wall-panel example, enters an emulated `immersive-vr` session, scripts controller pose/select.
+- **Accept:** emulated session starts (CI posture: assert local, log in CI); a scripted controller select on a panel produces a uikit pointer `'click'` → `onActivate` with `source:'pointer'` TODAY (pre-adapter baseline proving the @pmndrs/xr → pointer-events → uikit path end-to-end).
+
+### T4.1 — XR session awareness + `adapters/controller-ray.ts`
+
+- Session tracking: `watchXRSession(renderer)` — defaults to three's `renderer.xr` `sessionstart`/`sessionend` events (zero-dep); duck-typed reader for a @pmndrs/xr `store` when the app passes one (richer input-source state). Signal consumed by the focus manager (DOM mirror off in-session, spec §5.1) and the announcer (backend preference shift).
+- Controller-ray adapter per spec §5.2: listens to uikit's own pointer-event stream (XR pointers arrive tagged) — ray dwell (debounced) → `setFocus`; `select`/`squeeze` → `activateFocused({source:'xr-controller', handedness})` with REAL intersection passed through; thumbstick via @pmndrs/xr store input-sources or raw `XRInputSource.gamepad` polling → `focusDirectional`. No parallel raycasting — pointer-events is the single ray truth.
+- **Accept (emulated XR):** scripted ray-hover ≥ debounce sets manager focus (visual `focus` conditional lights — pixel probe); scripted select fires `onActivate` with `source:'xr-controller'` and real intersection; DOM `document.activeElement` does NOT change in-session. Matrix #11 machine half.
+
+### T4.2 — announcement backends (fan-out, one file each)
+
+- **a `backends/caption.ts`** — camera-anchored uikit caption panel (dogfoods uikit `Container`+`Text`); prefs: enabled/size/anchor; auto-registers when a session starts and captions pref on. Accept: unit + IWER — activation renders message text in-scene (getA11yTree probe), respects pref off.
+- **b `backends/earcon.ts`** — WebAudio focus tick / activate blip / toggle up-down; `source` pans via PannerNode from component world position; `monoAudio` pref collapses pan. Accept: unit with mocked AudioContext — node graph shape, pan set from position, mono pref bypasses panner.
+- **c `backends/haptic.ts`** — pulse `hapticActuators` on focus (weak) / activate (strong); no-op outside session. Accept: unit with stub XRInputSource — pulse called with expected intensity/duration; matrix #14 (with a+b).
+- **d `backends/speech.ts`** — opt-in `speechSynthesis`; never auto-registers; documented SR-conflict caveat. Accept: unit — speaks only when explicitly registered + pref on.
+
+### T4.3 — `adapters/gaze.ts`
+
+- Head-pose reticle fallback (viewer-space ray) + eye-gaze where exposed; dwell → focus; extended dwell or select → `activate({source:'gaze'})`; dwell time configurable via prefs; progress callback for apps to render a ring.
+- **Accept (IWER):** scripted head pose over a panel for dwell-time focuses then activates with `source:'gaze'`; matrix #12 machine half.
+
+### T4.4 — spatial metadata + queries
+
+- `getA11yTree(root)`, `describeSurroundings(manager)` per spec §5.4 (octant phrases from camera-relative transform; `a11ySpatialLabel`/`a11yPositionDescription` override computed text).
+- **Accept:** unit — tree snapshot matches scene fixture; describeSurroundings output contains labels ordered by distance and direction words match hand-computed octants.
+
+### T4.5 — DOM Overlay integration (spec §5.5)
+
+- When a session grants `dom-overlay`, re-parent the per-root a11y container + live region + caption element into `session.domOverlayState`'s root; restore on session end. Feature-detected; zero behavior change without it.
+- **Accept (IWER supports dom-overlay emulation; else guarded smoke):** container re-parents in and restores out; matrix #15 smoke half.
+
+### T4.6 — XAUR compliance sweep + manual checklist
+
+- Walk XAUR user needs against the shipped system; produce `planning/superpowers/specs/uikit-a11y-xaur-checklist.md` mapping each need → mechanism or explicit stakeholder-authorized deferral (acceptance-criteria gate rule: no silent drops).
+- Manual headset checklist (Quest browser): rows 11, 12, 14, 15 manual halves.
+
+## What cannot be machine-probed (stated plainly)
+
+Real headset screen-reader behavior, actual haptic feel, spatial-audio localization quality, visionOS system-AT interplay, and AR DOM Overlay on-device AT — these need the manual checklist on hardware. IWER covers session/input/pose scripting only. The loop's stop condition treats these as sign-off rows, not green-able gates.
+
+## Phase gate
+
+Unit + typecheck + lint + all prior probe regressions + IWER smokes (T4.1/T4.3/T4.5), orchestrator-run. Cross-vendor adversarial review on the XR focus/input model (finding #3 was the original miss — this is where the reviewer aims). Release requires the XAUR checklist complete (met or authorized-deferred).

--- a/planning/superpowers/specs/uikit-native-a11y-codex-review.md
+++ b/planning/superpowers/specs/uikit-native-a11y-codex-review.md
@@ -1,0 +1,57 @@
+**Adversarial Findings**
+
+1. **No XR accessibility contract exists, despite claiming “native accessibility.”**  
+   Scenario: a WebXR VR menu floats 5 m away; the user interacts with controller rays, hand tracking, gaze, or switch scanning. The hidden `<button>` described in [uikit-native-a11y.md](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:11) has no meaningful spatial relation to the headset scene, and normal `document.activeElement` is not the user’s in-world focus model.  
+   Change: split the spec into explicit modes: `screen/canvas DOM a11y`, `projected 2D canvas a11y`, `diegetic 3D a11y`, and `immersive XR a11y`. Mark the current DOM-shadow design as screen-space-first only. Add a first-class spatial accessibility layer with semantic scene nodes, spatial focus, input adapters, and output channels.
+
+2. **Deferred projection is not a nice-to-have; it is the difference between accessible and fake-accessible for visual/spatial UIs.**  
+   Scenario: a low-vision mobile screen-reader user touch-explores the canvas, or a voice-control user says “click settings” while the visible button is rendered in the center of the canvas. The DOM element is at `left:-1000vw`, so AT cannot map the target to what is visible. The spec explicitly defers projection at [line 262](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:262).  
+   Change: make projection required for non-XR screen/canvas mode, with a documented fallback only when projection cannot be configured. The required API should accept camera, renderer/canvas, root, viewport, clipping/frustum state, and per-frame layout updates.
+
+3. **The design treats DOM focus as universal; immersive XR does not.**  
+   Scenario: inside an immersive `XRSession`, the user points a controller at a wall terminal. No native DOM focus event occurs, no hidden button receives keyboard activation, and an off-screen aria-live region may not be perceivable in-headset.  
+   Change: add an XR focus manager independent of `document.activeElement`: controller ray focus, gaze dwell, hand-pinch, keyboard/gamepad/switch scanning, focus enter/exit events, and modality metadata. The DOM focus bridge can mirror spatial focus when available, but must not be the source of truth.
+
+4. **`dom-overlay` is not addressed, and it is not a solution for diegetic UI.**  
+   Scenario: in AR, a browser supports WebXR DOM Overlay for a 2D HUD, but the uikit panel is a 3D object attached to a real-world wall. DOM Overlay can expose conventional DOM overlay controls, but not automatically describe or focus the 3D mesh UI.  
+   Change: add a section distinguishing DOM Overlay UI from in-scene uikit UI. Use WebXR DOM Overlay only for true overlay fallback/companion controls, not as the accessibility model for spatial panels. Reference the WebXR DOM Overlays module explicitly.
+
+5. **Linear tab order is incoherent for world-space UI.**  
+   Scenario: three panels exist in construction order A, B, C, but the user sees C closest, A behind them, and B occluded by geometry. Tabbing through hidden DOM in mount order, as accepted at [line 277](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:277), can move focus to invisible or unreachable controls.  
+   Change: require authorable and computed spatial navigation: `a11yOrder`, groups/landmarks, panel priority, frustum filtering, occlusion policy, and directional navigation based on camera-relative positions. Construction order is acceptable only for flat screen-space layouts.
+
+6. **Visibility sync is too naive for 3D.**  
+   Scenario: `component.isVisible` is true, but the panel is behind the camera, clipped by near/far planes, facing away, too small due to distance, or hidden behind another mesh. The DOM element remains in the a11y tree because [line 91](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:91) only mirrors component visibility.  
+   Change: define `a11yVisibility` separately from render visibility: visible, perceivable, focusable, occluded, offscreen, behind-user, disabled-by-distance. Add hooks for apps to provide occlusion/reachability decisions.
+
+7. **Visual focus rings are insufficient and can create silent focus traps.**  
+   Scenario: focus lands on a button behind the user. The `focus={{}}` conditional lights up, but the user cannot see it. This is especially bad for screen-reader, blind, low-vision, and seated VR users.  
+   Change: add focus-reveal policy: skip offscreen controls by default, optionally orient panel toward user, move focus to nearest visible control, play spatial audio/haptic cues, or announce “Settings panel behind you.” Camera-follow and auto-orient should be opt-in because they can cause discomfort.
+
+8. **Synthetic `'click'` collapses distinct input modalities into a mouse-like event.**  
+   Scenario: a slider or button handler depends on ray intersection point, controller handedness, pointer capture, drag start, or distance. The synthetic event uses a center point and `distance: 0` per [lines 117-124](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:117), so the existing handler chain may run with misleading geometry.  
+   Change: introduce a semantic activation API separate from pointer click: `component.activate({ source: 'keyboard' | 'screenReader' | 'xr-controller' | 'gaze' | 'switch', ... })`. Pointer handlers can delegate to activation, not the other way around.
+
+9. **The announcer is DOM-screen-reader-only, not an XR feedback system.**  
+   Scenario: a blind VR user toggles a control through controller input. An off-screen aria-live singleton at [lines 131-142](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:131) may not be exposed in the headset experience.  
+   Change: define an announcement backend interface: DOM aria-live for browser mode, in-world captions, spatial audio/earcons via Web Audio, controller haptics, and optional speech synthesis. Include user preferences for captions, mono audio, reduced motion, and non-spatial fallback.
+
+10. **The role schema imports WAI-ARIA semantics but not spatial semantics.**  
+   Scenario: a wall terminal has buttons, status text, and a warning light. ARIA can say “button” and “checked,” but not “mounted on north wall,” “2 meters ahead,” “currently occluded,” “reachable by left controller,” or “part of the cockpit panel.”  
+   Change: add spatial metadata: `a11ySpatialLabel`, `a11yLandmark`, `a11yPositionDescription`, `a11yReachable`, `a11yPanelId`, `a11yGroup`, and query/details APIs. WAI-ARIA remains useful, but it is not enough for immersive navigation.
+
+11. **The spec does not reference the relevant XR accessibility requirements.**  
+   Scenario: implementation ships after passing VoiceOver keyboard tests, but misses motion-agnostic operation, alternative input mapping, spatial orientation, captions, and spatial audio alternatives. Those are central in W3C’s XR Accessibility User Requirements.  
+   Change: add a standards section covering W3C XAUR, WebXR Device API, WebXR DOM Overlay, Game Accessibility Guidelines, and a short survey of Unity/Meta/Babylon/A-Frame approaches. Use XAUR as the checklist for spatial/XR scope, not `@react-three/a11y`.
+
+12. **The test plan proves DOM plumbing, not spatial accessibility.**  
+   Scenario: happy-dom tests pass, VoiceOver tabs through buttons, but Quest/visionOS users cannot discover, focus, or activate an in-world panel. The current tests at [lines 264-272](/Users/tjw/Developer/three-flatland/.claude/worktrees/uikit-fork/planning/superpowers/specs/uikit-native-a11y.md:264) never exercise camera movement, occlusion, XR input, projected hit regions, or headset feedback.  
+   Change: add acceptance matrices for desktop SR, mobile touch exploration, keyboard-only canvas, voice control, switch scanning, WebXR controller/gaze/hand input, moving camera, panels behind/occluded/scaled/rotated, and AR DOM Overlay fallback.
+
+**What To Preserve**
+
+The core DOM-shadow design is still valuable for conventional browser/canvas accessibility: lazy per-component native elements, reactive ARIA sync, reuse of existing handler chains, `hasFocus` driving existing visual conditionals, accessible-name warnings, and the single listbox strategy for virtualized grids are all sound.
+
+Preserve it as the **screen-space foundation**, but stop presenting it as the whole native accessibility answer for uikit. The production-ready shape is DOM a11y plus a parallel spatial/XR a11y layer, with explicit mode boundaries and tests for each.
+
+References used: [W3C XR Accessibility User Requirements](https://www.w3.org/TR/xaur/), [WebXR DOM Overlays Module](https://immersive-web.github.io/dom-overlays/), [MDN WebXR fundamentals](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals).

--- a/planning/superpowers/specs/uikit-native-a11y.md
+++ b/planning/superpowers/specs/uikit-native-a11y.md
@@ -1,0 +1,438 @@
+# Accessibility for `@three-flatland/uikit` — screen-space core + spatial/XR layer
+
+**Status:** spec v2 — reworked after cross-vendor adversarial review (`uikit-native-a11y-codex-review.md`); ready for implementation via `planning/superpowers/plans/uikit-a11y-*.md`
+**Scope:** `packages/uikit`, `packages/uikit-default`, `packages/uikit-lucide/example`, `examples/*/uikit`
+**Decision context (settled):** `@react-three/a11y` was evaluated and rejected as a dependency — its `<A11y>` wrapper renders a THREE `<group>`, which uikit's child guard rejects (`component.ts` — `hasNonUikitChildren: false` components throw on non-uikit children), and its pointer-catching group is redundant with uikit's own pointer-event system. It survives only as a semantics reference.
+**Review verdict honored here:** the DOM-shadow core is sound **for screen-space** and is preserved intact; it is no longer presented as the whole answer. Accessibility for uikit is a mode-layered system: DOM semantics + required projection for anything rendered to a browser canvas, and a parallel spatial layer — independent of `document.activeElement` — for diegetic 3D and immersive XR.
+
+---
+
+## 0. The mode map
+
+A uikit panel can be experienced four ways. Each mode names its **focus truth**, its **output channel**, and its **activation path**. A component does not choose a mode; the *root's environment* does (renderer target, XR session state, projection availability). Modes 1+2 ship first and are the foundation; Modes 3+4 layer on top of the same property schema and the same semantic-activation API.
+
+| Mode | Situation | Focus truth | Output channel | Geometry contract |
+|---|---|---|---|---|
+| **1 — screen/canvas DOM semantics** | uikit rendered to a canvas in a normal page | `document.activeElement` on hidden native elements | Platform AT (VoiceOver/NVDA/TalkBack) via real DOM | Requires Mode 2 projection; off-screen placement is a *documented degraded fallback only* |
+| **2 — projected canvas geometry** | Same as 1 — this is Mode 1's required geometry pipeline | (same as 1) | (same as 1) | Hidden elements sized/positioned at the panel's projected screen rect, per frame |
+| **3 — diegetic 3D, moving camera (non-XR)** | World-space panels in a game/scene; camera moves; panels occlude, leave frustum | `A11yFocusManager` (spatial), mirrored into DOM focus when a hidden element exists | Platform AT where reachable + announcement backends | `a11yVisibility` (frustum/occlusion/size aware), spatial nav order, focus-reveal policy |
+| **4 — immersive XR** | Active `XRSession` (VR/AR); controller ray, gaze, hand, switch | `A11yFocusManager` **only** — `document.activeElement` is not perceivable in-headset and is never the source of truth | Announcement backends (captions, spatial audio/earcons, haptics, speech); DOM Overlay for true 2D companion UI only | Spatial metadata props; XAUR-driven requirements |
+
+The one thing every mode shares: **semantic activation** (§2). Focus models differ, output channels differ, but "the user activated this control" is a single API with a modality source, and every widget behavior hangs off it.
+
+---
+
+## 1. Mode 1 — screen/canvas DOM semantics (the preserved core)
+
+uikit already ships this machinery for one component: `packages/uikit/src/text/input/hidden-input.ts` creates a real hidden DOM `<input>`/`<textarea>`, appends it to `document.body`, reactively syncs `tabIndex`/`disabled`/`autocomplete`/`type`/`value` from properties signals via `abortableEffect`, and `setupUpdateHasFocus` routes `document.activeElement === element` back into the component's `hasFocus` signal — driving the `focus` style conditional. **Mode 1 generalizes that exact pattern to every component with a `role`.**
+
+```
+uikit Component (Mesh)                    hidden DOM element (per-root container)
+┌─────────────────────────┐   props →    ┌──────────────────────────────────┐
+│ properties.value.role   │──────────────│ <button> / <a> / <input range> … │
+│ properties.value.aria*  │  abortable   │ aria-* / disabled / tabIndex     │
+│                         │   Effect     │ rect = projected panel (Mode 2)  │
+│ activate({source}) ◄────┼──────────────│ 'click' (Enter/Space/AT)         │
+│ hasFocus: Signal<bool>  │◄─────────────│ focus/blur (activeElement)       │
+│  └→ `focus` conditional │              │                                  │
+└─────────────────────────┘              └──────────────────────────────────┘
+```
+
+### 1.1 Module layout
+
+```
+packages/uikit/src/a11y/
+  index.ts             re-exports; wired into packages/uikit/src/index.ts
+  hidden-element.ts    createHtmlA11yElement + setupComponentA11y + aria sync (Mode 1)
+  focus.ts             setupUpdateHasFocus (MOVED from text/input/hidden-input.ts)
+  activation.ts        A11yActivationEvent, Component.activate plumbing (§2)
+  projection.ts        setupA11yProjection — required geometry pipeline (Mode 2, §3)
+  visibility.ts        computedA11yVisibility (Mode 3, §4.1)
+  spatial-nav.ts       ordering, groups, directional nav (Mode 3, §4.2)
+  focus-manager.ts     A11yFocusManager — spatial focus truth (Modes 3–4, §5.1)
+  adapters/            XR input adapters: controller-ray.ts, gaze.ts, switch-scan.ts (§5.2)
+  announce/            announcer.ts (registry) + backends/: dom-live-region.ts,
+                       caption.ts, earcon.ts, haptic.ts, speech.ts (§6)
+```
+
+### 1.2 `hidden-element.ts`
+
+```ts
+export type A11yRole =
+  | 'button' | 'togglebutton' | 'link' | 'checkbox' | 'switch' | 'radio' | 'tab'
+  | 'slider'        // <input type="range"> — native arrow-key handling
+  | 'image'         // <img alt> (1px transparent data-URI svg)
+  | 'content'       // <p>; textContent = ariaLabel; focusable only if tabIndex set
+  | 'listbox'       // virtualized region: aria-activedescendant + posinset/setsize (§8)
+  | 'landmark'      // <section aria-label> — grouping/wayfinding (Mode 3 nav anchor)
+
+/** Element factory — mirrors createHtmlInputElement. Elements are opacity:0 +
+ *  pointer-events:none but REAL-SIZED and positioned by Mode 2 projection;
+ *  `left:-1000vw` off-screen placement happens ONLY in the degraded fallback (§3.3). */
+export function createHtmlA11yElement(role: A11yRole): HTMLElement
+
+/** Reactive orchestrator, called once from the Component constructor (§1.4).
+ *  One abortableEffect keyed on `properties.value.role`: role null → no element
+ *  (zero cost); role set/changed → create element, append into the per-root a11y
+ *  container, wire aria sync + activation + focus routing; cleanup → element.remove().
+ *  SSR guard: no-ops when `typeof document === 'undefined'`. */
+export function setupComponentA11y(component: Component, abortSignal: AbortSignal): void
+
+/** Shared aria sync used by BOTH a11y elements and Input's hidden <input>:
+ *  ariaLabel → aria-label, ariaDescription → aria-description. Folds in the fix
+ *  for Input's currently-nameless hidden element. */
+export function setupAriaAttributes(
+  properties: Component['properties'], element: HTMLElement, abortSignal: AbortSignal
+): void
+```
+
+Per-attribute `abortableEffect`s (mirroring `setupHtmlInputElement` style): `tabIndex` (default 0 for interactive roles; `-1` when disabled / non-perceivable per §4.1), `disabled`/`aria-disabled`, `aria-checked|pressed|expanded|selected` per role, slider `min/max/step/value` + `aria-valuetext` with `'input'` → `onA11yValueChange`, link `href` (SR context; navigation preventDefault-ed), name/description via `setupAriaAttributes`.
+
+**Activation routing:** the element's `'click'` (which native buttons fire for Enter/Space and AT activation) calls `component.activate({ source: 'screen-reader', nativeEvent })` (`'keyboard'` when a real keydown is in flight) — see §2. No raw synthetic three `'click'` as the primary path; provenance is explicit.
+
+**Focus routing:** `setupUpdateHasFocus(element, component.hasFocus, f => properties.peek().onFocusChange?.(f), abortSignal)` — the moved primitive, unchanged.
+
+**Per-root a11y container:** one `<div data-uikit-a11y>` per uikit root (`WeakMap<RootContext, {element, refCount}>` in `hidden-element.ts`; no `RootContext` type change), appended to `document.body`, removed at refCount 0. Mode 2 positions this container over the canvas and children within it.
+
+### 1.3 Properties schema — `packages/uikit/src/properties/schema.ts`
+
+New `a11yPropertyShape` spread into `baseOutPropertyShape`. Everything optional; every value signal-accepting via the existing `propertyValueSchema` union, so kit widgets bind `computed(...)` in `defaultOverrides` — the pub-sub system is the state-threading story. Types flow automatically to every vanilla constructor and React JSX component (wrappers are `build()`-generated over `z.input`); **no React-side type work**.
+
+```ts
+const a11yPropertyShape = /* @__PURE__ */ defineSchema(() => ({
+  // ——— semantics (Mode 1) ———
+  role: enumSchema(['button','togglebutton','link','checkbox','switch','radio','tab',
+                    'slider','image','content','listbox','landmark']).optional(),
+  ariaLabel: string().optional(),
+  ariaDescription: string().optional(),
+  tabIndex: numberValueSchema.optional(),          // hoisted from input.ts
+  disabled: boolean().optional(),                  // a11y semantics; visuals stay per-kit (§14.5)
+  href: string().optional(),
+  ariaChecked: boolean().optional(),
+  ariaPressed: boolean().optional(),
+  ariaExpanded: boolean().optional(),
+  ariaSelected: boolean().optional(),
+  ariaValueMin: numberValueSchema.optional(),
+  ariaValueMax: numberValueSchema.optional(),
+  ariaValueNow: numberValueSchema.optional(),
+  ariaValueStep: numberValueSchema.optional(),
+  ariaValueText: string().optional(),
+  ariaItemCount: numberValueSchema.optional(),     // listbox (§8)
+  ariaActiveIndex: numberValueSchema.optional(),
+  ariaActiveLabel: string().optional(),
+  activationMessage: string().optional(),          // announced on activate
+  deactivationMessage: string().optional(),        // announced on toggle-off
+  // ——— spatial semantics (Modes 3–4; §4–§5) ———
+  a11yOrder: numberValueSchema.optional(),         // authorable nav order within group
+  a11yGroup: string().optional(),                  // nav grouping / landmark membership
+  a11ySpatialLabel: string().optional(),           // "wall terminal, north wall"
+  a11yPositionDescription: string().optional(),    // "two meters ahead, slightly left" (app/computed)
+  a11yReachable: boolean().optional(),             // app-declared reachability
+  a11yVisibilityOverride: enumSchema(['visible','hidden']).optional(), // force include/exclude from AT
+  // ——— handlers ———
+  onFocusChange: functionSchema.optional(),        // hoisted from input.ts
+  onActivate: functionSchema.optional(),           // (event: A11yActivationEvent) => void  (§2)
+  onA11yValueChange: functionSchema.optional(),
+  onA11yActiveIndexChange: functionSchema.optional(),
+  onA11yActivate: functionSchema.optional(),       // listbox item activation
+}))
+```
+
+`uikit-default` widget schemas spread `...baseOutPropertyShape` then re-declare `disabled` — identical type, harmless override; leave them. Remove `tabIndex`/`onFocusChange` from `inputOutPropertiesSchema` once hoisted (`inputDefaults.tabIndex = 0` stays).
+
+### 1.4 `Component` base-class wiring — `packages/uikit/src/components/component.ts`
+
+1. **Hoist `hasFocus`.** `readonly hasFocus: Signal<boolean>` = `config?.hasFocus ?? signal(false)`, passed to `createConditionals(...)`. `Input` keeps passing its own via config (zero behavior change), drops its own field. Consequence: the already-parsed `focus={{...}}` conditional becomes live for every component with a role — focus rings are just props.
+2. **`activate(event?)`** — §2. The semantic entry point, on the base class.
+3. **`setupComponentA11y(this, this.abortSignal)`** at end of constructor, unless `config?.ownsHiddenA11yElement` (new flag; `Input`/`Textarea` pass it — their hidden `<input>` *is* their a11y element; they call `setupAriaAttributes(...)` beside `setupHtmlInputElement`).
+4. **`focus()` / `blur()`** — focus/blur the hidden element if present (Mode 1) or route to the root's `A11yFocusManager` when one is active (Modes 3–4). `Input.focus(start?, end?, direction?)`/`blur()` remain valid overrides.
+
+---
+
+## 2. Semantic activation — the cross-mode truth (`a11y/activation.ts`)
+
+Adversarial finding #8, accepted: a synthetic mouse-shaped `'click'` collapses modalities and lies about geometry. Activation becomes a first-class semantic event; **pointer clicks delegate to it, not the reverse.**
+
+```ts
+export type A11yActivationSource =
+  | 'pointer' | 'keyboard' | 'screen-reader' | 'voice'
+  | 'xr-controller' | 'gaze' | 'hand' | 'switch'
+
+export type A11yActivationEvent = {
+  source: A11yActivationSource
+  nativeEvent?: unknown            // DOM event / XRInputSourceEvent when available
+  intersection?: Intersection      // REAL geometry when source is 'pointer'/'xr-controller'; absent otherwise
+  handedness?: 'left' | 'right' | 'none'
+  stopPropagation?: () => void
+}
+
+// events.ts: Object3DEventMap gains  activate: A11yActivationEvent
+// eventHandlerShape / EventHandlersProperties gain  onActivate
+```
+
+`Component.activate(event)`:
+1. Returns early when `properties.peek().disabled`.
+2. Dispatches `'activate'` through the existing three EventDispatcher — so `onActivate` from input props, classes, star props, and kit `defaultOverrides` all fire via the exact `computedHandlers`/`addEventListener` chain already in `component.ts`.
+3. **Compat shim:** afterwards dispatches a `'click'` whose event is honestly marked — `{ synthetic: true, source, point: panel center world pos, distance: camera distance if a projection/focus manager knows it else 0 }` — so existing user `onClick`-only code keeps working for keyboard/AT activation. Documented: geometry-sensitive `onClick` handlers must check `synthetic`. Skipped when `event.source === 'pointer'` (the real click already ran).
+4. Announces `activationMessage`/`deactivationMessage` (pre-reading `ariaChecked ?? ariaPressed` to pick) through the announcer registry (§6).
+
+**Pointer delegation:** the base Component registers an internal `'click'` listener (guarded against the shim's synthetic events) that calls `this.activate({ source: 'pointer', intersection: clickEvent, nativeEvent: clickEvent.nativeEvent })`. Kit widgets **move their behavior from `onClick` to `onActivate`** (Checkbox toggle, TabsTrigger select, AccordionTrigger expand…), which is what makes controller/gaze/switch activation in Modes 3–4 work with zero further per-widget code.
+
+---
+
+## 3. Mode 2 — projection: the required geometry pipeline (`a11y/projection.ts`)
+
+Adversarial finding #2, accepted: without projection, mobile touch-exploration and voice control ("click Settings" resolves by accessible name + on-screen position) cannot map the target to what is visible. **Projection is required for Mode 1**, not a nice-to-have.
+
+```ts
+export type A11yProjectionOptions = {
+  camera: Camera
+  renderer: { domElement: HTMLCanvasElement }   // rects are relative to this canvas
+  /** optional app hook for occlusion (§4.1); default: frustum-only */
+  isPerceivable?: (component: Component) => boolean
+}
+/** Registers into root.onFrameSet. Each frame: for every a11y element under this
+ *  root, compute the panel's screen-space AABB (globalMatrix × size × pixelSize,
+ *  4 corners projected through camera, clamped to canvas, offset by canvas
+ *  client rect) and write left/top/width/height on the hidden element inside the
+ *  per-root container (position:absolute; container overlays the canvas).
+ *  Off-frustum / degenerate rect → visibility policy (§4.1) decides exposure.
+ *  Writes only on change (epsilon 1px) — zero DOM churn on a static camera.
+ *  Returns dispose. */
+export function setupA11yProjection(root: Component, options: A11yProjectionOptions): () => void
+```
+
+- **React:** auto-wired. `build()`'s `useSetup` (or the `Fullscreen`/root path) calls `setupA11yProjection` with `useThree`'s camera + `gl.domElement` once per root — R3F knows both, so React users get projected a11y by default with no extra component.
+- **Vanilla:** explicit `setupA11yProjection(rootComponent, { camera, renderer })` — one line next to the existing `component.update(delta)` wiring.
+- Elements stay `opacity: 0; pointer-events: none` (a11y hit-testing ignores pointer-events; real pointer input continues to hit the canvas), but are **real-sized** — this is what makes iOS/Android touch-exploration and voice-control targeting land on the visible control.
+
+### 3.3 Degraded fallback (documented, warned)
+
+When projection cannot be configured (vanilla app without camera access, headless), elements fall back to the `Input` precedent: off-screen block at `left:-1000vw`. Keyboard + linear SR navigation still work; touch-exploration and voice targeting do not. A one-shot dev-mode `console.warn` fires when a role is set under a root with no projection configured. This is the *only* sanctioned off-screen path.
+
+---
+
+## 4. Mode 3 — diegetic 3D, moving camera (non-XR)
+
+Diegetic explicitly includes the ordinary case: a 3D-positioned panel in a mouse-driven game on a flat screen. uikit's pointer events already resolve that mouse click via raycast — pointer users need nothing new. The a11y work is for everyone else: keyboard, voice-control, and magnifier users need the Mode-1/2 DOM shadow projected to where the panel *currently appears on screen* (projection is load-bearing outside XR too). Beyond that, world-space panels break two further Mode-1 assumptions: render-visibility ≈ perceivability (finding #6) and construction order as a sane focus order (finding #5). And focus can land somewhere the user can't see (finding #7).
+
+### 4.1 `a11yVisibility` — separate from render visibility (`a11y/visibility.ts`)
+
+```ts
+export type A11yVisibility =
+  | 'visible'        // in frustum, unoccluded, big enough
+  | 'offscreen'      // outside frustum, in front hemisphere
+  | 'behind-camera'
+  | 'occluded'       // app/probe says another mesh covers it
+  | 'too-small'      // projected rect under minPerceivableSize (default 8px)
+  | 'hidden'         // component.isVisible false or a11yVisibilityOverride 'hidden'
+
+export function computedA11yVisibility(
+  component: Component,
+  camera: Signal<Camera | undefined>,
+  options?: { occlusionProbe?: (c: Component) => boolean; minPerceivableSize?: number }
+): ReadonlySignal<A11yVisibility>
+```
+
+- Core computes frustum/behind/too-small from `globalMatrix` + `size` + `pixelSize` + camera (cheap; runs inside the Mode-2 frame pass, not per-signal-change).
+- **Occlusion is an app hook** (`occlusionProbe`), with an optional provided helper `createRaycastOcclusionProbe(scene, { budgetPerFrame: 8 })` — raycasts are budgeted and round-robined; occlusion is opt-in because it's the expensive part.
+- Policy mapping (defaults, all overridable): `visible` → exposed + focusable; `offscreen`/`occluded` → exposed to AT with position description, **skipped by sequential focus** unless focus-reveal (§4.3) is active; `behind-camera`/`too-small` → `aria-hidden`; `hidden` → removed. `a11yVisibilityOverride` force-includes (e.g. a critical alarm panel that must stay reachable) or force-excludes.
+- Mode 1 (Fullscreen/screen-space roots) short-circuits to `visible|hidden` — no cost.
+
+### 4.2 Spatial navigation (`a11y/spatial-nav.ts`)
+
+Construction order is acceptable **only** for flat screen-space layouts. For world-space roots:
+
+- **Authorable:** `a11yOrder` (number, sorts within a group), `a11yGroup` (string), `role: 'landmark'` + `ariaLabel` marks wayfinding anchors ("Cockpit panel", "Inventory wall").
+- **Computed:** default order = groups sorted by camera distance of their bounding centers, components within a group by `a11yOrder ?? camera-relative reading order` (projected top-left → bottom-right, hysteresis so small camera moves don't reshuffle mid-tab).
+- **Directional nav:** `focusDirectional('left'|'right'|'up'|'down')` on the focus manager — nearest focusable by projected camera-space position in that half-plane. Backs both arrow-key nav on landmark containers and XR thumbstick nav.
+- **DOM ordering sync:** for Mode 1 targets, the per-root container re-appends hidden elements to match computed order when it changes while no element inside holds focus (never yanks the tab cursor).
+
+### 4.3 Focus-reveal policy (finding #7)
+
+```ts
+export type FocusRevealPolicy = {
+  offscreen: 'skip' | 'announce' | 'reveal'      // default 'announce'
+  onReveal?: (component: Component) => void       // app moves camera / scrolls / re-orients panel
+}
+```
+
+- `skip`: sequential focus never lands outside `visible`.
+- `announce` (default): focus may land there; the announcer emits the position description ("Settings panel — behind you, to the left") built from `a11yPositionDescription` ?? computed camera-relative octant; an earcon backend (§6) can pan the cue spatially.
+- `reveal`: calls `onReveal` — camera-follow / panel auto-orient is **always app-implemented and opt-in** (comfort: never auto-move the camera by default; XAUR motion-agnostic requirement).
+
+---
+
+## 5. Mode 4 — immersive XR
+
+Inside an `XRSession`, `document.activeElement` is not the user's focus model and an off-screen live region may not be perceivable (findings #3, #9). Mode 4 stands on three legs: the focus manager, input adapters, and announcement backends. The DOM focus bridge *mirrors* spatial focus when hidden elements exist; it is never the source of truth.
+
+**Input foundation (verified 2026-07-12):** `@pmndrs/xr` implements **no accessibility** — its core (`packages/xr/src`) is XR input/setup only: controllers, hands, pointers, teleport, hit-test, emulate, store; zero tabIndex/activeElement/announcer/aria machinery. It is built on the same `@pmndrs/pointer-events` uikit already depends on. The division is therefore clean: **@pmndrs/xr is the XR input plumbing to integrate with, not reinvent** — it turns controllers/hands into pointer-events rays that already hit uikit panels — and this layer supplies exactly what it lacks: AT focus semantics, announcements, dwell/scan modalities. uikit has zero XR binding today; the Phase-4 dogfood establishes it (`@react-three/xr` in the react example, `@pmndrs/xr` in the vanilla pair). Integration is duck-typed/optional-peer — no new hard runtime dependency: session detection defaults to three's `renderer.xr` `sessionstart`/`sessionend` events, reading @pmndrs/xr's `store` for richer mode/input-source state when the app provides one; its `emulate` (IWER-based) is the test harness.
+
+### 5.1 `A11yFocusManager` (`a11y/focus-manager.ts`) — Modes 3–4
+
+```ts
+export class A11yFocusManager {
+  constructor(root: Component, options?: { policy?: FocusRevealPolicy })
+  readonly focused: Signal<Component | undefined>       // spatial focus truth
+  focusNext(): void; focusPrev(): void                  // computed order (§4.2)
+  focusDirectional(dir: 'left'|'right'|'up'|'down'): void
+  setFocus(component: Component | undefined, opts?: { reveal?: boolean }): void
+  activateFocused(event: Omit<A11yActivationEvent, 'intersection'>): void
+  /** focusables snapshot: role interactive + a11yVisibility policy-pass */
+  readonly focusables: ReadonlySignal<Array<Component>>
+  dispose(): void
+}
+```
+
+- Writing `focused` sets the target component's `hasFocus` signal (same signal DOM focus writes — the `focus` conditional and `onFocusChange` fire identically) and clears the previous one.
+- **DOM mirror:** when the focused component has a hidden element and no XR session is active, `setFocus` also calls `element.focus()` so platform AT tracks along; inside an XR session the mirror is skipped (no DOM focus dependence).
+- One manager per root, lazily created by the first adapter or by explicit construction; exposed as `getA11yFocusManager(root)`.
+
+### 5.2 Input adapters (`a11y/adapters/`)
+
+Each adapter is a small setup function binding an input source to the manager; all activation flows through `component.activate({source, ...})`:
+
+- **`controller-ray.ts`** — @pmndrs/xr (when wired by the app) delivers controller/hand rays as `@pmndrs/pointer-events` pointers that already produce uikit hover/click; the adapter listens to uikit's own pointer-event stream (XR pointers arrive tagged with their pointer type/state) and maps "ray dwell on focusable ≥ debounce" → `setFocus`, select/squeeze → `activateFocused({source:'xr-controller', handedness})`, and thumbstick flicks (via the @pmndrs/xr store's input sources, or raw `XRInputSource.gamepad` polling when absent) → `focusDirectional`. Real intersections pass through — no geometry lies, and no parallel raycasting is built.
+- **`gaze.ts`** — head/eye-gaze reticle: dwell timer (default 800 ms, configurable, visual progress ring hook) → `setFocus`; continued dwell or select → activate with `source:'gaze'`.
+- **`switch-scan.ts`** — single/dual-switch scanning: auto-advance interval over `focusables` (row-column scanning per `a11yGroup`), switch press → activate with `source:'switch'`. Also usable outside XR (motor a11y on desktop).
+
+Keyboard/gamepad in-scene nav (non-XR Mode 3) reuses the same manager: arrow/tab bindings on the canvas → `focusNext/Directional`.
+
+### 5.3 Announcement backends — §6; captions/earcons/haptics are the in-headset output channel.
+
+### 5.4 Spatial metadata (finding #10)
+
+`a11ySpatialLabel`, `a11yPositionDescription`, `a11yGroup`, landmark roles (§1.3) plus query helpers:
+
+```ts
+/** flattened semantic tree for AT bridges / debugging / test assertions */
+export function getA11yTree(root: Component): Array<{
+  component: Component; role: A11yRole; label?: string;
+  visibility: A11yVisibility; group?: string; order: number
+}>
+/** "Three controls: Play button, two meters ahead; Settings, to your left; …" */
+export function describeSurroundings(manager: A11yFocusManager): string
+```
+
+`describeSurroundings` output feeds a voice command / help gesture ("where am I?") — an XAUR spatial-orientation requirement.
+
+### 5.5 WebXR DOM Overlay — what it is and is not (finding #4)
+
+- **Is:** a way to keep *true 2D companion/overlay UI* (pause menu, caption strip, settings sheet) as real DOM inside AR sessions (`optionalFeatures: ['dom-overlay']`), fully accessible by the platform's own AT. The per-root a11y container + caption backend element are valid DOM Overlay content; when a session grants `dom-overlay`, the announcer's caption backend renders there.
+- **Is not:** an accessibility model for in-scene panels. A panel on a wall is Mode 4; DOM Overlay never describes or focuses the mesh.
+- Support is uneven (AR-first; headset browsers vary) — always feature-detect; Mode 4 must be complete without it. Reference: [WebXR DOM Overlays Module](https://immersive-web.github.io/dom-overlays/).
+
+---
+
+## 6. Announcer — backend registry (`a11y/announce/`)
+
+Finding #9 accepted: one DOM live region is a browser-mode backend, not the system.
+
+```ts
+export type Politeness = 'polite' | 'assertive'
+export type Announcement = {
+  message: string; politeness: Politeness
+  source?: Component            // enables spatial audio panning / caption anchoring
+  kind?: 'activation' | 'focus' | 'status'
+}
+export interface AnnouncementBackend {
+  announce(a: Announcement): void
+  dispose?(): void
+}
+export function registerAnnouncementBackend(b: AnnouncementBackend): () => void
+export function announce(message: string, opts?: Partial<Omit<Announcement,'message'>>): void
+```
+
+Backends (each its own file, independently tree-shakeable):
+- **`dom-live-region.ts`** — default, auto-registered on first `announce` in a DOM env: singleton off-screen live region (clip-rect pattern), clear-then-set ~100 ms so repeats re-announce (react-three-a11y port, no zustand, framework-free). Mounts inside the DOM Overlay root when a session provides one.
+- **`caption.ts`** — in-world caption panel: a camera-anchored uikit `Container`+`Text` (dogfoods uikit) showing the last message, per XAUR captions requirement; user prefs: on/off, size, anchor.
+- **`earcon.ts`** — Web Audio cues (focus tick, activate blip, toggle up/down); `source` component pans via `PannerNode`; mono-audio preference collapses to stereo-center.
+- **`haptic.ts`** — pulses `XRInputSource.gamepad.hapticActuators` on focus/activate when in-session.
+- **`speech.ts`** — optional `speechSynthesis` fallback for environments with no SR running (explicitly opt-in; never fights a real screen reader).
+
+Preferences: `setA11yPreferences({ captions, earcons, haptics, speech, monoAudio, reducedMotion })` — a plain signal-backed store; backends read it; `reducedMotion` also gates focus-reveal camera behaviors.
+
+---
+
+## 7. `uikit-default` widget wiring
+
+Same table as v1, with behavior moving to `onActivate` (§2). Roles are defaulted; labels are not — dev-mode one-shot `console.warn` when an interactive role has no accessible name.
+
+| Widget | defaultOverrides additions |
+|---|---|
+| `button/index.ts` `Button` | `role: 'button'` |
+| `checkbox/index.ts` `Checkbox` | `role: 'checkbox'`, `ariaChecked: computed(() => this.currentSignal.value ?? false)`, toggle moves `onClick`→`onActivate` |
+| `switch/index.ts` `Switch` | `role: 'switch'`, `ariaChecked: computed(...)`, `onActivate` |
+| `radio-group/index.ts` `RadioGroupItem` | `role: 'radio'`, `ariaChecked` via `searchFor` group compare, `onActivate` |
+| `tabs/trigger.ts` `TabsTrigger` | `role: 'tab'`, `ariaSelected` (reuses `active` computed), `onActivate` |
+| `accordion/trigger.ts` | `role: 'button'`, `ariaExpanded: computed(...)`, `onActivate` |
+| `slider/index.ts` `Slider` | `role: 'slider'`, `ariaValueNow/Min/Max/Step`, `onA11yValueChange` → existing controlled/uncontrolled path |
+| `toggle/`, `toggle-group/` | `role: 'togglebutton'`, `ariaPressed: computed(...)`, `onActivate` |
+| `pagination`, `menubar`, `dialog`, `alert-dialog`, `tooltip` | Later phase — dialog needs focus trap + `aria-modal` + restore-focus; menubar full keyboard grammar |
+
+`uikit-horizon` inherits base props free; widget sweep is a follow-up mirroring this table.
+
+## 8. Virtualized listbox (preserved from v1)
+
+One focusable hidden element for the icon grid's 1594 virtual items: `role="listbox" tabindex=0 aria-activedescendant` + a single managed `role="option"` child carrying `aria-posinset/aria-setsize/aria-selected` + label. Keydown grammar: arrows/Home/End → `onA11yActiveIndexChange({ move: 'next'|'prev'|'nextRow'|'prevRow'|'first'|'last' })` (the app owns column geometry), Enter/Space → `onA11yActivate(currentIndex)`. App scrolls via the existing `scrollPosition` signal, drives a visual highlight, announces selection.
+
+## 9. API surface
+
+**Vanilla:** props on construction/`setProperties`; `component.hasFocus`, `component.focus()/blur()`, `component.activate({source})`, `announce()`, `setupA11yProjection(root, {camera, renderer})`, `getA11yFocusManager(root)` + adapters, `registerAnnouncementBackend`, `setA11yPreferences`.
+
+**React:** individual flat props (not a grouped `a11y={{}}` object — flat props are what the schema/pub-sub natively threads, and they participate in conditionals/classes): `<Button ariaLabel="Copy manifest" focus={{ borderColor: colors.ring }} />`. Projection auto-wired per root (§3). Adapters/backends: thin optional components later (`<A11yXRAdapters />`), not required for Modes 1–2.
+
+## 10. Standards & prior art
+
+- **[W3C XR Accessibility User Requirements (XAUR)](https://www.w3.org/TR/xaur/)** — the checklist for Modes 3–4: motion-agnostic operation (never require head/body motion — gaze dwell + switch scanning cover it), alternative input mapping (adapters), spatial orientation (`describeSurroundings`, position descriptions), captions + spatial-audio alternatives (backends, mono pref), target-size/dwell customization.
+- **[WebXR Device API](https://www.w3.org/TR/webxr/)** — session/input-source model the adapters bind to; **[WebXR DOM Overlays](https://immersive-web.github.io/dom-overlays/)** — §5.5 scope.
+- **WCAG 2.2** — the DOM layer's floor (name/role/value 4.1.2, focus visible 2.4.7, target size 2.5.8 via projection).
+- **[Game Accessibility Guidelines](https://gameaccessibilityguidelines.com/)** — remappable input, captions, no-hold alternatives, configurable motor timing (switch-scan intervals).
+- **Prior art:** *Babylon.js* ships an HTML-twin accessibility tree (`accessibilityTag` → hidden DOM mirroring the scene) — direct precedent for Modes 1–2 and evidence the DOM-shadow approach is production-viable; *Unity* (Screen Reader API, mobile SR bridge) mirrors the "semantic tree + platform bridge" split; *Meta* Quest guidelines push haptics+audio redundancy (our backend set); *visionOS* maps gaze+pinch through system AT with Dwell Control — validating dwell as a first-class adapter; *A-Frame* has only community add-ons — no precedent to import; *@pmndrs/xr* (verified) ships no a11y at all — confirming this layer fills a real gap in the pmndrs stack rather than duplicating one.
+- `@react-three/a11y` — role taxonomy + announcer pattern only (already mined).
+
+## 11. Acceptance matrix
+
+| # | Scenario | Mode | Gate | Verified by |
+|---|---|---|---|---|
+| 1 | Desktop SR (VoiceOver/NVDA) reads name/role/state of every interactive component | 1 | name+role+state exposed | machine (a11y-tree probe) + manual SR pass |
+| 2 | Keyboard-only: Tab/Shift-Tab reach all controls; Enter/Space activate; visible ring | 1 | focus routes to `hasFocus`; ring renders; activation fires | machine (browser probe) |
+| 3 | Mobile touch-exploration lands on visible control positions | 2 | projected rect ∩ rendered panel rect ≥ 90% | machine (rect-overlap probe) + manual VoiceOver/TalkBack |
+| 4 | Voice control "click Settings" hits the control | 2 | accessible name + on-screen rect | manual (macOS Voice Control) |
+| 5 | aria-live announces activation/toggle messages | 1 | live-region text mutates | machine |
+| 6 | Virtualized grid: one tab stop, arrows move active item w/ posinset/setsize, Enter toggles | 1 | listbox semantics + callbacks | machine |
+| 7 | Moving camera: panel leaves frustum → focus policy honored, position announced | 3 | `a11yVisibility` transitions; announce fires | machine (scripted camera) |
+| 8 | Occluded panel skipped/announced per policy | 3 | occlusionProbe respected | machine (probe stub) + manual |
+| 9 | Scaled/rotated/oblique panels project correct rects | 2 | AABB overlap ≥ 90% at 30°/60° tilt | machine |
+| 10 | Panel behind user: never a silent focus trap; 'announce' policy describes direction | 3 | focus-reveal policy | machine |
+| 11 | XR controller ray: focus follows ray dwell, squeeze activates, haptic fires | 4 | manager focus + `activate({source:'xr-controller'})` | machine (IWER emulated session) + manual headset |
+| 12 | Gaze dwell focuses + activates without hand input | 4 | dwell timer → activate | machine (IWER) + manual |
+| 13 | Switch scan traverses focusables and activates | 3/4 | scan interval + activate | machine |
+| 14 | In-headset feedback without DOM SR: caption + earcon + haptic on activation | 4 | backends emit | machine (backend spies) + manual headset |
+| 15 | AR DOM Overlay: companion UI accessible via platform AT; in-scene panels still Mode-4 | 4 | overlay hosts container; no regression | manual (device) + IWER smoke |
+| 16 | `prefers-reduced-motion` + `setA11yPreferences` honored (no auto camera moves; earcon/caption prefs) | all | prefs gate behaviors | machine |
+| 17 | StrictMode double-mount leaves zero orphan DOM / listeners / managers | 1–4 | count probes | machine |
+
+Machine rows are loop gates (see horde plan); manual rows ship with a sign-off checklist and block release, not merge.
+
+## 12. Rollout
+
+Phased plans in `planning/superpowers/plans/`: `uikit-a11y-phase-0-core.md` (Mode-1 semantics + activation + announcer registry + DOM backend), `uikit-a11y-phase-1-projection.md` (Mode 2 + toolbar dogfood), `uikit-a11y-phase-2-widgets.md` (kit bindings + listbox + bento), `uikit-a11y-phase-3-diegetic.md` (visibility/nav/reveal + moving-camera example), `uikit-a11y-phase-4-xr.md` (focus manager, adapters, backends, DOM Overlay, IWER harness). Orchestration: `uikit-a11y-horde-execution.md`.
+
+## 13. Testing strategy
+
+- **Unit (vitest, node + happy-dom `Window` per existing `svg-shared-set.test.ts` pattern):** element lifecycle per role incl. abort/StrictMode-shaped double construct; aria sync; activation chain (Checkbox toggles through `onActivate`); focus→`hasFocus`→conditional; announcer backends (spies); projection math (pure function against known camera setups); visibility classification; nav ordering determinism; listbox grammar; focus-manager transitions; adapters against scripted input timelines.
+- **Live in-product probes (browser automation on the icon-browser + bento dev servers):** the machine rows of §11 — exact probe scripts live in the horde plan.
+- **XR (@pmndrs/xr `emulate`, IWER-based, dev-dep):** emulated `XRSession` + controller/gaze input driving rows 11–12, 14–15 smoke — same runtime the integration targets, so the harness exercises the real @pmndrs/xr → pointer-events → uikit path.
+- **Manual:** VoiceOver/NVDA/TalkBack passes, Voice Control, headset checklist — tracked in the acceptance matrix, release-blocking.
+
+## 14. Open questions / risks
+
+1. **Projection perf ceiling** — per-frame rect writes for hundreds of roles; mitigated by epsilon-gated writes + only-dirty updates; budget: ≤ 0.2 ms for 200 elements (measured in the Phase-1 gate).
+2. **Tab-order re-sync vs focus stability** — reordering the container only when it holds no focus can leave stale order during long focus dwell; acceptable, documented.
+3. **Occlusion cost/quality** — raycast probe is approximate (center-point) and budgeted; apps with heavy geometry supply their own probe. Wrong-side default: unoccluded (never hide a control we're not sure about).
+4. **Compat shim double-behavior** — apps binding the same behavior to both `onClick` and `onActivate` would double-fire on pointer; rule: shim never runs for `source:'pointer'`, kit widgets bind only `onActivate`. Docs call it out.
+5. **`disabled` on base Container** — a11y-element semantics only (does not gate uikit pointer events; kit visuals own their disabled look). Documented loudly.
+6. **XR AT reality** — headset screen readers are nascent; Mode 4's backends (captions/earcons/haptics/speech) are the practically-perceivable channel today, with the semantic tree ready for platform bridges as they mature. XAUR is the requirements bar, not current-browser parity.
+7. **speech.ts vs running SR** — speaking over a real screen reader is hostile; backend stays opt-in with a "no SR detected" heuristic documented as best-effort.


### PR DESCRIPTION
### **User description**
## Native a11y — Phase 0: screen-space core

First phase of building accessibility natively into `@three-flatland/uikit` (replacing the removed `react-three-a11y` fork). Interactive uikit components emit a hidden, positioned native DOM element (button / link / `input[type=range]` / …) synced to a11y props via reactive effects, and a single semantic activation path — `activate({ source })` — is the cross-mode truth: pointer clicks delegate **to** it, so keyboard, screen-reader/AT, and (later) XR-controller / gaze / switch activation all reuse the same path with no per-widget code. The design accounts for panels living **anywhere in 3D** (screen-space, diegetic 3D game panels, XR headsets), not only screen space.

### What shipped

- **Schema** (`properties/schema.ts`) — `a11yPropertyShape` spread into the base out-shape so every component inherits `role`, `ariaLabel`/`ariaDescription`, `tabIndex`, `disabled`, `href`, `aria{Checked,Pressed,Expanded,Selected}`, slider `ariaValue*`, activation/deactivation messages, spatial slots (`a11yOrder`/`a11yGroup`/`a11ySpatialLabel`/…, for Modes 3–4), and handlers (`onActivate`/`onFocusChange`/`onA11yValueChange`/…).
- **Semantic activation** (`a11y/activation.ts`) — `dispatchActivation` fires the `'activate'` event through the existing handler chain, then a compat synthetic `'click'` (marked `synthetic`, skipped for real pointer clicks) so legacy `onClick` code keeps working, then announces the activation/deactivation message by toggle state.
- **Hidden element** (`a11y/hidden-element.ts`) — `createHtmlA11yElement` role→native-element mapping; `setupComponentA11y` reactive lifecycle (role `null` → zero cost; set → create + wire aria/role-state/activation/focus; teardown removes it), mounted in a refcounted per-root `[data-uikit-a11y]` container.
- **Announcer** (`a11y/announce/*`) — pluggable backend registry with a default off-screen `aria-live` DOM backend (clear-then-set so identical repeats re-announce); XR/game modes can register captions/earcons/haptics/speech backends.
- **Component wiring** (`components/component.ts`) — `hasFocus` signal, `a11yElement`, `activate()`/`focus()`/`blur()`, pointer-click → `activate` delegation.
- **Input** (`components/input.ts`) — the hidden `<input>` is Input's own a11y element (accessible name synced; exposed as `a11yElement`).

### Adversarial review (Codex `gpt-5.5`)

A second-model review of the frozen activation API found **7 issues — all fixed in `12b8c11b`** (re-derived against source before fixing, not rubber-stamped):

| # | Issue | Fix |
|---|-------|-----|
| 1 | `onActivate` dead — omitted from `eventHandlerKeys`, never bound | added it (binds to `'activate'`) |
| 2 | pointer vs keyboard fired `onActivate`/`onClick` in opposite order | base delegation registered before prop-handler binding — activate leads in both modes |
| 3 | pointer delegation dropped `stopPropagation` | threaded through so `onActivate` can halt propagation |
| 4 | compat synthetic click fired even if `onActivate` synchronously disabled the control | re-check `disabled` after handlers (vanilla path) |
| 5 | hidden element read `root.peek()` (non-reactive) | `.value` — element follows a reparented component |
| 6 | Input never set `a11yElement` | set to its hidden `<input>` |
| 7 | focused-element teardown left `hasFocus` stuck true | reset + notify on teardown |

The `disabled`/`tabIndex` overlap with Input's own declarations was assessed and confirmed intentional (Input keeps its hidden-input path via `ownsHiddenA11yElement`).

### Gate

- `tsc --noEmit` clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- **117 uikit tests pass** (24 new: announcer, hidden-element lifecycle incl. StrictMode zero-orphans, activation contract, schema)

### Follow-ups (deferred, tracked)

- Schema `tabIndex`/`onFocusChange` hoist left as-is — the hidden-input type wants a required `tabIndex` and Input's own declarations override the inherited ones harmlessly.
- Phases 1–4 (projection math, listbox ARIA, spatial nav / focus manager, XR session) build on this frozen API.

https://claude.ai/code/session_01VSsxMZfAcro1QjCshpnbXf


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduce semantic activation dispatch (`activate`) unifying pointer, keyboard, screen-reader, and future XR interactions

- Mount hidden native DOM elements based on `role` for screen-reader/keyboard accessibility, with reactive aria attribute and focus sync

- Add an announcement system with default off-screen `aria-live` regions and pluggable backends for XR/game modes

- Extend the base component with `a11yPropertyShape`, adding `role`, `ariaLabel`, `tabIndex`, `disabled`, `onActivate`, `onFocusChange`, and spatial props


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Component"] -- "click delegate" --> ACT["activate()"]
  ACT --> DA["dispatchActivation"]
  DA -- "fires 'activate' event" --> H["onActivate handlers"]
  DA -- "synthetic click (non-pointer)" --> H2["onClick handlers"]
  A -- "has" --> HE["setupComponentA11y"]
  HE -- "creates" --> EL["createHtmlA11yElement (role → native DOM)"]
  HE -- "syncs" --> SA["setupAriaAttributes"]
  SA -- "reads" --> PS["a11yPropertyShape (inherited schema)"]
  A -- "uses" --> AN["announce()"]
  AN -- "backends" --> DL["dom-live-region (default)"]
  AN -- "pluggable" --> XR["XR/Game backends"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>activation.ts</strong><dd><code>Define A11yActivationEvent and dispatchActivation for cross-mode </code><br><code>semantic activation</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-2789fd00c020bb4deee71f40da572975170874c37e3b71bd867fffd0796e7ddd">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>announcer.ts</strong><dd><code>Announcement registry with signal‑based preferences and default </code><br><code>backend auto‑registration</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-19c45ba2270379f01cd9d6b7e123d5c3d96c6a30ed8488f1ae2b8dc01682e818">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dom-live-region.ts</strong><dd><code>Off‑screen aria‑live region backend that clears then re‑sets text for </code><br><code>repeat announcements</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-e294a8f4d419f0096bf24797122e4ce835a0b6b87494d7569ea731ec2dc80abf">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>focus.ts</strong><dd><code>Extracted focus‑mirror utility to drive generic component hasFocus</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-81819cf83f4ea78a9925142a0df53a279725678fb886194251686e195e58d8f5">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hidden-element.ts</strong><dd><code>Role‑to‑native‑element mapping, reactive lifecycle, aria sync, and </code><br><code>activation wiring</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-c5d14b68277bc275fe65779369cca496dfdd88d5bd4e1b4ef31c78aff2a3de96">+332/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Re‑export all a11y public API (activation, hidden element, announcer)</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-67e4c24c825269785ffd228d63b38bc5415734ea6cc942ce439ca5702cfcea4b">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>component.ts</strong><dd><code>Integrate activation dispatch, hidden a11y element setup, and </code><br><code>pointer‑to‑activation delegation</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-b0bd633d228c0a8f2821530d2f6331ecb2dc4d5c7a712ebb7ecfb1c29d57330c">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input.ts</strong><dd><code>Expose hidden input as a11yElement for unified focus/projection and </code><br><code>sync aria label</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-de9dec659ce2984709075f91f9b5165d1fdce72570668321b99b35ed9bc762a3">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>text.ts</strong><dd><code>Accept ownsHiddenA11yElement config to prevent double hidden elements</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-e9de9510d1d668f5b0b9f30b9d77f2720e50dc0b8e0646722ae61fdc3a9dbc7e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>events.ts</strong><dd><code>Add <code>activate</code> event to three.js Object3DEventMap and <code>synthetic</code>/source <br>fields to ThreeMouseEvent</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-2bda6d972a2d1d08639bb3be637ed658690b9f2a0d756c5050254952ade70af3">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export the new a11y module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-8c0e13d040562c640963c687fe03cec6af8c435c0213af0263bc1560f596986a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.ts</strong><dd><code>Add a11yPropertyShape (role, aria*, spatial props, handlers) spread </code><br><code>into base out‑shape</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-1115ac053aecfec1d06e95c2f4d6a1cc8b0d4117040b09d0a27f4618872e8014">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hidden-input.ts</strong><dd><code>Re‑export setupUpdateHasFocus from a11y/focus.ts (no behaviour change)</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-adec9b46752b3276da063533dc12f5907968e3c8f2412cc7581acafce5559214">+3/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Include <code>onActivate</code> in event handler keys so computedHandlers wire it</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-220159b6b6d853c8f7daac0d9b79e6a281ff7c364f1520c4f1493c6dd07095ae">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>a11y-activation.test.ts</strong><dd><code>Tests for semantic activation contract, cross‑mode ordering, synthetic </code><br><code>click, and input a11yElement</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-a8d4285827002f6a10d55947b3da53f555f5a7e3f210706ccdfa8a9387340ab9">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>a11y-announcer.test.ts</strong><dd><code>Tests for announcement registry routing, unregister, and DOM </code><br><code>live‑region lifecycle</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-2219250ed4f0d0e596d1d3a755d8b3798afafc5fa9301f7a0d22951ac533dcde">+131/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>a11y-hidden-element.test.ts</strong><dd><code>Tests for role‑to‑native‑element creation, component‑driven </code><br><code>mount/teardown, and reactive aria sync</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-1bde0cf31d8349c0c79822e05790755086488679b67f24e51045f904dcfeb46e">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.test.ts</strong><dd><code>Schema validation for inherited a11y props and strictness of role enum</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/182/files#diff-b5f3ba41cf86d292f1574d506235a9297cdcae944519256faa4f8b9d7eed7999">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

