### PR TITLE
ci(vscode): publish via Entra ID OIDC (drop end-of-life PAT)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -224,6 +224,14 @@ jobs:
     needs: [check-version, assemble-and-package]
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      # Azure DevOps Personal Access Tokens are END OF LIFE — the VS Code
+      # Marketplace publish uses Microsoft Entra ID instead (see the
+      # `--azure-credential` step below). `id-token: write` lets `azure/login`
+      # mint a short-lived OIDC federated token, so there is NO long-lived
+      # secret to store or rotate. `contents: read` is for the checkout.
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -249,6 +257,23 @@ jobs:
       - name: List downloaded package
         run: ls -la tools/vscode/*.vsix
 
+      # Microsoft Entra ID auth — Azure DevOps PATs (the old `VSCE_PAT`) are
+      # end of life, so `vsce publish` authenticates via Entra instead.
+      # OIDC federated credential: the Entra app registration trusts this
+      # repo's `release` environment, so nothing is stored here — GitHub
+      # mints a short-lived token per run. `az login` establishes the
+      # credential that `vsce publish --azure-credential` (via
+      # @azure/identity) exchanges for an Azure DevOps access token.
+      # `allow-no-subscriptions` because publishing touches no Azure
+      # subscription/ARM — the service principal only needs to be a member
+      # of the `three-flatland` Marketplace publisher (see PUBLISHING.md).
+      - name: Azure login (Entra ID via OIDC — no PAT)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
       # --skip-duplicate: idempotent re-runs (a retried job, or this
       # workflow re-triggering on an unrelated package.json edit that
       # didn't actually change the version) fail silently instead of
@@ -256,9 +281,7 @@ jobs:
       # it if both somehow both let a run through.
       - name: Publish to VS Code Marketplace
         working-directory: tools/vscode
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx vsce publish --packagePath *.vsix --skip-duplicate
+        run: npx vsce publish --azure-credential --packagePath *.vsix --skip-duplicate
 
       - name: Publish to Open VSX
         working-directory: tools/vscode

--- a/tools/vscode/PUBLISHING.md
+++ b/tools/vscode/PUBLISHING.md
@@ -18,11 +18,27 @@ in a browser.
    `tools/vscode/package.json`. If that exact ID is taken, you'll need to either negotiate for it
    or change `package.json`'s `publisher` field to match whatever you actually register (and update
    the marketplace badge URL in `README.md` to match).
-3. Generate a Personal Access Token at <https://dev.azure.com> (any organization, or "All accessible
-   organizations"): **User Settings → Personal Access Tokens → New Token**, scope
-   **Marketplace → Manage**, expiration however long you're comfortable with (these can be rotated
-   later without re-touching CI — just update the GitHub secret).
-4. This is your `VSCE_PAT`.
+3. **Set up Microsoft Entra ID auth. Azure DevOps Personal Access Tokens are END OF LIFE — there is
+   no `VSCE_PAT` anymore.** CI publishes via an Entra service principal with an OIDC federated
+   credential: nothing is stored in the repo, nothing expires or needs rotating. In the Azure portal
+   (<https://portal.azure.com> → Microsoft Entra ID):
+   1. **App registrations → New registration** (single-tenant is fine). Record its **Application
+      (client) ID** and the **Directory (tenant) ID** — these are the two values CI needs.
+   2. On that app → **Certificates & secrets → Federated credentials → Add credential → "GitHub
+      Actions deploying Azure resources"**. Set Organization `thejustinwalsh`, Repository
+      `three-flatland`, Entity **Environment**, Environment name **`release`** (subject
+      `repo:thejustinwalsh/three-flatland:environment:release`). This is what lets `azure/login` sign
+      in with **no client secret** — do NOT create a client secret.
+   3. **Grant that service principal publish rights on the `three-flatland` Marketplace publisher** —
+      the one genuinely fiddly grant. On
+      <https://marketplace.visualstudio.com/manage/publishers/three-flatland>, add the app
+      registration as a publisher member (equivalently: add the service principal to the Azure DevOps
+      organization backing the publisher, with Marketplace publish access). Without this the Entra
+      token is valid but the publish 403s.
+
+   To publish **locally** (bypassing CI) the same mechanism works interactively: `az login` with an
+   account that's a publisher member, then from `tools/vscode/`:
+   `npx vsce publish --azure-credential --packagePath *.vsix --skip-duplicate`.
 
 ### 2. Register the Open VSX namespace
 
@@ -41,15 +57,20 @@ auto-deploy story for all of them at once.
    - Locally: `npx ovsx create-namespace three-flatland -p <OVSX_PAT>` (run from anywhere — this
      talks to the registry directly, not tied to this repo).
 
-### 3. Add both tokens as GitHub secrets
+### 3. Add the credentials as GitHub secrets
 
 `publish-vscode.yml`'s `publish` job runs under `environment: release` — the **same environment**
-`release.yml` already uses for the npm publish token, so if that's already configured you're just
-adding two more secrets to it.
+`release.yml` already uses for the npm publish token, so you're just adding to it.
 
 1. Repo → **Settings → Environments → release** (create it first if `release.yml`'s own npm publish
    hasn't been set up yet — it should already exist).
-2. Add environment secrets: `VSCE_PAT` and `OVSX_PAT` (the two values from steps 1–2).
+2. Add environment secrets:
+   - `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` — the Application (client) ID and Directory (tenant) ID
+     from the Entra app registration in step 1.3. (These aren't sensitive per se, but keeping them as
+     environment secrets matches the scoping of everything else here.) There is **no `VSCE_PAT`** —
+     the publish job's `permissions: id-token: write` + `azure/login` OIDC handle Marketplace auth.
+   - `OVSX_PAT` — the Open VSX token from step 2. Open VSX is an Eclipse Foundation registry, entirely
+     separate from Entra/Azure DevOps and unaffected by the PAT deprecation, so it still uses a token.
 
 Do **not** add these as repo-wide secrets — the `release` environment scoping means only jobs that
 explicitly declare `environment: release` can read them, which is why `check-version` and
@@ -124,9 +145,18 @@ erroring on a version that's already live. If you see a hard failure here anyway
 signal something's wrong (a network issue, an expired/revoked token, a marketplace-side outage) —
 don't just re-run it blindly; check the actual error first.
 
-**A token needs rotating.** Generate a new one (same steps as initial setup above), update the
-GitHub environment secret, done — nothing in the workflow itself references the token's value, it's
-only ever read from `secrets.VSCE_PAT`/`secrets.OVSX_PAT` at publish time.
+**Marketplace publish fails auth (401/403) even though the token step "succeeded".** With Entra
+there's no token to rotate — check the two things that actually break: (a) `azure/login` succeeded
+but the service principal isn't a member of the `three-flatland` publisher (step 1.3) → 403 on
+publish; (b) the federated credential's subject doesn't match — it must be
+`repo:thejustinwalsh/three-flatland:environment:release`, so the job MUST keep `environment: release`
+and `permissions: id-token: write`. A 401 usually means the federated credential/tenant/client IDs
+don't line up; a 403 means auth worked but the identity lacks publisher rights.
+
+**The Open VSX token needs rotating.** Generate a new one at
+<https://open-vsx.org/user-settings/tokens>, update the `OVSX_PAT` environment secret, done — the
+workflow only ever reads it from `secrets.OVSX_PAT` at publish time. (The Marketplace side has no
+equivalent — it's Entra OIDC now, nothing stored.)
 
 **FL Audio's CodeLenses never appear after installing from the marketplace, but work fine in a dev
 build.** This was a real bug in the first version of this pipeline: `actions/upload-artifact` /


### PR DESCRIPTION
### **User description**
Azure DevOps PATs are end of life, so `VSCE_PAT` can no longer publish. This converts the Marketplace publish to **Microsoft Entra ID via OIDC** — no stored secret, nothing to rotate.

## Workflow (`publish-vscode.yml`)
- `publish` job: `permissions: id-token: write` + `azure/login@v2` (OIDC federated credential, `allow-no-subscriptions` since publishing isn't an ARM op).
- `vsce publish --azure-credential` (pinned vsce 3.9.2 supports it; `@azure/identity` 4.13.1 is in the tree) exchanges the Entra credential for an Azure DevOps token.
- **Open VSX untouched** — `OVSX_PAT` is an Eclipse token, not an Azure DevOps PAT.

## Human setup (only you can do — see updated PUBLISHING.md)
1. Entra app registration → record client + tenant IDs.
2. Federated credential trusting `repo:thejustinwalsh/three-flatland:environment:release` (no client secret).
3. Add the service principal as a member of the `three-flatland` Marketplace publisher (the one fiddly grant — without it the token 403s).
4. Store `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` in the `release` environment. No `VSCE_PAT`.

Local path also documented: `az login && vsce publish --azure-credential`.

https://claude.ai/code/session_01YVt7in7aFY1erzhiz9gBzL


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Replace deprecated VSCE_PAT with Azure Entra ID OIDC for Marketplace publishing

- Add azure/login step with OIDC federated credential and `--azure-credential` flag to vsce

- Update PUBLISHING.md with new Entra setup and troubleshooting

- Open VSX publishing remains unchanged (OVSX_PAT)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  publish_job["publish job (environment: release)"] --> az_login["Azure login (Entra ID OIDC)"]
  az_login --> vsce["vsce publish --azure-credential"] --> marketplace["VS Code Marketplace"]
  publish_job --> ovsx["ovsx publish (OVSX_PAT)"] --> open_vsx["Open VSX"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish-vscode.yml</strong><dd><code>Switch to Entra ID OIDC for vsce publish</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish-vscode.yml

<ul><li>Added permissions block granting id-token: write for OIDC <br>authentication.<br> <li> Added azure/login@v2 step that uses Entra ID OIDC with client-id, <br>tenant-id secrets and allow-no-subscriptions.<br> <li> Replaced the VSCE_PAT environment variable with the <code>--azure-credential</code> <br>flag in the vsce publish command.<br> <li> The Open VSX publish step remains unmodified, still using OVSX_PAT.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/192/files#diff-4621bee0866f72044e7d11001cbb33893e7ff45539f5a436bdcdd64a066ee8db">+26/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PUBLISHING.md</strong><dd><code>Document Entra ID OIDC setup and troubleshooting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/PUBLISHING.md

<ul><li>Replaced PAT generation instructions with steps for Entra app <br>registration, federated credential setup, and publisher membership <br>grant.<br> <li> Updated GitHub secrets section to <code>AZURE_CLIENT_ID</code> and <code>AZURE_TENANT_ID</code>; <br>removed <code>VSCE_PAT</code>.<br> <li> Added troubleshooting guide for Entra auth failures (401/403).<br> <li> Documented local publish using <code>az login</code> and <code>--azure-credential</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/192/files#diff-dd551add1a65f0a5310cae6a3ae1d0a9a00cf80ff1e648319dc187d6b22814cc">+42/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved VS Code Marketplace publishing security by replacing long-lived access tokens with federated authentication.
  * Duplicate extension releases are now skipped automatically during publishing.
  * Open VSX publishing remains supported.

* **Documentation**
  * Updated the publishing guide with current setup, local publishing, authentication, permissions, and troubleshooting instructions.
  * Clarified required publishing credentials and token rotation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->