### PR TITLE
fix(vscode): correct README image URLs + guard against sidecar-less VSIX

### DIFF
--- a/tools/vscode/scripts/package-vsix.mjs
+++ b/tools/vscode/scripts/package-vsix.mjs
@@ -81,6 +81,27 @@ if (vsceCommand === 'package' && !hasExplicitOut) {
 const hasExplicitBranch = extraArgs.includes('--githubBranch')
 if (!hasExplicitBranch) args.push('--githubBranch', 'main')
 
+// vsce rewrites README.md's RELATIVE image paths (docs/marketplace/*.png,
+// icons/readme/*.png) to absolute URLs at package time — but it resolves
+// them against the REPOSITORY ROOT and ignores package.json's
+// `repository.directory` (tools/vscode). In this monorepo that drops the
+// `tools/vscode/` prefix, so every rewritten image URL 404s on both the
+// Marketplace listing and the in-editor Extensions detail page (verified:
+// `.../raw/main/docs/marketplace/banner.png` → 404, `.../raw/main/tools/
+// vscode/docs/marketplace/banner.png` → 200). Pin the image base to the
+// subdir so the rewrite resolves to the committed files. Images are loaded
+// live over HTTPS from these URLs — they are NEVER served from inside the
+// .vsix (that's why .vscodeignore excludes docs/ + icons/readme/), so a
+// base64/local-packaged approach can't work; a reachable HTTPS URL is the
+// only path. `main` matches --githubBranch above; the assets must be on it.
+const hasImagesBase = extraArgs.some((a) => a === '--baseImagesUrl')
+if (!hasImagesBase) {
+  args.push(
+    '--baseImagesUrl',
+    'https://raw.githubusercontent.com/thejustinwalsh/three-flatland/main/tools/vscode'
+  )
+}
+
 try {
   writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n')
   console.log(`[package-vsix] package.json name: ${realName} → ${VSCE_VALID_NAME} (temporary)`)

--- a/tools/vscode/scripts/package-vsix.mjs
+++ b/tools/vscode/scripts/package-vsix.mjs
@@ -23,7 +23,7 @@
 // than slicing from the first/last one) makes this robust to that no
 // matter how many separators end up in argv.
 import { execFileSync } from 'node:child_process'
-import { copyFileSync, readFileSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -100,6 +100,38 @@ if (!hasImagesBase) {
     '--baseImagesUrl',
     'https://raw.githubusercontent.com/thejustinwalsh/three-flatland/main/tools/vscode'
   )
+}
+
+// GUARD: never ship a sidecar-less VSIX. `vsce` packages whatever files
+// are on disk and NEVER errors on a missing sidecar — so a package/publish
+// run on a tree where `bundle:sidecars` and/or `build` didn't run produces
+// a VSIX that installs fine but has NO working CodeLens (bin/) or FL Audio
+// (audio-play/), silently. This already bit once: a hand-built 0.0.0 VSIX
+// shipped without either. Verify the built artifacts exist and abort loudly
+// otherwise, for BOTH a bare local `pnpm run package` and the CI publish
+// path (whose assemble-and-package job builds these in dedicated steps
+// before calling `pnpm run package`). This only VERIFIES — it must NOT
+// build the sidecars itself: CI assembles all six platforms' codelens
+// binaries into bin/ before this point, and a current-platform-only
+// `bundle:sidecars` here would clobber that universal set down to one.
+const codelensBin = `bin/${process.platform}-${process.arch}/codelens-service${
+  process.platform === 'win32' ? '.exe' : ''
+}`
+const requiredArtifacts = [
+  ['dist/extension.js', 'pnpm --filter @three-flatland/vscode build'],
+  [codelensBin, 'pnpm run bundle:sidecars'],
+  ['audio-play/sidecar.js', 'pnpm run bundle:sidecars'],
+]
+const missingArtifacts = requiredArtifacts.filter(([rel]) => !existsSync(join(VSCODE_ROOT, rel)))
+if (missingArtifacts.length > 0) {
+  console.error(
+    `[package-vsix] Refusing to ${vsceCommand} — the VSIX would ship WITHOUT working ` +
+      `CodeLens/FL Audio. Missing build artifacts:\n` +
+      missingArtifacts.map(([rel, how]) => `  - ${rel}   (build with: ${how})`).join('\n') +
+      `\nRun \`pnpm run bundle:sidecars && pnpm --filter @three-flatland/vscode build\` first. ` +
+      `(CI's assemble-and-package job does this before \`pnpm run package\`.)`
+  )
+  process.exit(1)
 }
 
 try {


### PR DESCRIPTION
### **User description**
Two packaging-integrity fixes for the FL Tools VSIX, both proven against a real rebuilt package.

## 1. README images 404'd (monorepo rewrite base)

`vsce` rewrites README.md's relative image paths to absolute URLs at package time, but resolves them against the **repository root** and ignores `package.json`'s `repository.directory` (`tools/vscode`). In this monorepo that dropped the `tools/vscode/` prefix, so every screenshot + section-icon URL 404'd on both the Marketplace listing and the in-editor Extensions detail page.

- Proven: the previously-built `0.0.0` VSIX baked `…/raw/main/docs/marketplace/banner.png` → **404**; the real file lives at `…/raw/main/tools/vscode/docs/marketplace/banner.png` → **200**.
- Fix: pass `--baseImagesUrl …/main/tools/vscode`. Images load live over HTTPS from these URLs — they are never served from inside the `.vsix` (that's why `.vscodeignore` excludes `docs/` + `icons/readme/`), so base64/local-packaging can't work; a reachable HTTPS URL is the only path.
- Verified end-to-end: rebuilt the VSIX; **all 13** baked image URLs are now live `200` (were `404`).

## 2. Guard against a sidecar-less VSIX

`vsce` packages whatever files are on disk and never errors on a missing sidecar, so `pnpm run package` / `publish:vscode` on a tree where `bundle:sidecars`/`build` didn't run produces a VSIX that installs fine but has **no working CodeLens (`bin/`) or FL Audio (`audio-play/`)** — silently. This already bit once (the hand-built `0.0.0` VSIX shipped without either).

- Fix: a presence guard in `package-vsix.mjs` — verify `dist/extension.js`, the current platform's `bin/<platform>-<arch>/codelens-service`, and `audio-play/sidecar.js` exist before invoking `vsce`; abort with a clear remediation message otherwise.
- It only **verifies** — deliberately does not build the sidecars, because CI's `assemble-and-package` job assembles all six platforms' codelens binaries into `bin/` before calling `pnpm run package`, and a current-platform-only bundle here would clobber that universal set. Belt-and-suspenders with CI's existing 6-binary verify step; the real new coverage is a bare local package/publish.
- Verified: hiding `audio-play/sidecar.js` makes `package` abort with exit 1; with all artifacts present it packages normally.

Not published anywhere yet (Marketplace + Open VSX both 404), so no republish is needed — these just ensure the first publish (and any local build) bakes correct image URLs and can't silently omit the sidecars.

https://claude.ai/code/session_01YVt7in7aFY1erzhiz9gBzL


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix 404 README image URLs on Marketplace by passing `--baseImagesUrl` to `vsce` in the monorepo subdirectory.

- Add guard to detect missing built artifacts (`dist/extension.js`, platform codelens binary, and audio-play/sidecar.js) before packaging, preventing a silently broken VSIX.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package-vsix.mjs"] --> B["Add --baseImagesUrl to vsce"]
  A --> C["Check required artifacts"]
  C -->|missing| D["Abort with error message"]
  C -->|present| E["Run vsce package"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-vsix.mjs</strong><dd><code>Fix README image URLs and add sidecar presence guard for VSIX </code><br><code>packaging</code></dd></summary>
<hr>

tools/vscode/scripts/package-vsix.mjs

<ul><li>Added <code>--baseImagesUrl</code> argument to vsce pointing to the monorepo <br>subdirectory (<code>tools/vscode</code>), fixing Marketplace README image 404s.<br> <li> Added a guard that verifies <code>dist/extension.js</code>, the platform-specific <br><code>bin/<platform>-<arch>/codelens-service</code> binary, and <code>audio-play/sidecar.js</code> exist before <br>packaging; aborts with remediation instructions if any are missing.<br> <li> Imported <code>existsSync</code> from <code>node:fs</code> for the existence check.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/191/files#diff-03e48203a45ebdd4e03a4e4da48ed3e8b6591830ac7b91a755e0116f0cc5cc47">+54/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VSIX packaging reliability by ensuring README images use a consistent base URL.
  * Added validation for required build artifacts before packaging, with clear errors when files are missing.
  * Prevented incomplete extension packages from being generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->