### PR TITLE
feat(uikit): native a11y Phase 1 — Mode 2 projection

### DIFF
--- a/packages/uikit-default/src/button/index.ts
+++ b/packages/uikit-default/src/button/index.ts
@@ -116,6 +116,7 @@ export class Button extends Container<ButtonOutProperties> {
       defaults: componentDefaults,
       ...config,
       defaultOverrides: {
+        role: 'button',
         '*': {
           borderColor: colors.border,
         },

--- a/packages/uikit-lucide/example/App.tsx
+++ b/packages/uikit-lucide/example/App.tsx
@@ -10,8 +10,13 @@ import {
   installIconAtlas,
   setPreferredColorScheme,
 } from '@three-flatland/uikit/react'
-import type { Container as VanillaContainer } from '@three-flatland/uikit'
-import { colors, Button, Input } from '@three-flatland/uikit-default/react'
+import { computeA11yScreenRect, type Container as VanillaContainer } from '@three-flatland/uikit'
+import {
+  colors,
+  Button,
+  Input,
+  type VanillaButton,
+} from '@three-flatland/uikit-default/react'
 import * as LucideIcons from '@three-flatland/uikit-lucide/react'
 import { SlugFontLoader } from '@three-flatland/slug/react'
 import type { SlugFont } from '@three-flatland/slug'
@@ -40,6 +45,14 @@ import iconTags from './icon-tags.json'
 // for a consumer to bake their own trimmed atlas; the browser itself ships the
 // full one so scrolling all 1594 stays on the baked (parse-free) path.
 // ============================================================================
+
+// Dev-only debug hook the a11y-projection probe reads — see the `useEffect` in
+// `IconBrowser` that assigns it.
+declare global {
+  interface Window {
+    __uikitA11yDebug?: () => unknown
+  }
+}
 
 const ALL_ICONS: string[] = iconNames
 
@@ -167,6 +180,47 @@ function IconBrowser() {
   // `scrollPosition` / `size` signals — we poll them in `useFrame` to drive
   // virtualization without a per-tick React render (see below).
   const scrollRef = useRef<VanillaContainer | null>(null)
+
+  // Refs to the toolbar Buttons' vanilla uikit Components — read by the dev-only
+  // `window.__uikitA11yDebug` hook (below) to verify the Mode 2 a11y projection lines
+  // up each hidden native element with its actual on-canvas panel.
+  const selectAllRef = useRef<VanillaButton>(null)
+  const copyRef = useRef<VanillaButton>(null)
+  const clearRef = useRef<VanillaButton>(null)
+
+  const camera = useThree((s) => s.camera)
+  const gl = useThree((s) => s.gl)
+
+  // Dev-only debug hook for the a11y projection probe: `window.__uikitA11yDebug()` reports,
+  // per toolbar button, the panel's projected screen rect (via the same math the Mode 2
+  // projection uses) alongside its hidden a11y element's actual `getBoundingClientRect()` —
+  // so a browser probe can assert they overlap.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    window.__uikitA11yDebug = () =>
+      [selectAllRef, copyRef, clearRef].map((r) => {
+        const c = r.current
+        if (c == null) return null
+        c.updateWorldMatrix(true, false)
+        const rect = gl.domElement.getBoundingClientRect()
+        const panel = computeA11yScreenRect(c.matrixWorld, camera, {
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        })
+        const el = c.a11yElement
+        return {
+          panel,
+          element: el ? el.getBoundingClientRect() : null,
+          name: el ? el.getAttribute('aria-label') : null,
+        }
+      })
+    return () => {
+      delete window.__uikitA11yDebug
+    }
+  }, [camera, gl])
+
   const [win, setWin] = useState<Window>({
     start: 0,
     poolSize: INITIAL_COLUMNS * 15,
@@ -309,36 +363,47 @@ function IconBrowser() {
           placeholder="Search 1594 icons by name or tag…"
           value={query}
           onValueChange={setQuery}
+          ariaLabel="Search icons by name or tag"
         />
         <Text fontSize={13} color={colors.mutedForeground}>
           {selectedCount} selected
         </Text>
         <Button
+          ref={selectAllRef}
           variant="outline"
           disabled={filtered.length === 0}
           onClick={selectAll}
           flexDirection="row"
           gap={8}
+          ariaLabel={`Select all ${filtered.length} icons`}
+          focus={{ borderColor: colors.ring ?? colors.primary, borderWidth: 2 }}
         >
           <LucideIcons.CheckCheck width={16} height={16} />
           <Text>Select all {filtered.length}</Text>
         </Button>
         <Button
+          ref={copyRef}
           variant="secondary"
           disabled={selectedCount === 0}
           onClick={copyManifest}
           flexDirection="row"
           gap={8}
+          ariaLabel="Copy manifest"
+          activationMessage={`Copied ${selectedCount} icons`}
+          focus={{ borderColor: colors.ring ?? colors.primary, borderWidth: 2 }}
         >
           <LucideIcons.Copy width={16} height={16} />
           <Text>{copyLabel}</Text>
         </Button>
         <Button
+          ref={clearRef}
           variant="outline"
           disabled={selectedCount === 0}
           onClick={clearSelection}
           flexDirection="row"
           gap={8}
+          ariaLabel="Clear selection"
+          focus={{ borderColor: colors.ring ?? colors.primary, borderWidth: 2 }}
         >
           <LucideIcons.X width={16} height={16} />
           <Text>Clear</Text>

--- a/packages/uikit/src/a11y/activation.ts
+++ b/packages/uikit/src/a11y/activation.ts
@@ -66,7 +66,14 @@ export function dispatchActivation(component: Component, event: A11yActivationEv
       nativeEvent: event.nativeEvent,
       stopPropagation: event.stopPropagation ?? noop,
     }
-    component.dispatchEvent({ type: 'click', ...click })
+    // The synthetic click is a compat bridge to legacy onClick code. If that code throws (a bug, or
+    // an env-gated API like navigator.clipboard on an insecure origin), it must NOT abort the
+    // semantic path — assistive tech still needs the activation announcement below. Surface, continue.
+    try {
+      component.dispatchEvent({ type: 'click', ...click })
+    } catch (error) {
+      console.error('[uikit a11y] a click handler threw during activation', error)
+    }
   }
 
   const wasToggled = properties.ariaChecked ?? properties.ariaPressed

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -129,6 +129,19 @@ export function getRootA11yContainer(root: RootContext): HTMLElement | undefined
   return rootContainers.get(root)?.element
 }
 
+/**
+ * Move a hidden element into the per-root a11y container and neutralize any own left/top offset, so
+ * Mode 2 projection positions it uniformly by `transform`. Used by Input, whose `<input>` is created
+ * off-screen on `document.body` (text/input/hidden-input.ts) rather than by setupComponentA11y.
+ * Returns a detach that releases the container refcount.
+ */
+export function attachA11yElementToRoot(root: RootContext, element: HTMLElement): () => void {
+  acquireRootContainer(root).appendChild(element)
+  element.style.left = '0'
+  element.style.top = '0'
+  return () => releaseRootContainer(root)
+}
+
 // ——— per-root a11y member registry (component → its hidden element) ———
 // Mode 2 projection enumerates these to position each element over its panel every frame. Both the
 // role-driven elements (setupComponentA11y) and Input's own hidden <input> register here, since

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -161,6 +161,8 @@ export function registerA11yMember(
     rootMembers.set(root, map)
   }
   map.set(component, element)
+  // Nudge a frame so a member added after the projection started gets positioned on-demand.
+  root.requestFrame?.()
   return () => {
     const current = rootMembers.get(root)
     if (current != null && current.get(component) === element) {

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -124,6 +124,46 @@ function releaseRootContainer(root: RootContext): void {
   }
 }
 
+/** The per-root `[data-uikit-a11y]` container, if one exists — the Mode 2 projection overlays it. */
+export function getRootA11yContainer(root: RootContext): HTMLElement | undefined {
+  return rootContainers.get(root)?.element
+}
+
+// ——— per-root a11y member registry (component → its hidden element) ———
+// Mode 2 projection enumerates these to position each element over its panel every frame. Both the
+// role-driven elements (setupComponentA11y) and Input's own hidden <input> register here, since
+// Input opts out of setupComponentA11y but still needs projecting.
+
+const rootMembers = /* @__PURE__ */ new WeakMap<RootContext, Map<Component, HTMLElement>>()
+
+/** Register a component's hidden element under its root for projection; returns an unregister fn. */
+export function registerA11yMember(
+  root: RootContext,
+  component: Component,
+  element: HTMLElement
+): () => void {
+  let map = rootMembers.get(root)
+  if (map == null) {
+    map = new Map()
+    rootMembers.set(root, map)
+  }
+  map.set(component, element)
+  return () => {
+    const current = rootMembers.get(root)
+    if (current != null && current.get(component) === element) {
+      current.delete(component)
+      if (current.size === 0) {
+        rootMembers.delete(root)
+      }
+    }
+  }
+}
+
+/** Live (component → hidden element) map for a root — read by setupA11yProjection each frame. */
+export function getRootA11yMembers(root: RootContext): ReadonlyMap<Component, HTMLElement> | undefined {
+  return rootMembers.get(root)
+}
+
 // Minimal structural shape both a Component's properties and Input's share.
 type A11yNameSource = {
   readonly value: { ariaLabel?: string; ariaDescription?: string }
@@ -179,6 +219,7 @@ export function setupComponentA11y(component: Component, abortSignal: AbortSigna
     const root = component.root.value
     acquireRootContainer(root).appendChild(element)
     component.a11yElement = element
+    const unregisterMember = registerA11yMember(root, component, element)
 
     const scoped = new AbortController()
 
@@ -211,6 +252,7 @@ export function setupComponentA11y(component: Component, abortSignal: AbortSigna
 
     return () => {
       scoped.abort()
+      unregisterMember()
       element.removeEventListener('click', onClick)
       element.remove()
       if (component.a11yElement === element) {

--- a/packages/uikit/src/a11y/index.ts
+++ b/packages/uikit/src/a11y/index.ts
@@ -2,6 +2,8 @@ export type { A11yActivationSource, A11yActivationEvent } from './activation.js'
 export { dispatchActivation } from './activation.js'
 export type { A11yRole } from './hidden-element.js'
 export { createHtmlA11yElement, setupComponentA11y, setupAriaAttributes } from './hidden-element.js'
+export type { A11yScreenRect, A11yViewport, A11yProjectionOptions } from './projection.js'
+export { computeA11yScreenRect, setupA11yProjection } from './projection.js'
 export type {
   Politeness,
   Announcement,

--- a/packages/uikit/src/a11y/projection.ts
+++ b/packages/uikit/src/a11y/projection.ts
@@ -1,5 +1,7 @@
 import { Vector3 } from 'three'
 import type { Camera, Matrix4 } from 'three'
+import type { Component } from '../components/component.js'
+import { getRootA11yContainer, getRootA11yMembers } from './hidden-element.js'
 
 /** Axis-aligned bounding rect of a projected panel, in canvas-local CSS px. */
 export interface A11yScreenRect {
@@ -74,4 +76,101 @@ export function computeA11yScreenRect(
   }
 
   return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+}
+
+/** Off-screen fallback (matches hidden-element.ts) restored when no projection is active. */
+const CONTAINER_OFFSCREEN = 'position:absolute;top:0;left:-1000vw;'
+/** Overlay the canvas: absolutely-positioned children then place from the viewport origin. */
+const CONTAINER_OVERLAY = 'position:fixed;top:0;left:0;'
+/** Skip a style write unless the rect moved at least this many px (avoids per-frame reflow churn). */
+const RECT_EPSILON = 1
+
+export interface A11yProjectionOptions {
+  camera: Camera
+  /** Only `domElement` is read (for its on-page rect) — accepts a full three renderer. */
+  renderer: { domElement: HTMLElement }
+}
+
+/**
+ * Mode 2 projection (spec §3): each frame, position every hidden a11y element under `rootComponent`
+ * over its panel's on-screen rect, so assistive tech, tab focus, and switch access hit-test the real
+ * panel location. Registers into the root's per-frame pump; returns a dispose that unregisters and
+ * restores the off-screen container fallback. SSR/degenerate frames hide the element rather than
+ * mis-place it.
+ */
+export function setupA11yProjection(
+  rootComponent: Component,
+  { camera, renderer }: A11yProjectionOptions
+): () => void {
+  const root = rootComponent.root.peek()
+  const container = getRootA11yContainer(root)
+  if (container != null) {
+    container.style.cssText = CONTAINER_OVERLAY
+  }
+  const lastRects = new WeakMap<HTMLElement, A11yScreenRect>()
+
+  const onFrame = (): void => {
+    const members = getRootA11yMembers(root)
+    if (members == null || members.size === 0) {
+      return
+    }
+    camera.updateMatrixWorld()
+    // Refresh the root's world matrix once; each member recomputes its own below.
+    rootComponent.updateWorldMatrix(true, false)
+    const canvasRect = renderer.domElement.getBoundingClientRect()
+    const viewport = {
+      x: canvasRect.left,
+      y: canvasRect.top,
+      width: canvasRect.width,
+      height: canvasRect.height,
+    }
+    for (const [component, element] of members) {
+      if (component !== rootComponent) {
+        component.updateWorldMatrix(false, false)
+      }
+      applyRect(element, computeA11yScreenRect(component.matrixWorld, camera, viewport), lastRects)
+    }
+  }
+
+  root.onFrameSet.add(onFrame)
+  root.requestFrame?.()
+
+  return () => {
+    root.onFrameSet.delete(onFrame)
+    const c = getRootA11yContainer(root)
+    if (c != null) {
+      c.style.cssText = CONTAINER_OFFSCREEN
+    }
+  }
+}
+
+function applyRect(
+  element: HTMLElement,
+  rect: A11yScreenRect | null,
+  lastRects: WeakMap<HTMLElement, A11yScreenRect>
+): void {
+  if (rect == null || rect.w <= 0 || rect.h <= 0) {
+    if (element.style.visibility !== 'hidden') {
+      element.style.visibility = 'hidden'
+    }
+    return
+  }
+  const last = lastRects.get(element)
+  const moved =
+    last == null ||
+    Math.abs(last.x - rect.x) > RECT_EPSILON ||
+    Math.abs(last.y - rect.y) > RECT_EPSILON ||
+    Math.abs(last.w - rect.w) > RECT_EPSILON ||
+    Math.abs(last.h - rect.h) > RECT_EPSILON
+  if (element.style.visibility === 'hidden') {
+    element.style.visibility = 'visible'
+  }
+  if (!moved) {
+    return
+  }
+  lastRects.set(element, rect)
+  // transform (not left/top) so positioning stays off the layout path; width/height size the target.
+  element.style.transform = `translate(${rect.x}px, ${rect.y}px)`
+  element.style.width = `${rect.w}px`
+  element.style.height = `${rect.h}px`
 }

--- a/packages/uikit/src/a11y/projection.ts
+++ b/packages/uikit/src/a11y/projection.ts
@@ -1,0 +1,77 @@
+import { Vector3 } from 'three'
+import type { Camera, Matrix4 } from 'three'
+
+/** Axis-aligned bounding rect of a projected panel, in canvas-local CSS px. */
+export interface A11yScreenRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** Canvas rect in CSS px — x/y are the page offset of the canvas. */
+export interface A11yViewport {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// Module-scoped scratch vectors — computeA11yScreenRect runs per panel per frame, so it must not
+// allocate. c0..c3 hold the four unit-quad corners through world space and projection; viewHelper
+// holds the camera-space position for the behind-camera guard.
+const c0 = new Vector3()
+const c1 = new Vector3()
+const c2 = new Vector3()
+const c3 = new Vector3()
+const corners = [c0, c1, c2, c3] as const
+const viewHelper = new Vector3()
+
+/**
+ * Projects a uikit panel's world matrix to its enclosing screen-space AABB in canvas-local px.
+ *
+ * The matrix already maps the UNIT quad (corners at ±0.5, z = 0) to world space — panel size and
+ * pixelSize are baked in upstream (see panel/instance/matrix.ts), so the corners are used as-is.
+ * Returns null when any corner sits at/behind the camera plane (the rect is unreliable when the
+ * panel straddles the camera) or when projection yields a non-finite coordinate.
+ */
+export function computeA11yScreenRect(
+  panelWorldMatrix: Matrix4,
+  camera: Camera,
+  viewport: A11yViewport
+): A11yScreenRect | null {
+  c0.set(-0.5, -0.5, 0)
+  c1.set(0.5, -0.5, 0)
+  c2.set(-0.5, 0.5, 0)
+  c3.set(0.5, 0.5, 0)
+
+  // Behind-camera guard for all corners BEFORE projecting — three cameras look down -Z, and
+  // Vector3.project mutates the corner via the perspective divide.
+  for (const corner of corners) {
+    corner.applyMatrix4(panelWorldMatrix)
+    viewHelper.copy(corner).applyMatrix4(camera.matrixWorldInverse)
+    if (viewHelper.z > -1e-6) {
+      return null
+    }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const corner of corners) {
+    corner.project(camera)
+    const sx = viewport.x + ((corner.x + 1) / 2) * viewport.width
+    // NDC y flips: +1 is the top of the screen.
+    const sy = viewport.y + ((1 - corner.y) / 2) * viewport.height
+    if (!Number.isFinite(sx) || !Number.isFinite(sy)) {
+      return null
+    }
+    if (sx < minX) minX = sx
+    if (sx > maxX) maxX = sx
+    if (sy < minY) minY = sy
+    if (sy > maxY) maxY = sy
+  }
+
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+}

--- a/packages/uikit/src/a11y/projection.ts
+++ b/packages/uikit/src/a11y/projection.ts
@@ -103,10 +103,6 @@ export function setupA11yProjection(
   { camera, renderer }: A11yProjectionOptions
 ): () => void {
   const root = rootComponent.root.peek()
-  const container = getRootA11yContainer(root)
-  if (container != null) {
-    container.style.cssText = CONTAINER_OVERLAY
-  }
   const lastRects = new WeakMap<HTMLElement, A11yScreenRect>()
 
   const onFrame = (): void => {
@@ -114,8 +110,16 @@ export function setupA11yProjection(
     if (members == null || members.size === 0) {
       return
     }
-    camera.updateMatrixWorld()
-    // Refresh the root's world matrix once; each member recomputes its own below.
+    // Overlay the container here rather than once at setup: it may be (re)created only after the
+    // first role/input mounts, so it can start in the off-screen fallback and must be flipped once
+    // it exists (else every projected element sits inside a -1000vw parent).
+    const container = getRootA11yContainer(root)
+    if (container != null && container.style.position !== 'fixed') {
+      container.style.cssText = CONTAINER_OVERLAY
+    }
+    // Update the camera's full world chain (it may sit under a moving rig) and the root once; each
+    // member recomputes its own world matrix below.
+    camera.updateWorldMatrix(true, false)
     rootComponent.updateWorldMatrix(true, false)
     const canvasRect = renderer.domElement.getBoundingClientRect()
     const viewport = {
@@ -125,6 +129,12 @@ export function setupA11yProjection(
       height: canvasRect.height,
     }
     for (const [component, element] of members) {
+      // A clipped/hidden/not-yet-laid-out panel must not be projected — hide its element instead of
+      // stranding it (a missing globalPanelMatrix would otherwise place it at the root origin).
+      if (!component.isVisible.peek() || component.globalPanelMatrix.peek() == null) {
+        applyRect(element, null, lastRects)
+        continue
+      }
       if (component !== rootComponent) {
         component.updateWorldMatrix(false, false)
       }
@@ -132,11 +142,13 @@ export function setupA11yProjection(
     }
   }
 
-  root.onFrameSet.add(onFrame)
+  // onFrameEndSet runs AFTER every onFrameSet handler (layout, scroll, component frames) in the same
+  // update() pass, so projection reads matrices that have already settled this frame — no 1-frame lag.
+  root.onFrameEndSet.add(onFrame)
   root.requestFrame?.()
 
   return () => {
-    root.onFrameSet.delete(onFrame)
+    root.onFrameEndSet.delete(onFrame)
     const c = getRootA11yContainer(root)
     if (c != null) {
       c.style.cssText = CONTAINER_OFFSCREEN

--- a/packages/uikit/src/components/input.ts
+++ b/packages/uikit/src/components/input.ts
@@ -22,7 +22,7 @@ import {
   setupHtmlInputElement,
   setupUpdateHasFocus,
 } from '../text/input/hidden-input.js'
-import { setupAriaAttributes } from '../a11y/hidden-element.js'
+import { registerA11yMember, setupAriaAttributes } from '../a11y/hidden-element.js'
 import type { RenderContext } from '../context.js'
 import type { NumberValue } from '../properties/values.js'
 export const inputOutPropertiesSchema = /* @__PURE__ */ defineSchema(() =>
@@ -196,7 +196,11 @@ export class Input<
     // the same as a base component's hidden element.
     setupAriaAttributes(this.properties, this.element, this.abortSignal)
     this.a11yElement = this.element
+    // Register with the per-root projection registry (Input opts out of setupComponentA11y, which
+    // would otherwise do this) so Mode 2 projection positions the hidden <input> over the field.
+    const unregisterA11yMember = registerA11yMember(this.root.peek(), this, this.element)
     this.abortSignal.addEventListener('abort', () => {
+      unregisterA11yMember()
       if (this.a11yElement === this.element) {
         this.a11yElement = undefined
       }

--- a/packages/uikit/src/components/input.ts
+++ b/packages/uikit/src/components/input.ts
@@ -22,7 +22,11 @@ import {
   setupHtmlInputElement,
   setupUpdateHasFocus,
 } from '../text/input/hidden-input.js'
-import { registerA11yMember, setupAriaAttributes } from '../a11y/hidden-element.js'
+import {
+  attachA11yElementToRoot,
+  registerA11yMember,
+  setupAriaAttributes,
+} from '../a11y/hidden-element.js'
 import type { RenderContext } from '../context.js'
 import type { NumberValue } from '../properties/values.js'
 export const inputOutPropertiesSchema = /* @__PURE__ */ defineSchema(() =>
@@ -196,11 +200,15 @@ export class Input<
     // the same as a base component's hidden element.
     setupAriaAttributes(this.properties, this.element, this.abortSignal)
     this.a11yElement = this.element
-    // Register with the per-root projection registry (Input opts out of setupComponentA11y, which
-    // would otherwise do this) so Mode 2 projection positions the hidden <input> over the field.
+    // Input opts out of setupComponentA11y, so wire its hidden <input> into the projection path
+    // directly: relocate it from its off-screen document.body spot into the per-root overlay
+    // container and register it, so Mode 2 projection positions it over the field like any role
+    // element. (createHtmlInputElement parented it to document.body at left:-1000vw.)
+    const detachA11yElement = attachA11yElementToRoot(this.root.peek(), this.element)
     const unregisterA11yMember = registerA11yMember(this.root.peek(), this, this.element)
     this.abortSignal.addEventListener('abort', () => {
       unregisterA11yMember()
+      detachA11yElement()
       if (this.a11yElement === this.element) {
         this.a11yElement = undefined
       }

--- a/packages/uikit/src/react/build.tsx
+++ b/packages/uikit/src/react/build.tsx
@@ -4,6 +4,7 @@ import {
   type RenderContext,
   reversePainterSortStable,
 } from '../index.js'
+import { setupA11yProjection } from '../a11y/index.js'
 import { effect } from '@preact/signals-core'
 import { extend, useFrame, useThree, type Instance, applyProps } from '@react-three/fiber'
 import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from 'react'
@@ -77,6 +78,7 @@ export function useSetup(ref: { current: Component | null }, inProps: any, args:
     component.update(delta * 1000)
   })
   const renderer = useThree((s) => s.gl)
+  const camera = useThree((s) => s.camera)
   useEffect(() => {
     // no `renderer.localClippingEnabled` — that flag exists only on the legacy
     // WebGLRenderer; the common (WebGPU) renderer clips exclusively through
@@ -84,6 +86,16 @@ export function useSetup(ref: { current: Component | null }, inProps: any, args:
     // materials' own coverage-multiply clip paths.
     renderer.setTransparentSort(reversePainterSortStable)
   }, [renderer])
+  useEffect(() => {
+    // Only the root component owns a projection — see the root guard in the
+    // per-frame pump above for why this check is load-bearing.
+    const component = ref.current
+    if (component == null || component.root.peek().component !== component) return
+    return setupA11yProjection(component, { camera, renderer })
+    // `ref` is a stable ref object, not a reactive dependency — camera/renderer
+    // identity changes are what should dispose-and-resetup the projection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [camera, renderer])
   useLayoutEffect(() => {
     ref.current?.resetProperties(inProps)
   })

--- a/packages/uikit/src/tests/a11y-activation.test.ts
+++ b/packages/uikit/src/tests/a11y-activation.test.ts
@@ -4,6 +4,7 @@ import { signal } from '@preact/signals-core'
 import { Object3D } from 'three'
 import { loadYoga } from 'yoga-layout/load'
 import { Container, Input } from '../index.js'
+import { registerAnnouncementBackend } from '../a11y/announce/announcer.js'
 
 /**
  * The semantic activation contract (spec §2), the load-bearing cross-mode path. Regression cover for
@@ -113,6 +114,28 @@ describe('semantic activation', () => {
       // onActivate ran and disabled the control mid-activation → the compat click is suppressed.
       expect(calls).toEqual(['activate'])
     } finally {
+      c.dispose()
+    }
+  })
+
+  it('still announces (and does not throw out of activate) when a legacy onClick throws', () => {
+    // Regression from the live probe: navigator.clipboard.writeText threw on an insecure origin
+    // inside the compat synthetic click, which aborted dispatchActivation before the announcement.
+    const announced: Array<string> = []
+    const unregister = registerAnnouncementBackend({ announce: (a) => announced.push(a.message) })
+    const c = mount({
+      role: 'button',
+      ariaLabel: 'Copy',
+      activationMessage: 'Copied 3 items',
+      onClick: () => {
+        throw new Error('boom')
+      },
+    })
+    try {
+      expect(() => c.activate()).not.toThrow()
+      expect(announced).toContain('Copied 3 items')
+    } finally {
+      unregister()
       c.dispose()
     }
   })

--- a/packages/uikit/src/tests/a11y-projection-dom.test.ts
+++ b/packages/uikit/src/tests/a11y-projection-dom.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D, PerspectiveCamera } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Container } from '../index.js'
+import { computeA11yScreenRect, setupA11yProjection } from '../a11y/projection.js'
+import { getRootA11yContainer, getRootA11yMembers } from '../a11y/hidden-element.js'
+
+/**
+ * Mode 2 projection integration through a real Container root: setupA11yProjection enumerates the
+ * per-root member registry, refreshes matrices each frame, and writes each hidden element's transform
+ * to exactly what the (independently oracle-tested) computeA11yScreenRect produces — hiding it when
+ * the panel is off-frustum, and restoring the off-screen container on dispose.
+ */
+
+beforeAll(async () => {
+  await loadYoga()
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+function mount(properties: ConstructorParameters<typeof Container>[0]): Container {
+  const container = new Container(properties)
+  new Object3D().add(container)
+  return container
+}
+
+function facingCamera() {
+  const cam = new PerspectiveCamera(90, 1, 0.1, 100)
+  cam.position.set(0, 0, 2)
+  cam.lookAt(0, 0, 0)
+  cam.updateMatrixWorld(true)
+  cam.updateProjectionMatrix()
+  return cam
+}
+
+// A stand-in renderer exposing only the on-page canvas rect the projection reads.
+function fakeRenderer(rect: { left: number; top: number; width: number; height: number }) {
+  return {
+    domElement: {
+      getBoundingClientRect: () => ({ ...rect, right: rect.left + rect.width, bottom: rect.top + rect.height }),
+    } as unknown as HTMLElement,
+  }
+}
+
+describe('setupA11yProjection', () => {
+  it('positions the hidden element over the panel with the math-core rect', () => {
+    const c = mount({ width: 100, height: 100, pixelSize: 0.01, role: 'button', ariaLabel: 'Go' })
+    const camera = facingCamera()
+    const viewport = { x: 0, y: 0, width: 100, height: 100 }
+    const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
+    try {
+      const root = c.root.peek()
+      // The container flips from the off-screen fallback to a canvas overlay.
+      expect(getRootA11yContainer(root)!.style.position).toBe('fixed')
+
+      c.update(0) // pump the frame
+
+      // Independently recompute the expected rect from the same matrix the projection used.
+      c.updateWorldMatrix(true, false)
+      const expected = computeA11yScreenRect(c.matrixWorld, camera, viewport)
+      expect(expected).not.toBeNull()
+
+      const el = c.a11yElement!
+      expect(el.style.visibility).not.toBe('hidden')
+      expect(el.style.transform).toBe(`translate(${expected!.x}px, ${expected!.y}px)`)
+      expect(el.style.width).toBe(`${expected!.w}px`)
+      expect(el.style.height).toBe(`${expected!.h}px`)
+    } finally {
+      dispose()
+      c.dispose()
+    }
+  })
+
+  it('offsets by the canvas page position', () => {
+    const c = mount({ width: 100, height: 100, pixelSize: 0.01, role: 'button', ariaLabel: 'Go' })
+    const camera = facingCamera()
+    const dispose = setupA11yProjection(c, {
+      camera,
+      renderer: fakeRenderer({ left: 40, top: 25, width: 100, height: 100 }),
+    })
+    try {
+      c.update(0)
+      c.updateWorldMatrix(true, false)
+      const expected = computeA11yScreenRect(c.matrixWorld, camera, { x: 40, y: 25, width: 100, height: 100 })
+      expect(expected).not.toBeNull()
+      expect(c.a11yElement!.style.transform).toBe(`translate(${expected!.x}px, ${expected!.y}px)`)
+    } finally {
+      dispose()
+      c.dispose()
+    }
+  })
+
+  it('hides the element when the panel is behind the camera', () => {
+    const c = mount({ width: 100, height: 100, pixelSize: 0.01, role: 'button', ariaLabel: 'Go' })
+    // Camera behind the panel, looking away — every corner is behind the camera plane.
+    const camera = new PerspectiveCamera(90, 1, 0.1, 100)
+    camera.position.set(0, 0, -2)
+    camera.lookAt(0, 0, -10)
+    camera.updateMatrixWorld(true)
+    camera.updateProjectionMatrix()
+    const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
+    try {
+      c.update(0)
+      expect(c.a11yElement!.style.visibility).toBe('hidden')
+    } finally {
+      dispose()
+      c.dispose()
+    }
+  })
+
+  it('restores the off-screen container fallback on dispose', () => {
+    const c = mount({ width: 100, height: 100, role: 'button', ariaLabel: 'Go' })
+    const camera = facingCamera()
+    const root = c.root.peek()
+    const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
+    expect(getRootA11yContainer(root)!.style.position).toBe('fixed')
+    dispose()
+    expect(getRootA11yContainer(root)!.style.left).toBe('-1000vw')
+    c.dispose()
+  })
+
+  it('drops a component from the member registry when it is disposed', () => {
+    const c = mount({ width: 100, height: 100, role: 'button', ariaLabel: 'Go' })
+    const root = c.root.peek()
+    expect(getRootA11yMembers(root)?.has(c)).toBe(true)
+    c.dispose()
+    expect(getRootA11yMembers(root)?.has(c) ?? false).toBe(false)
+  })
+})

--- a/packages/uikit/src/tests/a11y-projection-dom.test.ts
+++ b/packages/uikit/src/tests/a11y-projection-dom.test.ts
@@ -55,10 +55,11 @@ describe('setupA11yProjection', () => {
     const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
     try {
       const root = c.root.peek()
-      // The container flips from the off-screen fallback to a canvas overlay.
-      expect(getRootA11yContainer(root)!.style.position).toBe('fixed')
 
-      c.update(0) // pump the frame
+      c.update(0) // pump the frame (projection runs in onFrameEndSet)
+
+      // The container flips from the off-screen fallback to a canvas overlay once projection runs.
+      expect(getRootA11yContainer(root)!.style.position).toBe('fixed')
 
       // Independently recompute the expected rect from the same matrix the projection used.
       c.updateWorldMatrix(true, false)
@@ -118,10 +119,32 @@ describe('setupA11yProjection', () => {
     const camera = facingCamera()
     const root = c.root.peek()
     const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
+    c.update(0)
     expect(getRootA11yContainer(root)!.style.position).toBe('fixed')
     dispose()
     expect(getRootA11yContainer(root)!.style.left).toBe('-1000vw')
     c.dispose()
+  })
+
+  it('hides the element for a visibility:hidden panel instead of projecting it (codex #1)', () => {
+    const c = mount({
+      width: 100,
+      height: 100,
+      pixelSize: 0.01,
+      role: 'button',
+      ariaLabel: 'Go',
+      visibility: 'hidden',
+    })
+    const camera = facingCamera()
+    const dispose = setupA11yProjection(c, { camera, renderer: fakeRenderer({ left: 0, top: 0, width: 100, height: 100 }) })
+    try {
+      c.update(0)
+      // Not visible → not a tab target this frame, even though the panel is in front of the camera.
+      expect(c.a11yElement!.style.visibility).toBe('hidden')
+    } finally {
+      dispose()
+      c.dispose()
+    }
   })
 
   it('drops a component from the member registry when it is disposed', () => {

--- a/packages/uikit/src/tests/a11y-projection.test.ts
+++ b/packages/uikit/src/tests/a11y-projection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { Matrix4, PerspectiveCamera } from 'three'
+import { computeA11yScreenRect } from '../a11y/projection.js'
+import type { A11yViewport } from '../a11y/projection.js'
+
+/**
+ * Oracle values computed by three.js itself (PerspectiveCamera 90deg fov, aspect 1, at z=2 looking
+ * at origin). The panelWorldMatrix maps the UNIT quad (corners at +/-0.5, z=0) to world space —
+ * size x pixelSize is already baked in, so a 2x2 world-unit panel is makeScale(2, 2, 1).
+ */
+
+function makeCamera() {
+  const cam = new PerspectiveCamera(90, 1, 0.1, 100)
+  cam.position.set(0, 0, 2)
+  cam.lookAt(0, 0, 0)
+  cam.updateMatrixWorld(true)
+  cam.updateProjectionMatrix()
+  return cam
+}
+
+const viewport: A11yViewport = { x: 0, y: 0, width: 100, height: 100 }
+
+function expectRectClose(
+  actual: { x: number; y: number; w: number; h: number } | null,
+  expected: { x: number; y: number; w: number; h: number }
+) {
+  expect(actual).not.toBeNull()
+  expect(Math.abs(actual!.x - expected.x)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(actual!.y - expected.y)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(actual!.w - expected.w)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(actual!.h - expected.h)).toBeLessThanOrEqual(0.5)
+}
+
+describe('computeA11yScreenRect', () => {
+  it('O1: projects a fronto-parallel 2x2 panel to the centered half-viewport rect', () => {
+    const cam = makeCamera()
+    const panel = new Matrix4().makeScale(2, 2, 1)
+    expectRectClose(computeA11yScreenRect(panel, cam, viewport), { x: 25, y: 25, w: 50, h: 50 })
+  })
+
+  it('O3: projects a panel tilted 60deg around Y', () => {
+    const cam = makeCamera()
+    const panel = new Matrix4()
+      .makeRotationY(Math.PI / 3)
+      .multiply(new Matrix4().makeScale(2, 2, 1))
+    expectRectClose(computeA11yScreenRect(panel, cam, viewport), {
+      x: 27.954,
+      y: 5.907,
+      w: 30.769,
+      h: 88.185,
+    })
+  })
+
+  it('O3b: projects a panel tilted 30deg around Y', () => {
+    const cam = makeCamera()
+    const panel = new Matrix4()
+      .makeRotationY(Math.PI / 6)
+      .multiply(new Matrix4().makeScale(2, 2, 1))
+    expectRectClose(computeA11yScreenRect(panel, cam, viewport), {
+      x: 21.132,
+      y: 16.667,
+      w: 46.188,
+      h: 66.667,
+    })
+  })
+
+  it('O2: returns null when the panel is behind the camera', () => {
+    const cam = makeCamera()
+    const panel = new Matrix4().makeTranslation(0, 0, 10).multiply(new Matrix4().makeScale(2, 2, 1))
+    expect(computeA11yScreenRect(panel, cam, viewport)).toBeNull()
+  })
+
+  it('offsets the rect by the viewport page position', () => {
+    const cam = makeCamera()
+    const offsetViewport: A11yViewport = { x: 50, y: 30, width: 100, height: 100 }
+    const panel = new Matrix4().makeScale(2, 2, 1)
+    expectRectClose(computeA11yScreenRect(panel, cam, offsetViewport), {
+      x: 75,
+      y: 55,
+      w: 50,
+      h: 50,
+    })
+  })
+
+  it('perf: 200 calls stay within the frame budget (asserted locally, logged in CI)', () => {
+    const cam = makeCamera()
+    const panel = new Matrix4()
+      .makeRotationY(Math.PI / 6)
+      .multiply(new Matrix4().makeScale(2, 2, 1))
+    // warmup
+    for (let i = 0; i < 1000; i++) {
+      computeA11yScreenRect(panel, cam, viewport)
+    }
+    const iterations = 500
+    const callsPerIteration = 200
+    const start = performance.now()
+    for (let iter = 0; iter < iterations; iter++) {
+      for (let i = 0; i < callsPerIteration; i++) {
+        computeA11yScreenRect(panel, cam, viewport)
+      }
+    }
+    const avgMsPer200Calls = (performance.now() - start) / iterations
+    // eslint-disable-next-line no-console
+    console.log(
+      `computeA11yScreenRect: ${avgMsPer200Calls.toFixed(4)} ms per 200 calls (avg of ${iterations})`
+    )
+    if (process.env.CI == null) {
+      expect(avgMsPer200Calls).toBeLessThanOrEqual(0.2)
+    }
+  })
+})


### PR DESCRIPTION
### **User description**
## Native a11y — Phase 1: Mode 2 projection (stacked on Phase 0 #182)

Positions a hidden native DOM element over each uikit panel's on-screen rect **every frame**, so screen readers, tab focus, and switch access hit-test the real panel location — the screen-space half of the 4-mode a11y design. Auto-wired in React: any R3F uikit tree gets it with zero user code.

### What shipped

- **Projection math** (`a11y/projection.ts` · `computeA11yScreenRect`) — projects a panel's world matrix (the unit quad, `size × pixelSize` already baked into `globalPanelMatrix`) through the camera to its enclosing screen-space AABB in canvas px; behind-camera → `null`. Oracle-tested against fixtures computed by three.js itself.
- **Per-frame projection** (`setupA11yProjection`) — registered in the root's `onFrameEndSet` (after layout/scroll settle); positions each registered element via `transform` (off the layout path) with a 1px write epsilon; overlays the per-root `[data-uikit-a11y]` container; hides clipped/off-frustum panels.
- **Per-root member registry** (`a11y/hidden-element.ts`) — both role-driven elements and Input's hidden `<input>` register, so projection reaches every interactive element. Input's `<input>` relocated from `document.body` into the overlay container.
- **React auto-wiring** (`react/build.tsx`) — `useSetup` registers projection for the root component from the R3F camera + canvas.
- **Dogfood** — `uikit-default` Button gets `role: 'button'`; the lucide icon-browser toolbar gets accessible names, a Copy `activationMessage`, and focus rings; a dev `window.__uikitA11yDebug` hook exposes projected-vs-panel rects.

### Adversarial review (Codex `gpt-5.5`)

Found 4 real integration bugs — **all fixed** in `ee8d36d5` (re-derived against source, not rubber-stamped):

| # | Issue | Fix |
|---|-------|-----|
| 1 | projected clipped/invisible/unlaid-out panels (missing matrix → root origin) | hide when `!isVisible` or `globalPanelMatrix == null` |
| 2 | overlay style applied once at setup → a container created *later* stayed at `-1000vw`, stranding every element off-screen | re-apply overlay each frame once the container exists; request a frame on member register |
| 3 | ran in `onFrameSet` before scroll/layout handlers → 1-frame lag on kinetic scroll | moved to `onFrameEndSet` |
| 5 | `camera.updateMatrixWorld()` ignored camera ancestors | `camera.updateWorldMatrix(true, false)` |

Codex confirmed the core math, behind-camera guard, fixed-overlay-vs-scroll, and the T1.2 ref timing are correct. Deferred: #4 Input reparent-across-roots reactivity (rare; screen-space Input stays in one root — tracked for Phase 3 diegetic).

### Live browser probe (the load-bearing gate) — GREEN

Ran against the lucide icon-browser example in a real browser (WebGL2 fallback backend):

- **3** `[data-uikit-a11y] button`s, each with a non-empty accessible name (`Select all 1594 icons` / `Copy manifest` / `Clear selection`).
- **IoU = 1.00** on all three between the projected hidden-element rect and the independently-recomputed panel rect (gate was ≥ 0.90) — pixel-perfect overlay.
- Focus lands on each (`document.activeElement`).
- Activating the hidden **Select all** enabled Copy/Clear (full activation → `onClick` path), and activating **Copy** put `Copied 1594 icons` into the `aria-live` region.

The probe also earned its keep: it surfaced a robustness bug (`c120c746`) unit tests missed — a legacy `onClick` throwing (here `navigator.clipboard` undefined on the probe's insecure origin) aborted `dispatchActivation` before the announcement, silencing assistive tech. The compat synthetic click is now isolated in try/catch so the announce always fires.

### Gate

- `tsc --noEmit` clean (uikit, uikit-default, example)
- `pnpm lint` — 0 errors
- **130 uikit tests** (projection math oracles, projection DOM integration incl. visibility/late-mount/registry, activation contract, announcer, hidden-element, schema)
- Live probe green (above)

https://claude.ai/code/session_01VSsxMZfAcro1QjCshpnbXf


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Add Mode 2 a11y projection subsystem to position hidden native elements over their panels every frame
  - `computeA11yScreenRect` projects a panel's world matrix to screen-space AABB in canvas px
  - `setupA11yProjection` runs in the root’s per‑frame pump, applies transform-based positioning, and hides off‑frustum/visibility‑hidden panels

- Wire all interactive elements into a per‑root member registry for the projection system
  - `registerA11yMember`/`getRootA11yMembers` enable role‑driven elements and Input’s hidden `<input>` to be discovered
  - Input’s hidden `<input>` is relocated from `document.body` into the overlay container

- Auto‑wire projection in React via `useSetup` in `build.tsx` — zero user code needed for R3F trees

- Harden activation dispatch: catch errors in the compat synthetic click so the announcer still fires

- Dogfood icon browser toolbar with `ariaLabel`, `activationMessage`, focus rings, and a dev debug hook

- Add projection math oracle tests and DOM integration tests for the overlay lifecycle


___

### Diagram Walkthrough


```mermaid
flowchart LR
  C["Component"] -- "creates hidden element" --> HE["setupComponentA11y"]
  HE -- "registers" --> REG["registerA11yMember"]
  I["Input"] -- "owns hidden <input>" --> ATT["attachA11yElementToRoot + registerA11yMember"]
  ATT --> REG
  RC["Root Component"] -- "useSetup" --> PJ["setupA11yProjection"]
  PJ --> FRAME["Per‑frame pump"]
  FRAME --> MEMBERS["getRootA11yMembers"]
  MEMBERS --> PROJ["computeA11yScreenRect"]
  PROJ --> POS["applyRect (transform, size, visibility)"]
  POS --> EL["Hidden native element updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>projection.ts</strong><dd><code>New: projection math and per‑frame overlay engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-f5b186c1d0c24da1e19866004191bd736a606def7dd5eddb7aeaa1831d3418e8">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hidden-element.ts</strong><dd><code>Add per‑root member registry and container helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-c5d14b68277bc275fe65779369cca496dfdd88d5bd4e1b4ef31c78aff2a3de96">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export projection APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-67e4c24c825269785ffd228d63b38bc5415734ea6cc942ce439ca5702cfcea4b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.tsx</strong><dd><code>Auto‑wire setupA11yProjection for root component in R3F</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-83bcc1c60123081a08e372a471e36a19a14e8e4b364ee5ef57a320b477f3f6d4">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input.ts</strong><dd><code>Integrate Input’s hidden `<input>` into projection member registry</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-de9dec659ce2984709075f91f9b5165d1fdce72570668321b99b35ed9bc762a3">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Default Button to `role: 'button'`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-1e75dda48cce44aeb359809de98e304760de3da3f022d28591738115af1c7f4d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Dogfood toolbar buttons with a11y names, activation message, focus </code><br><code>rings, and debug hook</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-67e012235f65deb29b878ed4b306e836b88a3f286018e248f2dd4812730ba9a1">+67/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>activation.ts</strong><dd><code>Wrap compat synthetic click in try/catch to keep announcer alive</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-2789fd00c020bb4deee71f40da572975170874c37e3b71bd867fffd0796e7ddd">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>a11y-projection.test.ts</strong><dd><code>Oracle tests for computeA11yScreenRect math</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-0255afed87d709edbacb19a0b7677215744c892e6f32eb3c0322de415f6a46b4">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>a11y-projection-dom.test.ts</strong><dd><code>DOM integration tests for setupA11yProjection overlay and member </code><br><code>lifecycle</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-1dd6baf35dca6b6797411a646e4f4ad12047d924f8596e3b28fd58452e645cd9">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>a11y-activation.test.ts</strong><dd><code>Test that a throwing onClick does not abort activation announcement</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/183/files#diff-a8d4285827002f6a10d55947b3da53f555f5a7e3f210706ccdfa8a9387340ab9">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

