### PR TITLE
feat(uikit): native a11y Phase 2 — widgets + virtualized listbox

### DIFF
--- a/examples/react/uikit/App.tsx
+++ b/examples/react/uikit/App.tsx
@@ -472,13 +472,13 @@ function GameMenu({ font }: { font: SlugFont }) {
       {/* Tabs */}
       <Tabs defaultValue="play">
         <TabsList width="100%">
-          <TabsTrigger value="play" flexGrow={1}>
+          <TabsTrigger value="play" flexGrow={1} ariaLabel="Play tab">
             <Text>Play</Text>
           </TabsTrigger>
-          <TabsTrigger value="loadout" flexGrow={1}>
+          <TabsTrigger value="loadout" flexGrow={1} ariaLabel="Loadout tab">
             <Text>Loadout</Text>
           </TabsTrigger>
-          <TabsTrigger value="settings" flexGrow={1}>
+          <TabsTrigger value="settings" flexGrow={1} ariaLabel="Settings tab">
             <Text>Settings</Text>
           </TabsTrigger>
         </TabsList>
@@ -487,22 +487,28 @@ function GameMenu({ font }: { font: SlugFont }) {
         <TabsContent value="play" flexDirection="column" gap={14}>
           <Container flexDirection="column" gap={6}>
             <Labeled>Player Name</Labeled>
-            <Input placeholder="Enter your name" defaultValue="Ranger" fontSize={14} width="100%" />
+            <Input
+              placeholder="Enter your name"
+              defaultValue="Ranger"
+              fontSize={14}
+              width="100%"
+              ariaLabel="Player Name"
+            />
           </Container>
           <Container flexDirection="column" gap={8}>
             <Labeled>Difficulty</Labeled>
-            <RadioGroup defaultValue="normal" flexDirection="row" gap={16}>
-              <RadioGroupItem value="easy">
+            <RadioGroup defaultValue="normal" flexDirection="row" gap={16} ariaLabel="Difficulty">
+              <RadioGroupItem value="easy" ariaLabel="Easy">
                 <Text color={WHITE} fontSize={14}>
                   Easy
                 </Text>
               </RadioGroupItem>
-              <RadioGroupItem value="normal">
+              <RadioGroupItem value="normal" ariaLabel="Normal">
                 <Text color={WHITE} fontSize={14}>
                   Normal
                 </Text>
               </RadioGroupItem>
-              <RadioGroupItem value="hardcore">
+              <RadioGroupItem value="hardcore" ariaLabel="Hardcore">
                 <Text color={WHITE} fontSize={14}>
                   Hardcore
                 </Text>
@@ -595,6 +601,7 @@ function GameMenu({ font }: { font: SlugFont }) {
               max={100}
               step={1}
               onValueChange={(v) => masterValueRef.current?.setProperties({ text: `${v}` })}
+              ariaLabel="Master Volume"
             />
           </Container>
           <Container flexDirection="column" gap={6}>
@@ -613,14 +620,15 @@ function GameMenu({ font }: { font: SlugFont }) {
               max={100}
               step={1}
               onValueChange={(v) => musicValueRef.current?.setProperties({ text: `${v}` })}
+              ariaLabel="Music Volume"
             />
           </Container>
           <Container flexDirection="row" justifyContent="space-between" alignItems="center">
             <Labeled>Fullscreen</Labeled>
-            <Switch defaultChecked={true} />
+            <Switch defaultChecked={true} ariaLabel="Fullscreen" />
           </Container>
           <Container flexDirection="row" gap={10} alignItems="center">
-            <Checkbox defaultChecked={true} />
+            <Checkbox defaultChecked={true} ariaLabel="V-Sync" />
             <Labeled>V-Sync</Labeled>
           </Container>
         </TabsContent>
@@ -645,7 +653,12 @@ function GameMenu({ font }: { font: SlugFont }) {
           a visible press-down is both game-feel and a regression guard for
           that path. */}
       <Container flexDirection="row" gap={12} width="100%">
-        <Button gap={8} flexGrow={1} active={{ transformTranslateY: 1, opacity: 0.85 }}>
+        <Button
+          gap={8}
+          flexGrow={1}
+          active={{ transformTranslateY: 1, opacity: 0.85 }}
+          ariaLabel="Play"
+        >
           <Play width={16} height={16} />
           <Text>Play</Text>
         </Button>
@@ -654,6 +667,7 @@ function GameMenu({ font }: { font: SlugFont }) {
           gap={8}
           flexGrow={1}
           active={{ transformTranslateY: 1, opacity: 0.85 }}
+          ariaLabel="Quit"
         >
           <X width={16} height={16} />
           <Text>Quit</Text>

--- a/examples/three/uikit/main.ts
+++ b/examples/three/uikit/main.ts
@@ -17,6 +17,7 @@ import {
   withOpacity,
   setPreferredColorScheme,
   attachCanvasInputProps,
+  setupA11yProjection,
 } from '@three-flatland/uikit'
 import type { RenderContext, ContainerProperties, TextProperties } from '@three-flatland/uikit'
 import {
@@ -322,6 +323,7 @@ const SAVE_SLOTS: Array<{ name: string; stamp: string; level: string }> = [
 let rafId = 0
 let activeRenderer: WebGPURenderer | null = null
 let activePointerEvents: { destroy: () => void } | null = null
+let activeDisposeA11yProjection: (() => void) | null = null
 
 async function main() {
   // ─── Renderer ───────────────────────────────────────────────────
@@ -433,6 +435,17 @@ async function main() {
   const rt = buildMenu(ui)
   const anchorMenu = createMenuAnchor(ui, rt.panel)
   flatland.camera.add(ui)
+
+  // ─── Accessibility projection ────────────────────────────────────
+  // The React twin wires this up for free — `build.tsx`'s root binding calls
+  // `setupA11yProjection` itself inside a `useEffect` once `camera` + `renderer`
+  // are known. Vanilla three has no such lifecycle to hook, so the example must
+  // call it explicitly, once the root uikit component, camera, and renderer all
+  // exist. It re-projects every hidden a11y DOM element under `ui` onto its
+  // panel's on-screen rect each frame, so screen readers / tab focus / switch
+  // access hit-test the real, currently-visible location instead of an
+  // off-screen fallback.
+  activeDisposeA11yProjection = setupA11yProjection(ui, { camera: flatland.camera, renderer })
 
   // ─── Pointer events ─────────────────────────────────────────────
   // Vanilla three has no built-in raycast / event routing. `forwardHtmlEvents`
@@ -583,9 +596,15 @@ function buildMenu(ui: Fullscreen): Realtime {
     defaultValue: 'Ranger',
     fontSize: 14,
     width: '100%',
+    ariaLabel: 'Player Name',
   })
 
-  const difficulty = new RadioGroup({ defaultValue: 'normal', flexDirection: 'row', gap: 16 })
+  const difficulty = new RadioGroup({
+    defaultValue: 'normal',
+    flexDirection: 'row',
+    gap: 16,
+    ariaLabel: 'Difficulty',
+  })
   difficulty.add(
     radioOption('easy', 'Easy'),
     radioOption('normal', 'Normal'),
@@ -674,6 +693,7 @@ function buildMenu(ui: Fullscreen): Realtime {
     max: 100,
     step: 1,
     onValueChange: (v) => masterValue.setProperties({ text: `${v}` }),
+    ariaLabel: 'Master Volume',
   })
   const musicSlider = new Slider({
     defaultValue: 45,
@@ -681,6 +701,7 @@ function buildMenu(ui: Fullscreen): Realtime {
     max: 100,
     step: 1,
     onValueChange: (v) => musicValue.setProperties({ text: `${v}` }),
+    ariaLabel: 'Music Volume',
   })
 
   const settingsTab = new TabsContent({ value: 'settings', flexDirection: 'column', gap: 16 })
@@ -714,11 +735,11 @@ function buildMenu(ui: Fullscreen): Realtime {
     row(
       { justifyContent: 'space-between', alignItems: 'center' },
       labeled('Fullscreen'),
-      new Switch({ defaultChecked: true })
+      new Switch({ defaultChecked: true, ariaLabel: 'Fullscreen' })
     ),
     row(
       { gap: 10, alignItems: 'center' },
-      new Checkbox({ defaultChecked: true }),
+      new Checkbox({ defaultChecked: true, ariaLabel: 'V-Sync' }),
       labeled('V-Sync')
     )
   )
@@ -751,6 +772,7 @@ function buildMenu(ui: Fullscreen): Realtime {
     gap: 8,
     flexGrow: 1,
     active: { transformTranslateY: 1, opacity: 0.85 },
+    ariaLabel: 'Play',
   })
   playButton.add(new Play({ width: 16, height: 16 }), new Text({ text: 'Play' }))
   const quitButton = new Button({
@@ -758,6 +780,7 @@ function buildMenu(ui: Fullscreen): Realtime {
     gap: 8,
     flexGrow: 1,
     active: { transformTranslateY: 1, opacity: 0.85 },
+    ariaLabel: 'Quit',
   })
   quitButton.add(new X({ width: 16, height: 16 }), new Text({ text: 'Quit' }))
   const buttons = row({ gap: 12, width: '100%' }, playButton, quitButton)
@@ -787,13 +810,13 @@ function buildMenu(ui: Fullscreen): Realtime {
 }
 
 function radioOption(value: string, label: string): RadioGroupItem {
-  const item = new RadioGroupItem({ value })
+  const item = new RadioGroupItem({ value, ariaLabel: label })
   item.add(new Text({ text: label, color: WHITE, fontSize: 14 }))
   return item
 }
 
 function tabTrigger(value: string, label: string): TabsTrigger {
-  const trigger = new TabsTrigger({ value, flexGrow: 1 })
+  const trigger = new TabsTrigger({ value, flexGrow: 1, ariaLabel: `${label} tab` })
   trigger.add(new Text({ text: label }))
   return trigger
 }
@@ -809,6 +832,10 @@ if (import.meta.hot) {
     if (activePointerEvents) {
       activePointerEvents.destroy()
       activePointerEvents = null
+    }
+    if (activeDisposeA11yProjection) {
+      activeDisposeA11yProjection()
+      activeDisposeA11yProjection = null
     }
     if (activeRenderer) {
       activeRenderer.dispose?.()

--- a/packages/uikit-default/package.json
+++ b/packages/uikit-default/package.json
@@ -74,8 +74,10 @@
     "@react-three/fiber": "catalog:",
     "@types/react": "catalog:",
     "@types/three": "catalog:",
+    "happy-dom": "^20.8.9",
     "react": "catalog:",
-    "three": "catalog:"
+    "three": "catalog:",
+    "yoga-layout": "catalog:"
   },
   "keywords": [
     "three.js",

--- a/packages/uikit-default/src/accordion/item.ts
+++ b/packages/uikit-default/src/accordion/item.ts
@@ -7,7 +7,6 @@ import {
   type InProperties,
   type RenderContext,
 } from '@three-flatland/uikit'
-import { Accordion } from './index.js'
 import { colors, componentDefaults } from '../theme.js'
 export const AccordionItemOutPropertiesSchema = /* @__PURE__ */ defineSchema(() =>
   object({
@@ -41,18 +40,11 @@ export class AccordionItem extends Container<AccordionItemOutProperties> {
         '*': {
           borderColor: colors.border,
         },
-        cursor: 'pointer',
+        // AccordionTrigger owns activation (role: 'button' + onActivate) so pointer/keyboard/AT/XR
+        // all toggle through one handler. The item itself is a non-interactive layout wrapper — it
+        // must NOT also handle 'click', or the bubbled pointer click would re-toggle via this
+        // component's own activate() right after the trigger's already ran (open-then-close flicker).
         flexDirection: 'column',
-        onClick: () => {
-          const parent = this.parentContainer.peek()
-          if (!(parent instanceof Accordion)) {
-            return
-          }
-          const ownValue = this.properties.peek().value
-          const currentValue = parent.openItemValue.peek()
-          const isSelected = ownValue === currentValue
-          parent.openItemValue.value = isSelected ? undefined : ownValue
-        },
         borderBottomWidth: 1,
         ...config?.defaultOverrides,
       },

--- a/packages/uikit-default/src/accordion/trigger.test.ts
+++ b/packages/uikit-default/src/accordion/trigger.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Accordion, AccordionItem, AccordionTrigger } from './index.js'
+
+/**
+ * T2.5 — the accordion trigger wires the frozen a11y contract (spec §7): `role: 'button'`,
+ * `ariaExpanded` synced from the parent item's open state, and the expand/collapse toggle body
+ * moved onto the trigger's own `onActivate` (previously misplaced on `AccordionItem.onClick`, which
+ * would have double-fired once the trigger also handled activation — bubbled pointer clicks reach
+ * both) so pointer, keyboard, AT, and future XR activation all share one handler on the actual
+ * interactive element.
+ */
+
+function mount(openValue: string | undefined, itemValue: string) {
+  const accordion = new Accordion()
+  accordion.openItemValue.value = openValue
+  const item = new AccordionItem({ value: itemValue })
+  const trigger = new AccordionTrigger()
+  item.add(trigger)
+  accordion.add(item)
+  new Object3D().add(accordion)
+  return { accordion, item, trigger }
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('AccordionTrigger a11y wiring', () => {
+  it('mounts a hidden <button> with aria-expanded reflecting the parent item open state', () => {
+    const { accordion, item, trigger } = mount('a', 'a')
+    try {
+      const el = trigger.a11yElement
+      expect(el).toBeDefined()
+      expect(el!.tagName).toBe('BUTTON')
+      expect(el!.getAttribute('aria-expanded')).toBe('true')
+    } finally {
+      trigger.dispose()
+      item.dispose()
+      accordion.dispose()
+    }
+  })
+
+  it('aria-expanded is false when the trigger item is not the open item', () => {
+    const { accordion, item, trigger } = mount('other', 'a')
+    try {
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('false')
+    } finally {
+      trigger.dispose()
+      item.dispose()
+      accordion.dispose()
+    }
+  })
+
+  it('updates aria-expanded reactively when the accordion open value changes', () => {
+    const { accordion, item, trigger } = mount(undefined, 'a')
+    try {
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('false')
+      accordion.openItemValue.value = 'a'
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('true')
+      accordion.openItemValue.value = undefined
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('false')
+    } finally {
+      trigger.dispose()
+      item.dispose()
+      accordion.dispose()
+    }
+  })
+
+  it('clicking the hidden a11y element opens the item through activate() (uncontrolled toggle)', () => {
+    const { accordion, item, trigger } = mount(undefined, 'a')
+    try {
+      expect(accordion.openItemValue.peek()).toBeUndefined()
+
+      trigger.a11yElement!.click()
+      expect(accordion.openItemValue.peek()).toBe('a')
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('true')
+
+      trigger.a11yElement!.click()
+      expect(accordion.openItemValue.peek()).toBeUndefined()
+      expect(trigger.a11yElement!.getAttribute('aria-expanded')).toBe('false')
+    } finally {
+      trigger.dispose()
+      item.dispose()
+      accordion.dispose()
+    }
+  })
+
+  it('activating a different item swaps which item is open (single-open accordion)', () => {
+    const accordion = new Accordion()
+    const itemA = new AccordionItem({ value: 'a' })
+    const triggerA = new AccordionTrigger()
+    itemA.add(triggerA)
+    const itemB = new AccordionItem({ value: 'b' })
+    const triggerB = new AccordionTrigger()
+    itemB.add(triggerB)
+    accordion.add(itemA)
+    accordion.add(itemB)
+    new Object3D().add(accordion)
+    try {
+      triggerA.a11yElement!.click()
+      expect(accordion.openItemValue.peek()).toBe('a')
+
+      triggerB.a11yElement!.click()
+      expect(accordion.openItemValue.peek()).toBe('b')
+      expect(triggerA.a11yElement!.getAttribute('aria-expanded')).toBe('false')
+      expect(triggerB.a11yElement!.getAttribute('aria-expanded')).toBe('true')
+    } finally {
+      triggerA.dispose()
+      itemA.dispose()
+      triggerB.dispose()
+      itemB.dispose()
+      accordion.dispose()
+    }
+  })
+
+  it('the item no longer registers its own click handler (activation lives solely on the trigger)', () => {
+    const { accordion, item, trigger } = mount(undefined, 'a')
+    try {
+      expect(item.properties.peek().onClick).toBeUndefined()
+      expect(item.properties.peek().onActivate).toBeUndefined()
+    } finally {
+      trigger.dispose()
+      item.dispose()
+      accordion.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/accordion/trigger.ts
+++ b/packages/uikit-default/src/accordion/trigger.ts
@@ -3,10 +3,13 @@ import { ContainerPropertiesSchema } from '@three-flatland/uikit'
 import {
   type BaseOutProperties,
   Container,
-  type ContainerProperties,
   type InProperties,
   type RenderContext,
+  searchFor,
 } from '@three-flatland/uikit'
+import { computed } from '@preact/signals-core'
+import { Accordion } from './index.js'
+import { AccordionItem } from './item.js'
 import { colors, componentDefaults } from '../theme.js'
 export const AccordionTriggerPropertiesSchema = ContainerPropertiesSchema
 
@@ -27,6 +30,30 @@ export class AccordionTrigger extends Container {
       defaultOverrides: {
         '*': {
           borderColor: colors.border,
+        },
+        role: 'button',
+        ariaExpanded: computed(() => {
+          const item = searchFor(this, AccordionItem, 2)
+          if (item == null) {
+            return false
+          }
+          const accordion = searchFor(item, Accordion, 2)
+          return item.properties.value.value === accordion?.openItemValue.value
+        }),
+        cursor: 'pointer',
+        onActivate: () => {
+          const item = searchFor(this, AccordionItem, 2)
+          if (item == null) {
+            return
+          }
+          const accordion = searchFor(item, Accordion, 2)
+          if (accordion == null) {
+            return
+          }
+          const ownValue = item.properties.peek().value
+          const currentValue = accordion.openItemValue.peek()
+          const isSelected = ownValue === currentValue
+          accordion.openItemValue.value = isSelected ? undefined : ownValue
         },
         flexDirection: 'row',
         flexGrow: 1,

--- a/packages/uikit-default/src/checkbox/index.test.ts
+++ b/packages/uikit-default/src/checkbox/index.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Checkbox } from './index.js'
+
+/**
+ * T2.1 — the checkbox widget wires the frozen a11y contract (spec §7): `role: 'checkbox'`,
+ * `ariaChecked` synced from `currentSignal`, and the toggle body moved from `onClick` to
+ * `onActivate` so pointer, keyboard, AT, and future XR activation all share one handler.
+ */
+
+function mount(properties?: ConstructorParameters<typeof Checkbox>[0]): Checkbox {
+  const checkbox = new Checkbox(properties)
+  new Object3D().add(checkbox)
+  return checkbox
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('Checkbox a11y wiring', () => {
+  it('mounts a hidden <button role="checkbox"> with aria-checked reflecting currentSignal', () => {
+    const checkbox = mount()
+    try {
+      const el = checkbox.a11yElement
+      expect(el).toBeDefined()
+      expect(el!.tagName).toBe('BUTTON')
+      expect(el!.getAttribute('role')).toBe('checkbox')
+      expect(el!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      checkbox.dispose()
+    }
+  })
+
+  it('reflects defaultChecked in aria-checked on mount', () => {
+    const checkbox = mount({ defaultChecked: true })
+    try {
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('true')
+    } finally {
+      checkbox.dispose()
+    }
+  })
+
+  it('clicking the hidden a11y element flips the uncontrolled state through activate()', () => {
+    const onCheckedChange: Array<boolean> = []
+    const checkbox = mount({ onCheckedChange: (checked) => onCheckedChange.push(checked) })
+    try {
+      expect(checkbox.currentSignal.peek()).toBeUndefined()
+
+      checkbox.a11yElement!.click()
+      expect(checkbox.currentSignal.peek()).toBe(true)
+      expect(checkbox.uncontrolledSignal.peek()).toBe(true)
+      expect(onCheckedChange).toEqual([true])
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('true')
+
+      checkbox.a11yElement!.click()
+      expect(checkbox.currentSignal.peek()).toBe(false)
+      expect(onCheckedChange).toEqual([true, false])
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      checkbox.dispose()
+    }
+  })
+
+  it('does not flip local state when controlled (checked prop set) — only notifies via onCheckedChange', () => {
+    const onCheckedChange: Array<boolean> = []
+    const checkbox = mount({ checked: false, onCheckedChange: (checked) => onCheckedChange.push(checked) })
+    try {
+      checkbox.a11yElement!.click()
+      expect(checkbox.uncontrolledSignal.peek()).toBeUndefined()
+      expect(onCheckedChange).toEqual([true])
+      // Still reflects the controlled `checked` prop (false), not the requested toggle.
+      expect(checkbox.currentSignal.peek()).toBe(false)
+    } finally {
+      checkbox.dispose()
+    }
+  })
+
+  it('writing the checked signal updates the aria-checked attribute', () => {
+    const checkbox = mount()
+    try {
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('false')
+      checkbox.uncontrolledSignal.value = true
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('true')
+      checkbox.uncontrolledSignal.value = false
+      expect(checkbox.a11yElement!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      checkbox.dispose()
+    }
+  })
+
+  it('is a no-op when disabled — activation does not toggle state', () => {
+    const onCheckedChange: Array<boolean> = []
+    const checkbox = mount({ disabled: true, onCheckedChange: (checked) => onCheckedChange.push(checked) })
+    try {
+      checkbox.a11yElement!.click()
+      expect(onCheckedChange).toEqual([])
+      expect(checkbox.currentSignal.peek()).toBeUndefined()
+    } finally {
+      checkbox.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/checkbox/index.ts
+++ b/packages/uikit-default/src/checkbox/index.ts
@@ -58,7 +58,9 @@ export class Checkbox extends Container<CheckboxOutProperties> {
         alignItems: 'center',
         justifyContent: 'center',
         cursor: computed(() => (this.properties.value.disabled ? undefined : 'pointer')),
-        onClick: () => {
+        role: 'checkbox',
+        ariaChecked: computed(() => this.currentSignal.value ?? false),
+        onActivate: () => {
           if (this.properties.peek().disabled) {
             return
           }

--- a/packages/uikit-default/src/input/index.test.ts
+++ b/packages/uikit-default/src/input/index.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Input } from './index.js'
+
+/**
+ * T2.8 — `input/textarea` aren't in the role/onActivate table (spec §7): the kit `Input` extends
+ * the base uikit `Input` directly, which already owns its hidden `<input>` as its a11y element and
+ * syncs `ariaLabel` onto it (`setupAriaAttributes`, spec §1.2). This locks in that the kit wrapper
+ * doesn't lose that wiring on the way through its own `defaultOverrides`.
+ */
+
+function mount(properties?: ConstructorParameters<typeof Input>[0]): Input {
+  const input = new Input(properties)
+  new Object3D().add(input)
+  return input
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('Input a11y wiring', () => {
+  it('forwards ariaLabel through to the hidden <input> exposed as a11yElement', () => {
+    const input = mount({ ariaLabel: 'Search' })
+    try {
+      const el = input.a11yElement
+      expect(el).toBeDefined()
+      expect(el).toBe(input.element)
+      expect(el!.tagName).toBe('INPUT')
+      expect(el!.getAttribute('aria-label')).toBe('Search')
+    } finally {
+      input.dispose()
+    }
+  })
+
+  it('updates aria-label when the ariaLabel prop signal changes', () => {
+    const ariaLabel = signal('Search')
+    const input = mount({ ariaLabel })
+    try {
+      expect(input.a11yElement!.getAttribute('aria-label')).toBe('Search')
+      ariaLabel.value = 'Find'
+      expect(input.a11yElement!.getAttribute('aria-label')).toBe('Find')
+    } finally {
+      input.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/radio-group/item.test.ts
+++ b/packages/uikit-default/src/radio-group/item.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { RadioGroup, RadioGroupItem } from './index.js'
+
+/**
+ * Phase 2 native a11y wiring (spec §7): RadioGroupItem gets role: 'radio', ariaChecked computed
+ * via searchFor(this, RadioGroup, ...) comparing this item's value to the group's selected value,
+ * and its selection behavior moves from onClick to onActivate so pointer, keyboard, and AT all
+ * drive selection through Component.activate().
+ */
+
+function mountGroup(
+  groupProperties: ConstructorParameters<typeof RadioGroup>[0],
+  items: Array<RadioGroupItem>
+): RadioGroup {
+  const group = new RadioGroup(groupProperties)
+  new Object3D().add(group)
+  for (const item of items) {
+    group.add(item)
+  }
+  return group
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('RadioGroupItem a11y wiring', () => {
+  it('exposes a hidden <button role="radio"> with aria-checked reflecting the group selection', () => {
+    const a = new RadioGroupItem({ value: 'a' })
+    const b = new RadioGroupItem({ value: 'b' })
+    const group = mountGroup({ defaultValue: 'a' }, [a, b])
+    try {
+      expect(a.a11yElement).toBeDefined()
+      expect(a.a11yElement!.tagName).toBe('BUTTON')
+      expect(a.a11yElement!.getAttribute('role')).toBe('radio')
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('true')
+      expect(b.a11yElement!.getAttribute('role')).toBe('radio')
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      a.dispose()
+      b.dispose()
+      group.dispose()
+    }
+  })
+
+  it('activating the hidden a11y element (AT/keyboard path) selects the item via the uncontrolled group', () => {
+    const a = new RadioGroupItem({ value: 'a' })
+    const b = new RadioGroupItem({ value: 'b' })
+    const onValueChange: Array<string | undefined> = []
+    const group = mountGroup({ onValueChange: (v) => onValueChange.push(v) }, [a, b])
+    try {
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('false')
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('false')
+
+      b.a11yElement!.click()
+
+      expect(group.uncontrolledSignal.peek()).toBe('b')
+      expect(onValueChange).toEqual(['b'])
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('true')
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      a.dispose()
+      b.dispose()
+      group.dispose()
+    }
+  })
+
+  it('does not flip a controlled group on activation, but still calls onValueChange', () => {
+    const a = new RadioGroupItem({ value: 'a' })
+    const b = new RadioGroupItem({ value: 'b' })
+    const onValueChange: Array<string | undefined> = []
+    const group = mountGroup({ value: 'a', onValueChange: (v) => onValueChange.push(v) }, [a, b])
+    try {
+      b.a11yElement!.click()
+      expect(onValueChange).toEqual(['b'])
+      // Controlled `value` prop stays 'a' — aria-checked reflects the group's controlled value.
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('true')
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      a.dispose()
+      b.dispose()
+      group.dispose()
+    }
+  })
+
+  it('writing the group value signal updates aria-checked on the previously/newly selected items', () => {
+    const a = new RadioGroupItem({ value: 'a' })
+    const b = new RadioGroupItem({ value: 'b' })
+    const group = mountGroup({ defaultValue: 'a' }, [a, b])
+    try {
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('true')
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('false')
+
+      group.uncontrolledSignal.value = 'b'
+
+      expect(a.a11yElement!.getAttribute('aria-checked')).toBe('false')
+      expect(b.a11yElement!.getAttribute('aria-checked')).toBe('true')
+    } finally {
+      a.dispose()
+      b.dispose()
+      group.dispose()
+    }
+  })
+
+  it('is a no-op when disabled — activation does not select the item', () => {
+    const a = new RadioGroupItem({ value: 'a', disabled: true })
+    const onValueChange: Array<string | undefined> = []
+    const group = mountGroup({ onValueChange: (v) => onValueChange.push(v) }, [a])
+    try {
+      a.a11yElement!.click()
+      expect(onValueChange).toEqual([])
+      expect(group.uncontrolledSignal.peek()).toBeUndefined()
+    } finally {
+      a.dispose()
+      group.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/radio-group/item.ts
+++ b/packages/uikit-default/src/radio-group/item.ts
@@ -47,7 +47,14 @@ export class RadioGroupItem extends Container<RadioGroupItemOutProperties> {
           borderColor: colors.border,
         },
         cursor: computed(() => (this.properties.value.disabled ? undefined : 'pointer')),
-        onClick: computed(() =>
+        role: 'radio',
+        // Self-contained (does not read the `isSelected` local below): setupComponentA11y's
+        // aria-checked effect runs synchronously inside this constructor's `super()` call, before
+        // any post-super `const` in this constructor body has initialized (TDZ).
+        ariaChecked: computed(
+          () => searchFor(this, RadioGroup, 2)?.currentSignal.value === this.properties.value.value
+        ),
+        onActivate: computed(() =>
           this.properties.value.disabled
             ? undefined
             : () => {

--- a/packages/uikit-default/src/slider/index.test.ts
+++ b/packages/uikit-default/src/slider/index.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Slider } from './index.js'
+
+/**
+ * T2.6: role:'slider' + ariaValueNow/Min/Max/Step on the hidden native <input type=range>, and
+ * onA11yValueChange running through the SAME clamp/step/set path as pointer drag. A Component only
+ * resolves its properties (and thus mounts its a11y element) once root-attached (see
+ * uikit/src/tests/a11y-hidden-element.test.ts mount helper).
+ */
+
+function mount(properties: ConstructorParameters<typeof Slider>[0]): Slider {
+  const slider = new Slider(properties)
+  new Object3D().add(slider)
+  return slider
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('Slider a11y', () => {
+  it('exposes role slider as a hidden <input type=range> with aria-value* synced from props', () => {
+    const s = mount({ ariaLabel: 'Volume', value: 25, min: 0, max: 50, step: 5 })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      expect(el).toBeDefined()
+      expect(el.tagName).toBe('INPUT')
+      expect(el.type).toBe('range')
+      expect(el.min).toBe('0')
+      expect(el.max).toBe('50')
+      expect(el.step).toBe('5')
+      expect(el.value).toBe('25')
+    } finally {
+      s.dispose()
+    }
+  })
+
+  it('defaults ariaValueMin/Max/Step to 0/100/1 when min/max/step are absent', () => {
+    const s = mount({ ariaLabel: 'Volume' })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      expect(el.min).toBe('0')
+      expect(el.max).toBe('100')
+      expect(el.step).toBe('1')
+    } finally {
+      s.dispose()
+    }
+  })
+
+  it('writing the value signal updates the aria-value-now (native input value)', () => {
+    const value = signal(20)
+    const s = mount({ ariaLabel: 'Volume', value, min: 0, max: 100, step: 1 })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      expect(el.value).toBe('20')
+      value.value = 40
+      expect(el.value).toBe('40')
+    } finally {
+      s.dispose()
+    }
+  })
+
+  it('onA11yValueChange runs the same clamp/step/set path as pointer drag (uncontrolled)', () => {
+    const onValueChange = vi.fn()
+    const s = mount({ ariaLabel: 'Volume', min: 0, max: 100, step: 5, onValueChange })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      el.valueAsNumber = 73 // AT/keyboard-driven raw value, not pre-stepped by us
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      // rounded to the nearest step of 5, clamped within [0, 100] — same math as handleSetValue
+      expect(onValueChange).toHaveBeenCalledWith(75)
+      expect(s.currentSignal.value).toBe(75)
+    } finally {
+      s.dispose()
+    }
+  })
+
+  it('onA11yValueChange clamps to max and does not write the uncontrolledSignal when controlled', () => {
+    const onValueChange = vi.fn()
+    const value = signal(10)
+    const s = mount({ ariaLabel: 'Volume', value, min: 0, max: 100, step: 10, onValueChange })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      el.valueAsNumber = 250
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      expect(onValueChange).toHaveBeenCalledWith(100)
+      // controlled: the prop signal, not the internal uncontrolled one, is the source of truth
+      expect(s.uncontrolledSignal.value).toBeUndefined()
+      expect(s.currentSignal.value).toBe(10)
+    } finally {
+      s.dispose()
+    }
+  })
+
+  it('does not commit a value change while disabled', () => {
+    const onValueChange = vi.fn()
+    const s = mount({ ariaLabel: 'Volume', disabled: true, onValueChange })
+    try {
+      const el = s.a11yElement as HTMLInputElement
+      el.valueAsNumber = 42
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      expect(onValueChange).not.toHaveBeenCalled()
+    } finally {
+      s.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/slider/index.ts
+++ b/packages/uikit-default/src/slider/index.ts
@@ -78,6 +78,17 @@ export class Slider extends Container<SliderOutProperties> {
         height: 8,
         width: '100%',
         alignItems: 'center',
+        role: 'slider',
+        ariaValueNow: computed(() => this.currentSignal.value),
+        ariaValueMin: computed(() => Number(this.properties.value.min ?? 0)),
+        ariaValueMax: computed(() => Number(this.properties.value.max ?? 100)),
+        ariaValueStep: computed(() => Number(this.properties.value.step ?? 1)),
+        onA11yValueChange: (value: number) => {
+          if (this.properties.peek().disabled ?? false) {
+            return
+          }
+          this.setValue(value)
+        },
         ...config?.defaultOverrides,
       },
     })
@@ -197,20 +208,23 @@ export class Slider extends Container<SliderOutProperties> {
     this.worldToLocal(vectorHelper)
     const minValue = Number(this.properties.peek().min ?? 0)
     const maxValue = Number(this.properties.peek().max ?? 100)
+    this.setValue((vectorHelper.x + 0.5) * (maxValue - minValue) + minValue)
+    e.stopPropagation?.()
+  }
+
+  /** Clamp/step a raw value and commit it through the controlled/uncontrolled path — shared by pointer drag and `onA11yValueChange`. */
+  private setValue(rawValue: number): void {
+    const minValue = Number(this.properties.peek().min ?? 0)
+    const maxValue = Number(this.properties.peek().max ?? 100)
     const stepValue = Number(this.properties.peek().step ?? 1)
     const newValue = Math.min(
-      Math.max(
-        Math.round(((vectorHelper.x + 0.5) * (maxValue - minValue) + minValue) / stepValue) *
-          stepValue,
-        minValue
-      ),
+      Math.max(Math.round(rawValue / stepValue) * stepValue, minValue),
       maxValue
     )
     if (this.properties.peek().value == null) {
       this.uncontrolledSignal.value = newValue
     }
     this.properties.peek().onValueChange?.(newValue)
-    e.stopPropagation?.()
   }
 
   dispose(): void {

--- a/packages/uikit-default/src/switch/index.test.ts
+++ b/packages/uikit-default/src/switch/index.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Switch } from './index.js'
+
+/**
+ * T2.2 (planning/superpowers/specs/uikit-native-a11y.md §7): Switch gets role:'switch',
+ * ariaChecked mirroring currentSignal, and its toggle behavior moved from onClick to
+ * onActivate so pointer, keyboard, AT, and XR activation all share one code path.
+ */
+
+function mount(properties?: ConstructorParameters<typeof Switch>[0]): Switch {
+  const widget = new Switch(properties)
+  new Object3D().add(widget)
+  return widget
+}
+
+beforeAll(async () => {
+  await loadYoga()
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('Switch — native a11y wiring', () => {
+  it('exposes role=switch with aria-checked mirroring currentSignal (defaults to false)', () => {
+    const w = mount()
+    try {
+      const el = w.a11yElement as HTMLButtonElement
+      expect(el.tagName).toBe('BUTTON')
+      expect(el.getAttribute('role')).toBe('switch')
+      expect(el.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      w.dispose()
+    }
+  })
+
+  it('a click on the hidden element drives the uncontrolled toggle through onActivate', () => {
+    const onCheckedChange = vi.fn()
+    const w = mount({ onCheckedChange })
+    try {
+      const el = w.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-checked')).toBe('false')
+
+      el.click()
+
+      expect(w.currentSignal.value).toBe(true)
+      expect(onCheckedChange).toHaveBeenCalledTimes(1)
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+      expect(el.getAttribute('aria-checked')).toBe('true')
+
+      el.click()
+
+      expect(w.currentSignal.value).toBe(false)
+      expect(onCheckedChange).toHaveBeenCalledTimes(2)
+      expect(onCheckedChange).toHaveBeenLastCalledWith(false)
+      expect(el.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      w.dispose()
+    }
+  })
+
+  it('writing the checked signal (controlled) updates aria-checked reactively', () => {
+    const checked = signal(false)
+    const w = mount({ checked })
+    try {
+      const el = w.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-checked')).toBe('false')
+
+      checked.value = true
+      expect(el.getAttribute('aria-checked')).toBe('true')
+
+      checked.value = false
+      expect(el.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      w.dispose()
+    }
+  })
+
+  it('a click does not toggle a controlled switch — onCheckedChange still fires (parent owns state)', () => {
+    const checked = signal(true)
+    const onCheckedChange = vi.fn()
+    const w = mount({ checked, onCheckedChange })
+    try {
+      const el = w.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-checked')).toBe('true')
+
+      el.click()
+
+      expect(onCheckedChange).toHaveBeenCalledWith(false)
+      // controlled: the source-of-truth signal was not written by the widget, so state holds.
+      expect(el.getAttribute('aria-checked')).toBe('true')
+    } finally {
+      w.dispose()
+    }
+  })
+
+  it('disabled suppresses activation entirely (no onActivate call, no state change)', () => {
+    const onCheckedChange = vi.fn()
+    const w = mount({ disabled: true, onCheckedChange })
+    try {
+      const el = w.a11yElement as HTMLButtonElement
+      el.click()
+      expect(onCheckedChange).not.toHaveBeenCalled()
+      expect(el.getAttribute('aria-checked')).toBe('false')
+    } finally {
+      w.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/switch/index.ts
+++ b/packages/uikit-default/src/switch/index.ts
@@ -64,7 +64,9 @@ export class Switch extends Container<SwitchOutProperties> {
           this.currentSignal.value ? colors.primary.value : colors.input.value
         ),
         cursor: computed(() => (this.properties.value.disabled ? undefined : 'pointer')),
-        onClick: computed(() => {
+        role: 'switch',
+        ariaChecked: computed(() => this.currentSignal.value ?? false),
+        onActivate: computed(() => {
           return this.properties.value.disabled
             ? undefined
             : () => {
@@ -101,7 +103,7 @@ export class Switch extends Container<SwitchOutProperties> {
     super.dispose()
   }
 
-  add(...object: Object3D[]): this {
+  add(..._object: Object3D[]): this {
     throw new Error(`the switch component can not have any children`)
   }
 }

--- a/packages/uikit-default/src/tabs/trigger.test.ts
+++ b/packages/uikit-default/src/tabs/trigger.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { loadYoga } from 'yoga-layout/load'
+import { Object3D } from 'three'
+import { Tabs, TabsTrigger } from './index.js'
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  // Text/icon components kick off a default-font fetch on construction; there is no server in
+  // tests, so pin fetch to a never-settling promise to keep the async font load from logging
+  // ECONNREFUSED noise.
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+function mountTab(tabsValue: string | undefined, triggerValue: string) {
+  const tabs = new Tabs({ value: tabsValue })
+  const trigger = new TabsTrigger({ value: triggerValue })
+  tabs.add(trigger)
+  new Object3D().add(tabs)
+  return { tabs, trigger }
+}
+
+describe('TabsTrigger a11y', () => {
+  it('renders a hidden element with role=tab and aria-selected reflecting the active computed', () => {
+    const { tabs, trigger } = mountTab('a', 'a')
+    try {
+      const el = trigger.a11yElement as HTMLButtonElement
+      expect(el.tagName).toBe('BUTTON')
+      expect(el.getAttribute('role')).toBe('tab')
+      expect(el.getAttribute('aria-selected')).toBe('true')
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+
+  it('aria-selected is false when the trigger is not the active tab', () => {
+    const { tabs, trigger } = mountTab('a', 'b')
+    try {
+      const el = trigger.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-selected')).toBe('false')
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+
+  it('updates aria-selected reactively when the active tab changes', () => {
+    const { tabs, trigger } = mountTab('a', 'b')
+    try {
+      const el = trigger.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-selected')).toBe('false')
+      tabs.setProperties({ value: 'b' })
+      expect(el.getAttribute('aria-selected')).toBe('true')
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+
+  it('driving a11yElement.click() activates the trigger and selects its tab (uncontrolled)', () => {
+    const { tabs, trigger } = mountTab(undefined, 'b')
+    try {
+      expect(tabs.currentSignal.peek()).toBeUndefined()
+      trigger.a11yElement!.click()
+      expect(tabs.uncontrolledSignal.peek()).toBe('b')
+      expect(tabs.currentSignal.peek()).toBe('b')
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+
+  it('driving a11yElement.click() calls onValueChange (controlled) and does not disable activation', () => {
+    const calls: Array<string> = []
+    const tabs = new Tabs({ value: 'a', onValueChange: (v) => calls.push(v) })
+    const trigger = new TabsTrigger({ value: 'b' })
+    tabs.add(trigger)
+    new Object3D().add(tabs)
+    try {
+      trigger.a11yElement!.click()
+      expect(calls).toEqual(['b'])
+      // controlled: value prop didn't change, so uncontrolledSignal stays untouched
+      expect(tabs.uncontrolledSignal.peek()).toBeUndefined()
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+
+  it('disabled trigger does not activate on a11yElement.click()', () => {
+    const { tabs, trigger } = mountTab(undefined, 'b')
+    trigger.setProperties({ value: 'b', disabled: true })
+    try {
+      trigger.a11yElement!.click()
+      expect(tabs.uncontrolledSignal.peek()).toBeUndefined()
+      expect(tabs.currentSignal.peek()).toBeUndefined()
+    } finally {
+      trigger.dispose()
+      tabs.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/tabs/trigger.ts
+++ b/packages/uikit-default/src/tabs/trigger.ts
@@ -45,10 +45,12 @@ export class TabsTrigger extends Container<TabsTriggerOutProperties> {
       defaults: componentDefaults,
       ...config,
       defaultOverrides: {
+        role: 'tab',
+        ariaSelected: active,
         '*': {
           borderColor: colors.border,
         },
-        onClick: computed(() => {
+        onActivate: computed(() => {
           return (this.properties.value.disabled ?? false)
             ? undefined
             : () => {

--- a/packages/uikit-default/src/textarea/index.test.ts
+++ b/packages/uikit-default/src/textarea/index.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Textarea } from './index.js'
+
+/**
+ * T2.8 — `input/textarea` aren't in the role/onActivate table (spec §7). The kit `Textarea` wraps
+ * an internal base uikit `Input` (`multiline: true`) which owns its own hidden `<textarea>` as its
+ * a11y element (`setupAriaAttributes`, spec §1.2) regardless of the outer Container's `role`. This
+ * asserts the outer `Textarea`'s `ariaLabel` prop actually reaches that inner hidden `<textarea>`.
+ */
+
+function mount(properties?: ConstructorParameters<typeof Textarea>[0]): Textarea {
+  const textarea = new Textarea(properties)
+  new Object3D().add(textarea)
+  return textarea
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('Textarea a11y wiring', () => {
+  it('forwards ariaLabel through to the inner Input hidden <textarea> exposed as a11yElement', () => {
+    const textarea = mount({ ariaLabel: 'Comments' })
+    try {
+      const el = textarea.input.a11yElement
+      expect(el).toBeDefined()
+      expect(el).toBe(textarea.input.element)
+      expect(el!.tagName).toBe('TEXTAREA')
+      expect(el!.getAttribute('aria-label')).toBe('Comments')
+    } finally {
+      textarea.dispose()
+    }
+  })
+
+  it('updates aria-label on the inner hidden <textarea> when the ariaLabel prop signal changes', () => {
+    const ariaLabel = signal('Comments')
+    const textarea = mount({ ariaLabel })
+    try {
+      expect(textarea.input.a11yElement!.getAttribute('aria-label')).toBe('Comments')
+      ariaLabel.value = 'Feedback'
+      expect(textarea.input.a11yElement!.getAttribute('aria-label')).toBe('Feedback')
+    } finally {
+      textarea.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/textarea/index.ts
+++ b/packages/uikit-default/src/textarea/index.ts
@@ -85,6 +85,10 @@ export class Textarea extends Container<TextareaOutProperties> {
         type: this.properties.signal.type,
         onValueChange: this.properties.signal.onValueChange,
         onFocusChange: this.properties.signal.onFocusChange,
+        // The inner Input owns the hidden <textarea> (its a11y element) — without forwarding these,
+        // ariaLabel/ariaDescription set on the outer Textarea never reach it (gap found by T2.8).
+        ariaLabel: this.properties.signal.ariaLabel,
+        ariaDescription: this.properties.signal.ariaDescription,
       },
     })
     this.input = inputImpl
@@ -115,7 +119,7 @@ export class Textarea extends Container<TextareaOutProperties> {
     super.dispose()
   }
 
-  add(...object: Object3D[]): this {
+  add(..._object: Object3D[]): this {
     throw new Error(`the input component can not have any children`)
   }
 }

--- a/packages/uikit-default/src/toggle-group/item.test.ts
+++ b/packages/uikit-default/src/toggle-group/item.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { ToggleGroup, ToggleGroupItem } from './index.js'
+
+/**
+ * Phase 2 native a11y wiring (spec §7): role: 'togglebutton', ariaPressed reflecting
+ * currentSignal, and behavior moved from onClick to onActivate so pointer, keyboard,
+ * and AT all drive the same toggle logic through Component.activate().
+ *
+ * Note: the actual toggle state lives on ToggleGroupItem (toggle-group/item.ts) — the
+ * ToggleGroup container itself (toggle-group/index.ts) is a plain layout wrapper with no
+ * checked state and no onClick, so it does not get a togglebutton role.
+ */
+
+function mountItem(item: ToggleGroupItem): ToggleGroupItem {
+  const group = new ToggleGroup()
+  new Object3D().add(group)
+  group.add(item)
+  return item
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('ToggleGroupItem a11y wiring', () => {
+  it('exposes a togglebutton with aria-pressed reflecting the unchecked default', () => {
+    const item = mountItem(new ToggleGroupItem())
+    try {
+      const el = item.a11yElement as HTMLButtonElement
+      expect(el.tagName).toBe('BUTTON')
+      expect(el.getAttribute('aria-pressed')).toBe('false')
+    } finally {
+      item.dispose()
+    }
+  })
+
+  it('reflects defaultChecked through aria-pressed', () => {
+    const item = mountItem(new ToggleGroupItem({ defaultChecked: true }))
+    try {
+      const el = item.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-pressed')).toBe('true')
+    } finally {
+      item.dispose()
+    }
+  })
+
+  it('clicking the hidden a11y element (AT/keyboard path) flips the uncontrolled state', () => {
+    const item = mountItem(new ToggleGroupItem())
+    try {
+      expect(item.currentSignal.peek()).toBeUndefined()
+      item.a11yElement!.click()
+      expect(item.currentSignal.peek()).toBe(true)
+      expect(item.a11yElement!.getAttribute('aria-pressed')).toBe('true')
+
+      item.a11yElement!.click()
+      expect(item.currentSignal.peek()).toBe(false)
+      expect(item.a11yElement!.getAttribute('aria-pressed')).toBe('false')
+    } finally {
+      item.dispose()
+    }
+  })
+
+  it('does not flip a controlled item on activation, but still calls onCheckedChange', () => {
+    let lastChecked: boolean | undefined
+    const item = mountItem(
+      new ToggleGroupItem({ checked: false, onCheckedChange: (checked) => (lastChecked = checked) })
+    )
+    try {
+      item.a11yElement!.click()
+      expect(lastChecked).toBe(true)
+      expect(item.currentSignal.peek()).toBe(false)
+    } finally {
+      item.dispose()
+    }
+  })
+
+  it('activation is a no-op while disabled', () => {
+    let onCheckedChangeCalls = 0
+    const item = mountItem(
+      new ToggleGroupItem({ disabled: true, onCheckedChange: () => (onCheckedChangeCalls += 1) })
+    )
+    try {
+      item.a11yElement!.click()
+      expect(onCheckedChangeCalls).toBe(0)
+      expect(item.currentSignal.peek()).toBeUndefined()
+    } finally {
+      item.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/toggle-group/item.ts
+++ b/packages/uikit-default/src/toggle-group/item.ts
@@ -79,7 +79,9 @@ export class ToggleGroupItem extends Container<ToggleGroupItemOutProperties> {
         '*': {
           borderColor: colors.border,
         },
-        onClick: () => {
+        role: 'togglebutton',
+        ariaPressed: computed(() => this.currentSignal.value ?? false),
+        onActivate: () => {
           if (this.properties.peek().disabled) {
             return
           }

--- a/packages/uikit-default/src/toggle/index.test.ts
+++ b/packages/uikit-default/src/toggle/index.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Toggle } from './index.js'
+
+/**
+ * Phase 2 native a11y wiring (spec §7): role: 'togglebutton', ariaPressed reflecting
+ * currentSignal, and behavior moved from onClick to onActivate so pointer, keyboard,
+ * and AT all drive the same toggle logic through Component.activate().
+ */
+
+function mount(toggle: Toggle): Toggle {
+  new Object3D().add(toggle)
+  return toggle
+}
+
+let realFetch: typeof globalThis.fetch
+beforeAll(async () => {
+  await loadYoga() // loads the Yoga WASM via fetch — must run BEFORE fetch is stubbed
+  realFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<never>(() => {})) as typeof globalThis.fetch
+})
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('Toggle a11y wiring', () => {
+  it('exposes a togglebutton with aria-pressed reflecting the unchecked default', () => {
+    const toggle = mount(new Toggle())
+    try {
+      const el = toggle.a11yElement as HTMLButtonElement
+      expect(el.tagName).toBe('BUTTON')
+      expect(el.getAttribute('aria-pressed')).toBe('false')
+    } finally {
+      toggle.dispose()
+    }
+  })
+
+  it('reflects defaultChecked through aria-pressed', () => {
+    const toggle = mount(new Toggle({ defaultChecked: true }))
+    try {
+      const el = toggle.a11yElement as HTMLButtonElement
+      expect(el.getAttribute('aria-pressed')).toBe('true')
+    } finally {
+      toggle.dispose()
+    }
+  })
+
+  it('clicking the hidden a11y element (AT/keyboard path) flips the uncontrolled state', () => {
+    const toggle = mount(new Toggle())
+    try {
+      expect(toggle.currentSignal.peek()).toBeUndefined()
+      toggle.a11yElement!.click()
+      expect(toggle.currentSignal.peek()).toBe(true)
+      expect(toggle.a11yElement!.getAttribute('aria-pressed')).toBe('true')
+
+      toggle.a11yElement!.click()
+      expect(toggle.currentSignal.peek()).toBe(false)
+      expect(toggle.a11yElement!.getAttribute('aria-pressed')).toBe('false')
+    } finally {
+      toggle.dispose()
+    }
+  })
+
+  it('writing the checked prop updates aria-pressed without going through activation', () => {
+    let onCheckedChangeCalls = 0
+    const toggle = mount(
+      new Toggle({ checked: false, onCheckedChange: () => (onCheckedChangeCalls += 1) })
+    )
+    try {
+      expect(toggle.a11yElement!.getAttribute('aria-pressed')).toBe('false')
+      toggle.setProperties({ checked: true })
+      expect(toggle.a11yElement!.getAttribute('aria-pressed')).toBe('true')
+      expect(onCheckedChangeCalls).toBe(0)
+    } finally {
+      toggle.dispose()
+    }
+  })
+
+  it('does not flip a controlled toggle on activation, but still calls onCheckedChange', () => {
+    let lastChecked: boolean | undefined
+    const toggle = mount(
+      new Toggle({ checked: false, onCheckedChange: (checked) => (lastChecked = checked) })
+    )
+    try {
+      toggle.a11yElement!.click()
+      expect(lastChecked).toBe(true)
+      // Controlled: the internal uncontrolled signal never took over, so currentSignal still
+      // reflects the (unchanged) `checked` prop rather than the requested toggle.
+      expect(toggle.currentSignal.peek()).toBe(false)
+    } finally {
+      toggle.dispose()
+    }
+  })
+
+  it('activation is a no-op while disabled', () => {
+    let onCheckedChangeCalls = 0
+    const toggle = mount(
+      new Toggle({ disabled: true, onCheckedChange: () => (onCheckedChangeCalls += 1) })
+    )
+    try {
+      toggle.a11yElement!.click()
+      expect(onCheckedChangeCalls).toBe(0)
+      expect(toggle.currentSignal.peek()).toBeUndefined()
+    } finally {
+      toggle.dispose()
+    }
+  })
+})

--- a/packages/uikit-default/src/toggle/index.ts
+++ b/packages/uikit-default/src/toggle/index.ts
@@ -82,7 +82,9 @@ export class Toggle extends Container<ToggleOutProperties> {
         '*': {
           borderColor: colors.border,
         },
-        onClick: () => {
+        role: 'togglebutton',
+        ariaPressed: computed(() => this.currentSignal.value ?? false),
+        onActivate: () => {
           if (this.properties.peek().disabled) {
             return
           }

--- a/packages/uikit-lucide/example/App.tsx
+++ b/packages/uikit-lucide/example/App.tsx
@@ -10,13 +10,12 @@ import {
   installIconAtlas,
   setPreferredColorScheme,
 } from '@three-flatland/uikit/react'
-import { computeA11yScreenRect, type Container as VanillaContainer } from '@three-flatland/uikit'
 import {
-  colors,
-  Button,
-  Input,
-  type VanillaButton,
-} from '@three-flatland/uikit-default/react'
+  announce,
+  computeA11yScreenRect,
+  type Container as VanillaContainer,
+} from '@three-flatland/uikit'
+import { colors, Button, Input, type VanillaButton } from '@three-flatland/uikit-default/react'
 import * as LucideIcons from '@three-flatland/uikit-lucide/react'
 import { SlugFontLoader } from '@three-flatland/slug/react'
 import type { SlugFont } from '@three-flatland/slug'
@@ -86,6 +85,11 @@ interface Window {
   cellH: number
 }
 
+/** Keyboard-grammar move tokens the listbox role emits on arrow/Home/End — the app (not uikit)
+ *  owns the grid geometry, so it translates a move into a new active index using the live column
+ *  count (see `onA11yActiveIndexChange` below). */
+type A11yMove = 'next' | 'prev' | 'nextRow' | 'prevRow' | 'first' | 'last'
+
 /** Shape emitted to the clipboard — an `IconBakeManifest` (uikit CLI). */
 interface BakeManifest {
   out: string
@@ -96,6 +100,7 @@ interface BakeManifest {
 const IconChip = memo(function IconChip({
   name,
   selected,
+  active,
   onToggle,
   top,
   left,
@@ -104,6 +109,8 @@ const IconChip = memo(function IconChip({
 }: {
   name: string
   selected: boolean
+  /** Keyboard/AT focus highlight — the single listbox "active" cell, independent of `selected`. */
+  active: boolean
   onToggle: (name: string) => void
   top: number
   left: number
@@ -123,8 +130,10 @@ const IconChip = memo(function IconChip({
       gap={8}
       padding={8}
       borderRadius={8}
-      borderWidth={1}
-      borderColor={selected ? colors.primary : colors.border}
+      borderWidth={active ? 2 : 1}
+      borderColor={
+        active ? (colors.ring ?? colors.primary) : selected ? colors.primary : colors.border
+      }
       backgroundColor={selected ? colors.accent : colors.card}
       hover={{ borderColor: colors.primary }}
       cursor="pointer"
@@ -173,6 +182,10 @@ function IconBrowser() {
   const font = useBrowserAssets()
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState<Set<string>>(() => new Set<string>())
+  // The listbox role's single managed "active" descendant — an index into `filtered`, not a
+  // selection. Keyboard/AT users arrow through this; the grid never re-renders per-arrow beyond
+  // the one or two `IconChip`s whose `active` prop actually flips (see `bySlot` below).
+  const [activeIdx, setActiveIdx] = useState(0)
   const [copyLabel, setCopyLabel] = useState('Copy manifest')
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -237,7 +250,8 @@ function IconBrowser() {
   )
 
   // Reset to the top whenever the filter changes — the old scroll offset is
-  // meaningless against a different (often shorter) result set.
+  // meaningless against a different (often shorter) result set. The active listbox index
+  // resets too — it may no longer even be in range against the new (often shorter) result set.
   useEffect(() => {
     const c = scrollRef.current
     if (c) c.scrollPosition.value = [0, 0]
@@ -249,6 +263,7 @@ function IconBrowser() {
       cellW: w.cellW,
       cellH: w.cellH,
     }))
+    setActiveIdx(0)
   }, [q])
 
   // Poll scroll offset + viewport size every frame; recompute the visible row
@@ -296,6 +311,70 @@ function IconBrowser() {
     })
   }, [])
 
+  // Listbox role (uikit's native-a11y virtualized-listbox pattern, spec §8): the scroll Container
+  // is the ONE focusable tab stop; arrow/Home/End keys on it dispatch these moves and WE translate
+  // move → a new active index using the LIVE column count (`lastWin.current`, freshest — `win`
+  // only updates on a row-boundary crossing) since the grid geometry is app-owned, not uikit's.
+  const onA11yActiveIndexChange = useCallback(
+    ({ move }: { move: A11yMove }) => {
+      if (filtered.length === 0) return
+      const columns = Math.max(1, lastWin.current.columns || win.columns)
+      const last = filtered.length - 1
+      let next = activeIdx
+      switch (move) {
+        case 'next':
+          next = activeIdx + 1
+          break
+        case 'prev':
+          next = activeIdx - 1
+          break
+        case 'nextRow':
+          next = activeIdx + columns
+          break
+        case 'prevRow':
+          next = activeIdx - columns
+          break
+        case 'first':
+          next = 0
+          break
+        case 'last':
+          next = last
+          break
+      }
+      next = Math.max(0, Math.min(last, next))
+      setActiveIdx(next)
+
+      // Scroll the active row into view — minimally: only when it's above the current top or
+      // below the current bottom, using the same row stride (`cellH + GAP`) the grid renders with.
+      const c = scrollRef.current
+      if (c == null) return
+      const cellH = lastWin.current.cellH || win.cellH
+      const stride = cellH + GAP
+      const activeRow = Math.floor(next / columns)
+      const rowTop = GAP + activeRow * stride
+      const rowBottom = rowTop + cellH
+      const size = c.size.value
+      const viewportH = size ? size[1] : 0
+      const [x, y] = c.scrollPosition.value ?? [0, 0]
+      let targetY = y
+      if (rowTop < y) targetY = rowTop
+      else if (rowBottom > y + viewportH) targetY = rowBottom - viewportH
+      if (targetY !== y) c.scrollPosition.value = [x, targetY]
+    },
+    [activeIdx, filtered.length, win.columns, win.cellH]
+  )
+
+  const onA11yActivate = useCallback(
+    (index: number) => {
+      const name = filtered[index]
+      if (name == null) return
+      const wasSelected = selected.has(name)
+      toggle(name)
+      announce(`${name} ${wasSelected ? 'deselected' : 'selected'}`)
+    },
+    [filtered, selected, toggle]
+  )
+
   const selectAll = useCallback(() => {
     setSelected((prev) => {
       const next = new Set(prev)
@@ -335,9 +414,8 @@ function IconBrowser() {
   // leaving row vacated (i+poolSize ≡ i mod poolSize) — one row rebinds (offscreen, in the
   // overscan buffer) and every other slot is memo-skipped. No unmount/remount churn: the uikit
   // Container is reused and only its (baked, so cheap) icon swaps. Empty trailing slots park off.
-  const bySlot: Array<{ name: string; top: number; left: number } | null> = new Array(
-    poolSize
-  ).fill(null)
+  const bySlot: Array<{ name: string; top: number; left: number; index: number } | null> =
+    new Array(poolSize).fill(null)
   const end = Math.min(win.start + poolSize, filtered.length)
   for (let i = win.start; i < end; i++) {
     const row = Math.floor(i / columns)
@@ -346,6 +424,7 @@ function IconBrowser() {
       name: filtered[i]!,
       top: GAP + row * rowStride,
       left: GAP + col * colStride,
+      index: i,
     }
   }
 
@@ -422,6 +501,17 @@ function IconBrowser() {
         scrollbarColor={colors.mutedForeground}
         scrollbarWidth={8}
         scrollbarBorderRadius={4}
+        // Native-a11y virtualized listbox (uikit spec §8): ONE focusable tab stop for the whole
+        // 1594-icon grid. uikit renders the managed aria-posinset/aria-setsize option and owns the
+        // keydown grammar (arrows/Home/End); WE own geometry — translating `move` → index and
+        // scrolling the active row into view (see `onA11yActiveIndexChange` above).
+        role="listbox"
+        ariaLabel={`Icon grid, ${filtered.length} icons`}
+        ariaItemCount={filtered.length}
+        ariaActiveIndex={activeIdx}
+        ariaActiveLabel={filtered[activeIdx] ?? ''}
+        onA11yActiveIndexChange={onA11yActiveIndexChange}
+        onA11yActivate={onA11yActivate}
       >
         {filtered.length === 0 ? (
           <Container flexGrow={1} alignItems="center" justifyContent="center" padding={48}>
@@ -438,6 +528,7 @@ function IconBrowser() {
                 key={slot}
                 name={cell?.name ?? ''}
                 selected={cell != null && selected.has(cell.name)}
+                active={cell != null && cell.index === activeIdx}
                 onToggle={toggle}
                 top={cell?.top ?? -9999}
                 left={cell?.left ?? -9999}

--- a/packages/uikit-lucide/example/App.tsx
+++ b/packages/uikit-lucide/example/App.tsx
@@ -99,6 +99,7 @@ interface BakeManifest {
 /** One selectable icon tile, absolutely positioned at its grid cell. */
 const IconChip = memo(function IconChip({
   name,
+  index,
   selected,
   active,
   onToggle,
@@ -108,10 +109,11 @@ const IconChip = memo(function IconChip({
   height,
 }: {
   name: string
+  index: number
   selected: boolean
   /** Keyboard/AT focus highlight — the single listbox "active" cell, independent of `selected`. */
   active: boolean
-  onToggle: (name: string) => void
+  onToggle: (name: string, index: number) => void
   top: number
   left: number
   width: number
@@ -137,7 +139,7 @@ const IconChip = memo(function IconChip({
       backgroundColor={selected ? colors.accent : colors.card}
       hover={{ borderColor: colors.primary }}
       cursor="pointer"
-      onClick={() => onToggle(name)}
+      onClick={() => onToggle(name, index)}
     >
       {name ? (
         // A single reusable <Svg> whose `icon` prop changes as the pool slot rebinds — the
@@ -375,6 +377,22 @@ function IconBrowser() {
     [filtered, selected, toggle]
   )
 
+  // Pointer-selecting a chip also moves the listbox active descendant, so keyboard + pointer keep a
+  // single "active" cell (codex P2 #5). Stable identity so IconChip's memo isn't defeated.
+  const onChipSelect = useCallback(
+    (name: string, index: number) => {
+      setActiveIdx(index)
+      toggle(name)
+    },
+    [toggle]
+  )
+
+  // The stored activeIdx is only reset in an effect (post-render), so clamp it to the live filtered
+  // set for THIS render — otherwise the managed option briefly reads "501 of 3" after filtering, or
+  // "1 of 0" with no matches (codex P2 #4). -1 / undefined => no active option.
+  const safeActiveIdx = filtered.length === 0 ? -1 : Math.min(activeIdx, filtered.length - 1)
+  const activeName = safeActiveIdx >= 0 ? filtered[safeActiveIdx] : undefined
+
   const selectAll = useCallback(() => {
     setSelected((prev) => {
       const next = new Set(prev)
@@ -508,8 +526,9 @@ function IconBrowser() {
         role="listbox"
         ariaLabel={`Icon grid, ${filtered.length} icons`}
         ariaItemCount={filtered.length}
-        ariaActiveIndex={activeIdx}
-        ariaActiveLabel={filtered[activeIdx] ?? ''}
+        ariaActiveIndex={safeActiveIdx >= 0 ? safeActiveIdx : undefined}
+        ariaActiveLabel={activeName ?? ''}
+        ariaSelected={activeName != null && selected.has(activeName)}
         onA11yActiveIndexChange={onA11yActiveIndexChange}
         onA11yActivate={onA11yActivate}
       >
@@ -527,9 +546,10 @@ function IconBrowser() {
               <IconChip
                 key={slot}
                 name={cell?.name ?? ''}
+                index={cell?.index ?? -1}
                 selected={cell != null && selected.has(cell.name)}
-                active={cell != null && cell.index === activeIdx}
-                onToggle={toggle}
+                active={cell != null && cell.index === safeActiveIdx}
+                onToggle={onChipSelect}
                 top={cell?.top ?? -9999}
                 left={cell?.left ?? -9999}
                 width={win.cellW}

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -35,11 +35,27 @@ const INTERACTIVE_ROLES = new Set<A11yRole>([
 ])
 const warnedRoles = /* @__PURE__ */ new Set<string>()
 const missingLabelWarned = /* @__PURE__ */ new WeakSet<object>()
+let nextListboxOptionId = 0
+
+// Key → move-token grammar for the virtualized listbox (spec §8, APG listbox).
+const LISTBOX_MOVE_BY_KEY: Record<
+  string,
+  'next' | 'prev' | 'nextRow' | 'prevRow' | 'first' | 'last'
+> = {
+  ArrowRight: 'next',
+  ArrowLeft: 'prev',
+  ArrowDown: 'nextRow',
+  ArrowUp: 'prevRow',
+  Home: 'first',
+  End: 'last',
+}
 
 /**
  * Create the hidden native DOM element for a role (spec §1.2). Native `<button>`/`<a>`/
  * `<input type=range>`/`<img>`/`<p>` so Enter/Space/AT activation and arrow-key handling come for
- * free. Unimplemented roles (`listbox` P2, `landmark` P3) warn once and fall back to content.
+ * free. `listbox` (spec §8) is the virtualized pattern: ONE focusable element with ONE managed
+ * option re-labelled as the active index moves — no per-item DOM. Unimplemented roles
+ * (`landmark` P3) warn once and fall back to content.
  */
 export function createHtmlA11yElement(role: A11yRole): HTMLElement {
   let element: HTMLElement
@@ -80,6 +96,17 @@ export function createHtmlA11yElement(role: A11yRole): HTMLElement {
     case 'content':
       element = document.createElement('p')
       break
+    case 'listbox': {
+      element = document.createElement('div')
+      element.setAttribute('role', 'listbox')
+      element.setAttribute('tabindex', '0')
+      const option = document.createElement('div')
+      option.setAttribute('role', 'option')
+      option.id = `uikit-a11y-option-${nextListboxOptionId++}`
+      element.appendChild(option)
+      element.setAttribute('aria-activedescendant', option.id)
+      break
+    }
     default:
       if (!warnedRoles.has(role)) {
         warnedRoles.add(role)
@@ -175,7 +202,9 @@ export function registerA11yMember(
 }
 
 /** Live (component → hidden element) map for a root — read by setupA11yProjection each frame. */
-export function getRootA11yMembers(root: RootContext): ReadonlyMap<Component, HTMLElement> | undefined {
+export function getRootA11yMembers(
+  root: RootContext
+): ReadonlyMap<Component, HTMLElement> | undefined {
   return rootMembers.get(root)
 }
 
@@ -256,6 +285,28 @@ export function setupComponentA11y(component: Component, abortSignal: AbortSigna
       scoped.signal.addEventListener('abort', () => input.removeEventListener('input', onInput))
     }
 
+    if (role === 'listbox') {
+      // Key → move-token grammar (spec §8). The app owns column geometry and scroll; this only
+      // translates keys — no row/column math here.
+      const onKeyDown = (event: KeyboardEvent): void => {
+        const move = LISTBOX_MOVE_BY_KEY[event.key]
+        if (move != null) {
+          event.preventDefault()
+          component.properties.peek().onA11yActiveIndexChange?.({ move })
+          return
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          const { onA11yActivate, ariaActiveIndex } = component.properties.peek()
+          onA11yActivate?.(parseNumberValue(ariaActiveIndex ?? 0))
+        }
+      }
+      element.addEventListener('keydown', onKeyDown)
+      scoped.signal.addEventListener('abort', () =>
+        element.removeEventListener('keydown', onKeyDown)
+      )
+    }
+
     setupUpdateHasFocus(
       element,
       component.hasFocus,
@@ -286,7 +337,9 @@ function setupRoleState(
 ): void {
   const properties = component.properties
   const nativeFormEl =
-    element instanceof HTMLButtonElement || element instanceof HTMLInputElement ? element : undefined
+    element instanceof HTMLButtonElement || element instanceof HTMLInputElement
+      ? element
+      : undefined
 
   abortableEffect(() => {
     const disabled = properties.value.disabled === true
@@ -344,6 +397,36 @@ function setupRoleState(
         element.removeAttribute('href')
       }
     }, abortSignal)
+  }
+  if (role === 'listbox') {
+    // The one managed option (created by createHtmlA11yElement); aria-activedescendant already
+    // points at it. setsize/posinset/selected/label are re-stamped as the active index moves, so
+    // AT reads "n of N" without a DOM node per item.
+    const option = element.querySelector<HTMLElement>('[role=option]')
+    if (option != null) {
+      abortableEffect(() => {
+        const count = properties.value.ariaItemCount
+        if (count != null) {
+          option.setAttribute('aria-setsize', String(parseNumberValue(count)))
+        } else {
+          option.removeAttribute('aria-setsize')
+        }
+      }, abortSignal)
+      abortableEffect(() => {
+        const index = properties.value.ariaActiveIndex
+        if (index != null) {
+          option.setAttribute('aria-posinset', String(parseNumberValue(index) + 1))
+        } else {
+          option.removeAttribute('aria-posinset')
+        }
+      }, abortSignal)
+      abortableEffect(() => {
+        option.setAttribute('aria-selected', properties.value.ariaSelected ? 'true' : 'false')
+      }, abortSignal)
+      abortableEffect(() => {
+        option.textContent = properties.value.ariaActiveLabel ?? ''
+      }, abortSignal)
+    }
   }
   if (role === 'slider') {
     const input = element as HTMLInputElement

--- a/packages/uikit/src/a11y/hidden-element.ts
+++ b/packages/uikit/src/a11y/hidden-element.ts
@@ -289,6 +289,11 @@ export function setupComponentA11y(component: Component, abortSignal: AbortSigna
       // Key → move-token grammar (spec §8). The app owns column geometry and scroll; this only
       // translates keys — no row/column math here.
       const onKeyDown = (event: KeyboardEvent): void => {
+        // Unlike click (which routes through dispatchActivation's disabled guard), this path calls
+        // the callbacks directly — so a disabled listbox must ignore arrow/Enter/Space itself.
+        if (component.properties.peek().disabled === true) {
+          return
+        }
         const move = LISTBOX_MOVE_BY_KEY[event.key]
         if (move != null) {
           event.preventDefault()

--- a/packages/uikit/src/tests/a11y-hidden-element.test.ts
+++ b/packages/uikit/src/tests/a11y-hidden-element.test.ts
@@ -91,11 +91,11 @@ describe('createHtmlA11yElement — role → native element', () => {
     expect(el.getAttribute('src')).toContain('svg')
   })
 
-  it('an unimplemented role (listbox) warns once and falls back to <p> content', () => {
+  it('an unimplemented role (landmark) warns once and falls back to <p> content', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      expect(createHtmlA11yElement('listbox').tagName).toBe('P')
-      createHtmlA11yElement('listbox') // second time: already warned, stays quiet
+      expect(createHtmlA11yElement('landmark').tagName).toBe('P')
+      createHtmlA11yElement('landmark') // second time: already warned, stays quiet
       expect(warn).toHaveBeenCalledTimes(1)
     } finally {
       warn.mockRestore()

--- a/packages/uikit/src/tests/a11y-listbox.test.ts
+++ b/packages/uikit/src/tests/a11y-listbox.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { signal } from '@preact/signals-core'
+import { Object3D } from 'three'
+import { loadYoga } from 'yoga-layout/load'
+import { Container } from '../index.js'
+import { createHtmlA11yElement } from '../a11y/hidden-element.js'
+
+/**
+ * Virtualized listbox role (spec §8, WAI-ARIA APG listbox): ONE focusable role="listbox" element
+ * with ONE managed role="option" child re-labelled as the active index moves. Keydown translates
+ * to app-owned move tokens — the app owns geometry/scroll; no rows/columns are computed here.
+ */
+
+function mount(properties: ConstructorParameters<typeof Container>[0]): Container {
+  const container = new Container(properties)
+  new Object3D().add(container)
+  return container
+}
+
+beforeAll(async () => {
+  await loadYoga()
+})
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-uikit-a11y]')) {
+    el.remove()
+  }
+})
+
+describe('createHtmlA11yElement — listbox', () => {
+  it('builds a focusable listbox with one managed option child as its active descendant', () => {
+    const listbox = createHtmlA11yElement('listbox')
+    expect(listbox.tagName).toBe('DIV')
+    expect(listbox.getAttribute('role')).toBe('listbox')
+    expect(listbox.getAttribute('tabindex')).toBe('0')
+
+    const option = listbox.querySelector('[role=option]')
+    expect(option).not.toBeNull()
+    expect(option!.id).not.toBe('')
+    expect(listbox.getAttribute('aria-activedescendant')).toBe(option!.id)
+
+    // Visually gone but in the accessibility tree, like every hidden a11y element.
+    expect(listbox.style.opacity).toBe('0')
+    expect(listbox.style.pointerEvents).toBe('none')
+  })
+
+  it('mints a distinct option id per listbox', () => {
+    const a = createHtmlA11yElement('listbox').querySelector('[role=option]')!
+    const b = createHtmlA11yElement('listbox').querySelector('[role=option]')!
+    expect(a.id).not.toBe(b.id)
+  })
+})
+
+describe('setupRoleState — listbox option state', () => {
+  it('syncs aria-setsize / aria-posinset / aria-selected / textContent on signal writes', () => {
+    const ariaItemCount = signal(1594)
+    const ariaActiveIndex = signal(0)
+    const ariaActiveLabel = signal<string | undefined>('anchor')
+    const ariaSelected = signal(false)
+    const c = mount({
+      role: 'listbox',
+      ariaLabel: 'Icons',
+      ariaItemCount,
+      ariaActiveIndex,
+      ariaActiveLabel,
+      ariaSelected,
+    })
+    try {
+      const listbox = c.a11yElement!
+      const option = listbox.querySelector('[role=option]')!
+      expect(listbox.getAttribute('aria-activedescendant')).toBe(option.id)
+      expect(option.getAttribute('aria-setsize')).toBe('1594')
+      expect(option.getAttribute('aria-posinset')).toBe('1')
+      expect(option.getAttribute('aria-selected')).toBe('false')
+      expect(option.textContent).toBe('anchor')
+
+      ariaItemCount.value = 42
+      ariaActiveIndex.value = 7
+      ariaActiveLabel.value = 'badge'
+      ariaSelected.value = true
+      expect(option.getAttribute('aria-setsize')).toBe('42')
+      expect(option.getAttribute('aria-posinset')).toBe('8')
+      expect(option.getAttribute('aria-selected')).toBe('true')
+      expect(option.textContent).toBe('badge')
+
+      ariaActiveLabel.value = undefined
+      expect(option.textContent).toBe('')
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('honors shared disabled handling: tabIndex 0 enabled, -1 disabled', () => {
+    const disabled = signal(false)
+    const c = mount({ role: 'listbox', ariaLabel: 'Icons', disabled })
+    try {
+      const listbox = c.a11yElement!
+      expect(listbox.tabIndex).toBe(0)
+      disabled.value = true
+      expect(listbox.tabIndex).toBe(-1)
+      expect(listbox.getAttribute('aria-disabled')).toBe('true')
+    } finally {
+      c.dispose()
+    }
+  })
+})
+
+describe('listbox keydown grammar', () => {
+  const moves: Array<[string, string]> = [
+    ['ArrowRight', 'next'],
+    ['ArrowLeft', 'prev'],
+    ['ArrowDown', 'nextRow'],
+    ['ArrowUp', 'prevRow'],
+    ['Home', 'first'],
+    ['End', 'last'],
+  ]
+
+  it.each(moves)('%s → onA11yActiveIndexChange({ move: %s }) and preventDefault', (key, move) => {
+    const onA11yActiveIndexChange = vi.fn()
+    const c = mount({ role: 'listbox', ariaLabel: 'Icons', onA11yActiveIndexChange })
+    try {
+      const event = new KeyboardEvent('keydown', { key, cancelable: true })
+      c.a11yElement!.dispatchEvent(event)
+      expect(onA11yActiveIndexChange).toHaveBeenCalledTimes(1)
+      expect(onA11yActiveIndexChange).toHaveBeenCalledWith({ move })
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it.each([['Enter'], [' ']])('%j → onA11yActivate(currentIndex)', (key) => {
+    const onA11yActivate = vi.fn()
+    const ariaActiveIndex = signal(11)
+    const c = mount({ role: 'listbox', ariaLabel: 'Icons', ariaActiveIndex, onA11yActivate })
+    try {
+      const event = new KeyboardEvent('keydown', { key, cancelable: true })
+      c.a11yElement!.dispatchEvent(event)
+      expect(onA11yActivate).toHaveBeenCalledTimes(1)
+      expect(onA11yActivate).toHaveBeenCalledWith(11)
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('Enter with no ariaActiveIndex activates index 0', () => {
+    const onA11yActivate = vi.fn()
+    const c = mount({ role: 'listbox', ariaLabel: 'Icons', onA11yActivate })
+    try {
+      c.a11yElement!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }))
+      expect(onA11yActivate).toHaveBeenCalledWith(0)
+    } finally {
+      c.dispose()
+    }
+  })
+
+  it('unmapped keys neither fire callbacks nor preventDefault', () => {
+    const onA11yActiveIndexChange = vi.fn()
+    const onA11yActivate = vi.fn()
+    const c = mount({
+      role: 'listbox',
+      ariaLabel: 'Icons',
+      onA11yActiveIndexChange,
+      onA11yActivate,
+    })
+    try {
+      const event = new KeyboardEvent('keydown', { key: 'a', cancelable: true })
+      c.a11yElement!.dispatchEvent(event)
+      expect(onA11yActiveIndexChange).not.toHaveBeenCalled()
+      expect(onA11yActivate).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    } finally {
+      c.dispose()
+    }
+  })
+})

--- a/packages/uikit/src/tests/a11y-listbox.test.ts
+++ b/packages/uikit/src/tests/a11y-listbox.test.ts
@@ -156,6 +156,26 @@ describe('listbox keydown grammar', () => {
     }
   })
 
+  it('a disabled listbox ignores arrow/Enter keydown (codex P2 #2)', () => {
+    const onA11yActiveIndexChange = vi.fn()
+    const onA11yActivate = vi.fn()
+    const c = mount({
+      role: 'listbox',
+      ariaLabel: 'Icons',
+      disabled: true,
+      onA11yActiveIndexChange,
+      onA11yActivate,
+    })
+    try {
+      c.a11yElement!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true }))
+      c.a11yElement!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }))
+      expect(onA11yActiveIndexChange).not.toHaveBeenCalled()
+      expect(onA11yActivate).not.toHaveBeenCalled()
+    } finally {
+      c.dispose()
+    }
+  })
+
   it('unmapped keys neither fire callbacks nor preventDefault', () => {
     const onA11yActiveIndexChange = vi.fn()
     const onA11yActivate = vi.fn()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1837,12 +1837,18 @@ importers:
       '@types/three':
         specifier: 'catalog:'
         version: 0.183.1
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.10.6
       react:
         specifier: 'catalog:'
         version: 19.2.3
       three:
         specifier: 'catalog:'
         version: 0.183.1(patch_hash=7342f6838d6d5c06d076fb84a89d9e262887d2ed7bc07b4d3bf78fce8454dcfc)
+      yoga-layout:
+        specifier: 'catalog:'
+        version: 3.2.1
 
   packages/uikit-default/example:
     dependencies:
@@ -10681,7 +10687,7 @@ snapshots:
       unstorage: 1.17.5
       vfile: 6.0.3
       vite: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@7.3.6(@types/node@22.19.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -14385,9 +14391,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.6(@types/node@22.19.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
 
   vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.7)(happy-dom@20.10.6)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
### **User description**
## Native a11y — Phase 2: widgets + virtualized listbox (stacked on Phase 1 #183)

Gives every interactive `uikit-default` widget its WAI-ARIA role + state, adds a virtualized-listbox core for large collections, and dogfoods both. Behavior moves from `onClick` to `onActivate`, so a single handler covers pointer + keyboard + AT + future XR.

### What shipped

- **Widget roles + state** (`uikit-default`, WAI-ARIA APG): checkbox → `checkbox`/aria-checked; switch → `switch`/aria-checked; radio-group item → `radio`/aria-checked (group compare); tabs trigger → `tab`/aria-selected; accordion → the toggle moved from `AccordionItem.onClick` to `AccordionTrigger.onActivate` (role `button` + aria-expanded; item made a non-interactive wrapper — the correct APG shape, no double-toggle); slider → `slider`/aria-valuenow/min/max/step + `onA11yValueChange` through the shared clamp/step path; toggle + toggle-group → `togglebutton`/aria-pressed. Each with a happy-dom unit test. Textarea now forwards `ariaLabel`/`ariaDescription` to its hidden input (a gap the test surfaced).
- **Virtualized listbox** (`a11y/hidden-element.ts`, spec §8): one focusable `role=listbox` with a single managed `role=option` (aria-posinset/aria-setsize/aria-selected/label) + `aria-activedescendant`; keydown grammar (arrows/Home/End → `onA11yActiveIndexChange({ move })`, Enter/Space → `onA11yActivate(index)`). The app owns geometry.
- **Dogfoods**: the lucide icon grid's scroll container becomes a `role=listbox` with keyboard active-index navigation (active-index state only, memo keeps virtualization at 60fps); both paired bento examples (React + vanilla three) label all interactive controls, and the vanilla one demonstrates explicit `setupA11yProjection(root, { camera, renderer })`.

### Adversarial review (Codex `gpt-5.5`)

Codex **validated** the widget semantics (native `<button aria-pressed>` for togglebutton, accordion trigger-only, no aria-checked on plain buttons) and found 5 issues. Four fixed (`e1f7482a`); one deferred:

| # | Issue | Resolution |
|---|-------|-----------|
| 2 | listbox keydown bypassed the disabled guard | early-return when disabled (+ regression test) |
| 3 | grid never passed `aria-selected` | pass it from the live selection |
| 4 | active index reset only in an effect → stale `posinset` while filtering / "1 of 0" | derive a clamped `safeActiveIdx` during render |
| 5 | pointer selection didn't move the active descendant | pointer toggle now sets the active index |
| 1 | composite `radiogroup`/`tablist`/`tabpanel` roles + `aria-controls`/`labelledby` relationships | **deferred** — needs new core roles + id wiring; beyond the planned item-role scope, tracked follow-up |

### Gate

- `tsc --noEmit` clean (uikit, uikit-default, all 3 examples); `pnpm lint` 0 errors
- **145 uikit tests + 58 uikit-default tests** (widget roles/state/toggle, listbox element + APG keydown + disabled guard, projection, activation, announcer, schema)

### Live probe status

The load-bearing live browser probe was **partially confirmed and is otherwise deferred to a stable browser** this session — an environment/tooling issue, not a code defect:

- **In-browser confirmed**: the lucide app rendered (WebGL2 fallback) with the toolbar a11y tree — the labeled search `input` + 3 correctly-named hidden `<button>`s (`Select all 1594 icons` / `Copy manifest` / `Clear selection`) + the `__uikitA11yDebug` hook — matching Phase 1's already-green toolbar probe (IoU 1.0).
- **Blocked**: the automated browser's R3F `<Canvas>` init is flaky (it can load with the canvas stuck at its default 300×150 until a synthetic resize fires; reloads are inconsistent), so the full grid-listbox keyboard-nav + bento walkthrough couldn't be captured reliably. Both connected browsers exhibited this; last session's Phase 1 probe was green on the same infrastructure.
- **Code path proven instead**: a happy-dom repro confirms an `overflow:scroll` + `role=listbox` Container creates its managed listbox/option element (the exact grid shape), and the listbox keydown grammar + posinset/setsize/aria-selected sync are covered by the 15 unit tests. To re-run the full in-browser grid/bento probe: serve the example and, in the automated tab, `window.focus(); dispatchEvent(new Event('resize'))` before asserting.

https://claude.ai/code/session_01VSsxMZfAcro1QjCshpnbXf


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Assign WAI-ARIA roles and states to every interactive default widget
  - `role` and `aria-checked`/`aria-pressed` etc. synced from signals
  - `onClick` moved to `onActivate` for unified pointer/keyboard/AT activation

- Move accordion toggle from `AccordionItem` to `AccordionTrigger` to prevent double‑firing

- Implement virtualized listbox role with single managed option, key‑driven active index, and app‑owned geometry

- Dogfood a11y in React and vanilla examples (icon grid listbox, labeled controls)

- Forward `ariaLabel`/`ariaDescription` from `Textarea` wrapper to inner hidden input

- Add extensive unit tests for each widget’s a11y contract and listbox keyboard grammar


___

### Diagram Walkthrough


```mermaid
flowchart LR
  W["Interactive Widgets"] -- "role & aria" --> ROLES["ARIA roles & states"]
  W -- "onClick → onActivate" --> ACTIVATE["Single activation path"]
  ACC["AccordionItem"] -- "move click handler" --> TRIGGER["AccordionTrigger handles activation"]
  LIST["hidden-element.ts"] -- "adds listbox role" --> VL["Virtualized listbox"]
  DOGFOOD["Example apps"] -- "ariaLabel, listbox" --> USAGE["Dogfood a11y"]
  TESTS["Unit tests"] -- "cover widgets & listbox" --> COVERAGE["A11y contract validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>hidden-element.ts</strong><dd><code>Add virtualized listbox role creation and keydown grammar</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-c5d14b68277bc275fe65779369cca496dfdd88d5bd4e1b4ef31c78aff2a3de96">+91/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Dogfood listbox on icon grid with active index, keyboard scrolling, </code><br><code>and selection</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-67e012235f65deb29b878ed4b306e836b88a3f286018e248f2dd4812730ba9a1">+126/-15</a></td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Add ariaLabels to menu controls (tabs, inputs, sliders, switch, </code><br><code>checkbox, buttons)</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-e5a319059167742e2c29b09ed3e1e1a1c1fe8034084d22db40477abf1c9da95a">+25/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong><dd><code>Apply ariaLabels in vanilla example and wire projection teardown</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-2af41a70c56e20be5cd6a77f8b684cbc774ce6db00a5b56b9a6de790c801b56b">+32/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trigger.ts</strong><dd><code>Add role button, ariaExpanded, and onActivate for accordion trigger</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-5af97f78b33ba09ad3ad26d52a0e9fcc1ceeafdee0e6fbb36c03b4ec1c2777e2">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add role checkbox, ariaChecked, and onActivate to Checkbox</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-8b092a758806fb0aace1ae4f86fc6ad0944a1b60365bc6b2ded5abde10ceaad4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>item.ts</strong><dd><code>Add role radio, computed ariaChecked, and onActivate to RadioGroupItem</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-23e0ce2094a89cb032398b1408f4a2a65dce36905dcd0c6cd15b4c10d78d8810">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add role slider, aria-value* syncing, onA11yValueChange, and refactor </code><br><code>setValue</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-4d12867243e80ad16528a9b483fe24e7cf509f9625ebd61a021be4a6bae167e8">+20/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add role switch, ariaChecked, and onActivate to Switch</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-4272ad93e0d6d8d582d713facf844ce93143358e3b4677d52b3ae6b1f2635cdd">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trigger.ts</strong><dd><code>Add role tab, ariaSelected, and onActivate to TabsTrigger</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-eb4cc11c2be8165eacf9b3aad40fafd4722c4c31958156179e352b8161ac7723">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Forward ariaLabel and ariaDescription from Textarea to inner hidden </code><br><code>textarea</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-79e5ecb56475fad11434a6c102ca0c34ec3d3c846c1b60ba23e11c3074371602">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>a11y-listbox.test.ts</strong><dd><code>Test listbox element, option state sync, and keyboard interactions</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-0968f9483c10ff161ea57bc90f55b8fa082b61f511d62bcacdf01f834064e3d4">+198/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>a11y-hidden-element.test.ts</strong><dd><code>Update unimplemented role test from listbox to landmark</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-1bde0cf31d8349c0c79822e05790755086488679b67f24e51045f904dcfeb46e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trigger.test.ts</strong><dd><code>Test accordion trigger a11y wiring and activation behaviour</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-a98d3e4c6fe846559a29c523abb0f39e856c9033d328aae165b63bb394fb369a">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.test.ts</strong><dd><code>Test Checkbox a11y contract (role, aria-checked, </code><br><code>controlled/uncontrolled, disabled)</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-3a8d2d0bc4bdd1c42f88a66a949e8985df75c77ce80071ed655e9f0dd1353dee">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.test.ts</strong><dd><code>Test Slider a11y values, clamp/step path, controlled vs uncontrolled, </code><br><code>and disabled state</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-6391d6e8612fc572909e1f5ac944066ec78069650d36b7022b692f2b6bb135b0">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.test.ts</strong><dd><code>Test Switch a11y wiring (role, aria-checked, activation, </code><br><code>controlled/disabled behaviour)</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-5f591431588ca4676e19755652ac965f043ba76978234d385598df2d11594e91">+115/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>item.ts</strong><dd><code>Remove onClick toggle to let AccordionTrigger own activation</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-eeb859f7d8e5c265fc58831d868c37c703bf462e8c72f61af3455cc246bf5371">+4/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add happy-dom and yoga-layout as dev dependencies for new tests</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-ea41944f79515228de89aeea589c0e3f84eff8ce13ce32538afb50013e75cd69">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>index.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-24a440a84df378f88f17a16a7cb0fe5a42d7ef5b34e983be473c2eef2acbe211">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>item.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-3d503e48b3ddfe5a122bc6b2454d3e7f127c3ab5c13ded93932f590b1791dcae">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>trigger.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-9b743cbdcc9ee170c63b13e3bd076dd90f72e8eba00bb60aeb2485ed0396c2fa">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-7d82c06aad5f475d44014216563076efd2126bc6a9152be56731e86a05db3404">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>item.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-d954d5b8dfe8d7414d5c0d17f849da109231ee8e896e86622808307780e82fbe">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>item.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-b47ef9188d00f2050431fdf8e75ff4f3b8400dc8ef963a98e329bec385f12d6a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.test.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-c0fbcb6d455ab611694674c6d4e38e978c459a0be1d06bc97eebbae3b9799971">+116/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/184/files#diff-0b60411aa28a2985eb05cdec7249e0a9eb925087c0d6a464ce86233677a52653">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

