### PR TITLE
fix(vscode): render inert CodeLens labels (nbsp) + Three.js/R3F marketplace search

### DIFF
--- a/.changeset/vscode-codelens-render-and-search.md
+++ b/.changeset/vscode-codelens-render-and-search.md
@@ -1,5 +1,5 @@
 ---
-'@three-flatland/vscode': patch
+'@three-flatland/vscode': minor
 ---
 
 FL Audio CodeLens fixes + marketplace discoverability. The inert `Unresolved` / `Searching…` / `Not Found` lens titles rendered as a bare, invisible icon (VS Code collapses a regular space after a `$(icon)` codicon) — fixed with a non-breaking space so the label shows. The `Unresolved` lens is now clickable: it pops an information message explaining that the sound can't be determined by static analysis (live input, a sprite/preset, or a runtime-only value). The marketplace listing now surfaces for `Three.js` / `React Three Fiber` searches (description + keywords).

--- a/.changeset/vscode-codelens-render-and-search.md
+++ b/.changeset/vscode-codelens-render-and-search.md
@@ -1,0 +1,5 @@
+---
+'@three-flatland/vscode': patch
+---
+
+FL Audio CodeLens fixes + marketplace discoverability. The inert `Unresolved` / `Searching…` / `Not Found` lens titles rendered as a bare, invisible icon (VS Code collapses a regular space after a `$(icon)` codicon) — fixed with a non-breaking space so the label shows. The `Unresolved` lens is now clickable: it pops an information message explaining that the sound can't be determined by static analysis (live input, a sprite/preset, or a runtime-only value). The marketplace listing now surfaces for `Three.js` / `React Three Fiber` searches (description + keywords).

--- a/tools/vscode/e2e/fixtures/workspace/src/audio-sources.ts
+++ b/tools/vscode/e2e/fixtures/workspace/src/audio-sources.ts
@@ -226,12 +226,16 @@ export function playWadUnresolvable() {
   new Wad(invalidWadConfig).play()
 }
 
-// Negative cases: live mic input (not statically playable), sprite
-// segments (numbers, not a source keyword), and a stock preset (member
-// expression, no object literal for the scanner to read) — none match
-// wad.synth's `{source: <oscillator keyword>}` shape, and none end in a
-// recognized audio extension either. ZERO lenses for this entire block,
-// proven by the spec's exact-total assertion and per-line checks.
+// TRUE decoys: live mic input (not statically playable), sprite segments
+// (numbers, not a source keyword), and a stock preset (member expression,
+// no object literal for the scanner to read). None match wad.synth's
+// `{source: <oscillator keyword>}` shape and none end in a recognized audio
+// extension — but each is still a recognized `new Wad(...)` instantiation,
+// so the sidecar emits an UNRESOLVED wad.synth finding and each surfaces
+// exactly ONE inert `$(question) Unresolved` lens (signal over silence, #41),
+// asserted per line in zzfx-audio-lenses.spec.ts. (This block previously
+// claimed "ZERO lenses" — stale; the decoy-Unresolved feature made these
+// three inert lenses, not nothing.)
 export function synthDecoys() {
   new Wad({ source: 'mic' }).play()
   new Wad({ sprite: { hello: [0, 0.4] } }).play()

--- a/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
+++ b/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
@@ -180,7 +180,9 @@ async function fetchSettledLenses(
       const ext = vscode.extensions.all.find((e) => e.packageJSON.name === '@three-flatland/vscode')
       if (ext && !ext.isActive) await ext.activate()
       const api = ext!.exports as {
-        zzfxCodeLens: { onDidChangeCodeLenses: (listener: () => void) => import('vscode').Disposable }
+        zzfxCodeLens: {
+          onDidChangeCodeLenses: (listener: () => void) => import('vscode').Disposable
+        }
       }
 
       const [folder] = vscode.workspace.workspaceFolders ?? []
@@ -198,7 +200,10 @@ async function fetchSettledLenses(
           uri,
           100
         )) as Lens[]
-        return raw.map((l) => ({ range: { start: { line: l.range.start.line } }, command: l.command }))
+        return raw.map((l) => ({
+          range: { start: { line: l.range.start.line } },
+          command: l.command,
+        }))
       }
       const isSearching = (lenses: Lens[]): boolean =>
         lenses.some((l) => (l.command?.title ?? '').replace(/\s+/g, ' ') === '$(search) Searching…')
@@ -296,7 +301,9 @@ async function pollLensAt(
       const ext = vscode.extensions.all.find((e) => e.packageJSON.name === '@three-flatland/vscode')
       if (ext && !ext.isActive) await ext.activate()
       const api = ext!.exports as {
-        zzfxCodeLens: { onDidChangeCodeLenses: (listener: () => void) => import('vscode').Disposable }
+        zzfxCodeLens: {
+          onDidChangeCodeLenses: (listener: () => void) => import('vscode').Disposable
+        }
       }
       const [folder] = vscode.workspace.workspaceFolders ?? []
       const uri = vscode.Uri.joinPath(folder!.uri, arg.file)
@@ -311,7 +318,10 @@ async function pollLensAt(
           uri,
           100
         )) as Lens[]
-        return raw.map((l) => ({ range: { start: { line: l.range.start.line } }, command: l.command }))
+        return raw.map((l) => ({
+          range: { start: { line: l.range.start.line } },
+          command: l.command,
+        }))
       }
       const find = (lenses: Lens[]): Lens | undefined =>
         lenses.find(
@@ -467,12 +477,13 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
 
     // No declaration/initializer at all for this var-ref (a function
     // parameter) — provably never playable, so no Play/Stop pair, just a
-    // single inert lens with an empty command.
+    // single Unresolved lens wired to `explainUnresolved` (clicking pops an
+    // info message about why there's no preview, never a Play that fails).
     expect(lensAt(lenses, TONE_UNRESOLVABLE_NOTE_LINE, '▶ Play')).toBeUndefined()
     expect(lensAt(lenses, TONE_UNRESOLVABLE_NOTE_LINE, '⏹ Stop')).toBeUndefined()
     expect(
       lensAt(lenses, TONE_UNRESOLVABLE_NOTE_LINE, '$(question) Unresolved')?.command?.command
-    ).toBe('')
+    ).toBe('threeFlatland.audio.explainUnresolved')
   })
 
   // #41 slow tier: thunder.ogg misses every fast tier (it lives only at
@@ -556,7 +567,11 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
     const playLens = lensAt(lenses, CLICK_SFX_LINE, '▶ Play')!
     expect(playLens.command?.command).toBe('threeFlatland.audio.playFile')
 
-    await executeVSCodeCommand(evaluateInVSCode, playLens.command!.command, playLens.command!.arguments)
+    await executeVSCodeCommand(
+      evaluateInVSCode,
+      playLens.command!.command,
+      playLens.command!.arguments
+    )
     await executeVSCodeCommand(evaluateInVSCode, 'threeFlatland.audio.stopSong', [])
   })
 
@@ -596,8 +611,9 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
 
     // Recognized-but-unplayable Wad instantiations surface an
     // informational signal, never silence and never a Play that would
-    // always fail (#41's principle): exactly one INERT lens per decoy —
-    // Unresolved title, empty command id, nothing to click.
+    // always fail (#41's principle): exactly one lens per decoy — an
+    // Unresolved title wired to `explainUnresolved`, which pops an info
+    // message about why there's no preview (never a Play that would fail).
     for (const line of SYNTH_DECOY_LINES) {
       const decoyLenses = lenses.filter((l) => l.range.start.line === line)
       expect(
@@ -607,8 +623,8 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
       expect(decoyLenses[0]?.command?.title).toMatch(/\$\(question\)\s+Unresolved/)
       expect(
         decoyLenses[0]?.command?.command,
-        'the Unresolved lens is inert — empty command id'
-      ).toBe('')
+        'the Unresolved lens is clickable — explains why via an info message'
+      ).toBe('threeFlatland.audio.explainUnresolved')
     }
   })
 
@@ -636,7 +652,11 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
 
     // Play — the lens SET doesn't change at all: same two lenses, same
     // titles, same commands. No refresh-triggered recompute, no face flip.
-    await executeVSCodeCommand(evaluateInVSCode, playLens.command!.command, playLens.command!.arguments)
+    await executeVSCodeCommand(
+      evaluateInVSCode,
+      playLens.command!.command,
+      playLens.command!.arguments
+    )
     lenses = await fetchLenses(evaluateInVSCode)
     const whilePlaying = lenses
       .filter((l) => l.range.start.line === LONG_MARCH_CALL_LINE)
@@ -748,7 +768,11 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
     const playLens = lensAt(lenses, FANFARE_SPREAD_CALL_LINE, '▶ Play')!
     expect(playLens.command?.command).toBe('threeFlatland.audio.playSong')
 
-    await executeVSCodeCommand(evaluateInVSCode, playLens.command!.command, playLens.command!.arguments)
+    await executeVSCodeCommand(
+      evaluateInVSCode,
+      playLens.command!.command,
+      playLens.command!.arguments
+    )
     await executeVSCodeCommand(evaluateInVSCode, 'threeFlatland.audio.stopSong', [])
   })
 })

--- a/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
+++ b/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
@@ -595,11 +595,12 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
   // kind, the TRUE decoy block — mic (live input), sprite segments, and a
   // stock preset — each surfaces exactly one inert `$(question) Unresolved`
   // lens (the sidecar's unresolved wad.synth flavor), asserted per line
-  // below. NOTE: this used a NON-BREAKING space between the codicon and
-  // text (provider.ts) — a regular space collapses in VS Code's CodeLens
-  // rendering, leaving a bare, invisible icon. The matchers here normalize
-  // `\s+` (which includes the nbsp), so they don't pin that distinction —
-  // only a human/rendered check catches a regression to a plain space.
+  // below. The title uses a NON-BREAKING space between the codicon and text
+  // (provider.ts) — a regular space collapses in VS Code's CodeLens
+  // rendering, leaving a bare, invisible icon. The general matchers here
+  // normalize `\s+` (which includes the nbsp), so the loop ALSO pins the
+  // exact U+00A0 (a `toContain` below) to fail on a regression to a plain
+  // space rather than only catching it on a human's screen.
   test("Wad reverb impulse (nested 2 levels) gets a resolved ▶ Play lens; Wad's mic/sprite/preset decoys get an inert Unresolved lens each", async ({
     evaluateInVSCode,
   }) => {
@@ -621,6 +622,12 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
         `synthesis decoy on fixture line ${line} must surface exactly one lens`
       ).toHaveLength(1)
       expect(decoyLenses[0]?.command?.title).toMatch(/\$\(question\)\s+Unresolved/)
+      // Exact non-breaking-space guard (CodeRabbit): the `\s+` matcher above
+      // would still pass if the provider regressed to a REGULAR space — the
+      // exact rendering bug this fixes (VS Code collapses a regular space
+      // after a `$(icon)`, hiding the label). Pin the literal U+00A0 so a
+      // regression to a plain space fails here, not just on a human's screen.
+      expect(decoyLenses[0]?.command?.title).toContain('$(question)\u00A0Unresolved')
       expect(
         decoyLenses[0]?.command?.command,
         'the Unresolved lens is clickable — explains why via an info message'

--- a/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
+++ b/tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts
@@ -577,9 +577,14 @@ test.describe('FL Audio: multi-library Play/Stop lenses', () => {
   // reference TWO object levels down — {reverb:{impulse}}) gets a ▶ Play
   // lens with the resolved real path baked into its arguments. Since #47
   // gave Wad's oscillator/noise keywords their OWN wad.synth finding
-  // kind, only the TRUE decoy block — mic (live input), sprite segments,
-  // and a stock preset — surfaces ZERO lenses now; asserted per line, not
-  // just via the exact total above.
+  // kind, the TRUE decoy block — mic (live input), sprite segments, and a
+  // stock preset — each surfaces exactly one inert `$(question) Unresolved`
+  // lens (the sidecar's unresolved wad.synth flavor), asserted per line
+  // below. NOTE: this used a NON-BREAKING space between the codicon and
+  // text (provider.ts) — a regular space collapses in VS Code's CodeLens
+  // rendering, leaving a bare, invisible icon. The matchers here normalize
+  // `\s+` (which includes the nbsp), so they don't pin that distinction —
+  // only a human/rendered check catches a regression to a plain space.
   test("Wad reverb impulse (nested 2 levels) gets a resolved ▶ Play lens; Wad's mic/sprite/preset decoys get an inert Unresolved lens each", async ({
     evaluateInVSCode,
   }) => {

--- a/tools/vscode/e2e/specs/zzfx-synth-lenses.spec.ts
+++ b/tools/vscode/e2e/specs/zzfx-synth-lenses.spec.ts
@@ -208,7 +208,11 @@ test.describe('FL Audio: wad.synth and tone.synth Play/Stop lenses (#47)', () =>
     expect(playLens.command?.command).toBe('threeFlatland.audio.playWadSynth')
     expect(stopLens.command?.command).toBe('threeFlatland.audio.stopSong')
 
-    await executeVSCodeCommand(evaluateInVSCode, playLens.command!.command, playLens.command!.arguments)
+    await executeVSCodeCommand(
+      evaluateInVSCode,
+      playLens.command!.command,
+      playLens.command!.arguments
+    )
     // The lens SET doesn't change while playing — same two lenses.
     lenses = await fetchLenses(evaluateInVSCode)
     const whilePlaying = lenses
@@ -295,7 +299,11 @@ test.describe('FL Audio: wad.synth and tone.synth Play/Stop lenses (#47)', () =>
     expect(playLens.command?.command).toBe('threeFlatland.audio.playToneSynth')
     expect(stopLens.command?.command).toBe('threeFlatland.audio.stopSong')
 
-    await executeVSCodeCommand(evaluateInVSCode, playLens.command!.command, playLens.command!.arguments)
+    await executeVSCodeCommand(
+      evaluateInVSCode,
+      playLens.command!.command,
+      playLens.command!.arguments
+    )
     lenses = await fetchLenses(evaluateInVSCode)
     const whilePlaying = lenses
       .filter((l) => l.range.start.line === TONE_NOTE_LINE)
@@ -395,9 +403,10 @@ test.describe('FL Audio: wad.synth and tone.synth Play/Stop lenses (#47)', () =>
       if (ext && !ext.isActive) await ext.activate()
       return (ext!.exports as ExtensionApi).zzfxPlay.ping()
     })
-    expect(alive, 'the sidecar must still answer ping after dispatching PluckSynth — not crashed/hung').toBe(
-      true
-    )
+    expect(
+      alive,
+      'the sidecar must still answer ping after dispatching PluckSynth — not crashed/hung'
+    ).toBe(true)
   })
 
   // #47's wad.synth var-ref cases, driven end to end: the scanner always
@@ -460,12 +469,13 @@ test.describe('FL Audio: wad.synth and tone.synth Play/Stop lenses (#47)', () =>
     )
     await executeVSCodeCommand(evaluateInVSCode, 'threeFlatland.audio.stopSong', [])
 
-    // No Play/Stop pair at all for this line — just the one inert lens.
+    // No Play/Stop pair at all for this line — just the one Unresolved lens,
+    // clickable to an info message (never a Play that would fail).
     expect(lensAt(lenses, TONE_VAR_UNRESOLVABLE_LINE, '▶ Play')).toBeUndefined()
     expect(lensAt(lenses, TONE_VAR_UNRESOLVABLE_LINE, '⏹ Stop')).toBeUndefined()
     const unresolvedLens = lensAt(lenses, TONE_VAR_UNRESOLVABLE_LINE, '$(question) Unresolved')!
     expect(unresolvedLens).toBeDefined()
-    expect(unresolvedLens.command?.command).toBe('')
+    expect(unresolvedLens.command?.command).toBe('threeFlatland.audio.explainUnresolved')
   })
 
   // HONEST SCOPE (adversarial-review finding #2, fix/deterministic-tests-p1):
@@ -485,7 +495,7 @@ test.describe('FL Audio: wad.synth and tone.synth Play/Stop lenses (#47)', () =>
   // device-less runner — that coverage comes from
   // `audio-render-gate.spec.ts`'s offline probes instead, which call that
   // exact production helper directly, no device or sidecar process needed.
-  test('Tone play against a freshly respawned sidecar: shutdown+respawn dispatches and the process stays alive (device-tolerance, not a cold-start import(\'tone\') proof)', async ({
+  test("Tone play against a freshly respawned sidecar: shutdown+respawn dispatches and the process stays alive (device-tolerance, not a cold-start import('tone') proof)", async ({
     evaluateInVSCode,
   }) => {
     const lenses = await fetchLenses(evaluateInVSCode)

--- a/tools/vscode/extension/tools/audio/provider.ts
+++ b/tools/vscode/extension/tools/audio/provider.ts
@@ -233,21 +233,20 @@ export class ZzfxCodeLensProvider implements vscode.CodeLensProvider, vscode.Dis
     const source = { uri: docUri.toString(), findingId: finding.id }
 
     if (variant === 'unresolved') {
-      // Not clickable — same inert shape as audio.file's `$(search)
-      // Searching…` lens (empty command id). Unlike a searching/not-found
-      // audio.file reference, this can never become resolved by a later
-      // fallback search: the identifier provably has no declaration/
-      // initializer to read (see provideCodeLenses), so there's nothing
-      // to retry.
-      // \u00A0 (non-breaking space) between the codicon and the label:
-      // VS Code collapses a regular space that follows a `$(icon)` in a
-      // CodeLens title, which rendered this as a bare, near-invisible icon
-      // with no visible text in the shipped build (the old title had a
-      // DOUBLE space, both collapsed). A non-breaking space survives it.
-      // The e2e reads the lens OBJECT via executeCodeLensProvider, never
-      // VS Code's painted output, so it could not catch this; spec matchers
-      // normalize \s+ (which includes \u00A0), so they stay green.
-      codeLens.command = { title: '$(question)\u00A0Unresolved', command: '' }
+      // Clickable, but never a Play — this reference can never resolve (the
+      // identifier provably has no declaration/initializer, or the sidecar
+      // already classified the call as an unplayable mic/sprite/preset decoy
+      // at parse time; see provideCodeLenses). Instead of doing nothing,
+      // clicking it explains WHY there's no preview (`explainUnresolved`,
+      // register.ts). The title uses a NON-BREAKING space (\\u00A0) between
+      // the codicon and the text: VS Code collapses a regular space after a
+      // `$(icon)` in a CodeLens title, which rendered this as a bare,
+      // near-invisible icon with no label in the shipped build. The e2e reads
+      // the lens OBJECT (executeCodeLensProvider), never the painted output.
+      codeLens.command = {
+        title: '$(question)\u00A0Unresolved',
+        command: 'threeFlatland.audio.explainUnresolved',
+      }
       return codeLens
     }
 

--- a/tools/vscode/extension/tools/audio/provider.ts
+++ b/tools/vscode/extension/tools/audio/provider.ts
@@ -239,7 +239,15 @@ export class ZzfxCodeLensProvider implements vscode.CodeLensProvider, vscode.Dis
       // fallback search: the identifier provably has no declaration/
       // initializer to read (see provideCodeLenses), so there's nothing
       // to retry.
-      codeLens.command = { title: '$(question)  Unresolved', command: '' }
+      // \u00A0 (non-breaking space) between the codicon and the label:
+      // VS Code collapses a regular space that follows a `$(icon)` in a
+      // CodeLens title, which rendered this as a bare, near-invisible icon
+      // with no visible text in the shipped build (the old title had a
+      // DOUBLE space, both collapsed). A non-breaking space survives it.
+      // The e2e reads the lens OBJECT via executeCodeLensProvider, never
+      // VS Code's painted output, so it could not catch this; spec matchers
+      // normalize \s+ (which includes \u00A0), so they stay green.
+      codeLens.command = { title: '$(question)\u00A0Unresolved', command: '' }
       return codeLens
     }
 
@@ -324,12 +332,12 @@ export class ZzfxCodeLensProvider implements vscode.CodeLensProvider, vscode.Dis
         // Not clickable while the fallback search is in flight — the
         // empty command id renders an inert lens; onDidChangeCodeLenses
         // fires when it settles.
-        codeLens.command = { title: '$(search)  Searching…', command: '' }
+        codeLens.command = { title: '$(search)\u00A0Searching…', command: '' }
       } else {
         // The retry click carries `source` too — a successful lazy-repair
         // play is a real playback and must mark its finding active.
         codeLens.command = {
-          title: '$(search)  Not Found',
+          title: '$(search)\u00A0Not Found',
           command: 'threeFlatland.audio.playFile',
           arguments: [undefined, ref, source],
         }

--- a/tools/vscode/extension/tools/audio/register.ts
+++ b/tools/vscode/extension/tools/audio/register.ts
@@ -395,6 +395,22 @@ export function registerAudioTool(context: vscode.ExtensionContext): vscode.Disp
     )
   )
 
+  // The inert `$(question) Unresolved` lens (provider.ts) is now clickable:
+  // instead of doing nothing, it explains WHY there's no Play — the call
+  // was recognized but its sound can't be determined by static analysis
+  // (a wad.synth decoy like mic/sprite/preset, or a var-ref with no findable
+  // declaration such as a function parameter). No tool/sidecar needed — it's
+  // a pure informational message, so no `isToolEnabled`/client guards.
+  disposables.push(
+    vscode.commands.registerCommand('threeFlatland.audio.explainUnresolved', () => {
+      void vscode.window.showInformationMessage(
+        "FL Audio can't preview this call — it reads sounds statically from your source, and " +
+          "this one can't be resolved without running the code (e.g. live mic input, a sprite or " +
+          'preset reference, or a value that only exists at runtime like a function parameter).'
+      )
+    })
+  )
+
   disposables.push(
     vscode.commands.registerCommand('threeFlatland.audio.playAtCursor', async () => {
       // Defense in depth — see atlas/register.ts's identical guard comment.

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Flatland Tools",
   "version": "0.0.0",
   "private": true,
-  "description": "Visual editors for game and multimedia assets, right in your editor. Sprite atlas packing, GPU image encoding, normal-map baking, and inline audio playback. Built by the three-flatland team; every tool works standalone.",
+  "description": "Visual editors for game and multimedia assets, right in your editor — ideal for Three.js and React Three Fiber (R3F) projects. Sprite atlas packing, GPU image encoding, normal-map baking, and inline audio playback. Built by the three-flatland team; every tool works standalone.",
   "publisher": "three-flatland",
   "icon": "icons/icon.png",
   "type": "module",
@@ -25,6 +25,9 @@
   ],
   "keywords": [
     "three.js",
+    "threejs",
+    "react-three-fiber",
+    "r3f",
     "webgpu",
     "webgl",
     "tsl",


### PR DESCRIPTION
### **User description**
Two things from live testing of the built VSIX.

## 1. Inert CodeLens labels didn't render (the real bug)
The inert audio lens titles (`$(question) Unresolved`, `$(search) Searching…`, `$(search) Not Found`) used a **double regular space** between the codicon and the text. VS Code collapses that in CodeLens rendering, so the lens painted as a bare, near-invisible icon with **no visible label** — every `synthDecoys` decoy line looked empty in the shipped build. Play/Stop lenses are fine because they use plain glyphs (`▶`/`■`), not codicons.

Fix: a single **non-breaking space** (`\u00A0`) between icon and text in all three titles. Verified it ships as a runtime nbsp.

**Why the e2e didn't catch it (and my process gap):** the e2e asserts on the lens *objects* from `executeCodeLensProvider`, never VS Code's painted output, and its matchers normalize `\s+` (which includes the nbsp). A passing assertion on the object was not proof of a rendered pixel. Also corrected the stale "ZERO lenses" comments in the fixture + spec that described pre-feature behavior and misled the diagnosis.

## 2. Marketplace search (`three.js` / `react-three-fiber`)
Description now reads "…ideal for Three.js and React Three Fiber (R3F) projects…" and keywords front-load `three.js`/`threejs`/`react-three-fiber`/`r3f` (30/30 cap).

Held for stakeholder visual confirmation that the label renders before merge — the automated suite structurally can't verify it.

https://claude.ai/code/session_01YVt7in7aFY1erzhiz9gBzL


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix invisible CodeLens labels by using `\u00A0` (non-breaking space) instead of double regular space.

- Update marketplace description to mention Three.js and React Three Fiber (R3F).

- Add `threejs`, `react-three-fiber`, `r3f` keywords for better discoverability.

- Correct e2e fixture and spec comments to accurately reflect current decode-unresolved lens behavior.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio-sources.ts</strong><dd><code>Update comments to reflect decoy Unresolved lenses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/e2e/fixtures/workspace/src/audio-sources.ts

<ul><li>Updated block comment that previously claimed zero lenses, clarifying <br>that each decoy now surfaces one inert <code>Unresolved</code> lens.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/193/files#diff-80a5d798c5ffbb8afbcc1ab1ebb896853c7efd54596cc87ff22651afdbe29c74">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zzfx-audio-lenses.spec.ts</strong><dd><code>Update spec comments for inert lens rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/e2e/specs/zzfx-audio-lenses.spec.ts

<ul><li>Corrected test block comment to describe that decoy lines emit exactly <br>one inert <code>Unresolved</code> lens each.<br> <li> Added note explaining why the e2e could not catch the invisible label <br>rendering bug (object-based assertion normalizes whitespace).</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/193/files#diff-8659dea8c3b8382056b018218453e4694582591e5019f46c58f8d6c59c9a7ef1">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>provider.ts</strong><dd><code>Fix invisible CodeLens labels with non-breaking space</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/extension/tools/audio/provider.ts

<ul><li>Replaced double regular space with <code>\u00A0</code> (non-breaking space) in <br><code>$(question) Unresolved</code>, <code>$(search) Searching…</code>, and <code>$(search) Not Found</code> <br>CodeLens titles.<br> <li> This prevents VS Code from collapsing the space after the codicon, <br>restoring a visible label.<br> <li> Added comment explaining why regular spaces fail and why e2e could not <br>detect this.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/193/files#diff-9f94e8363e78e729150dbf1a91a3fe68d693972a47356d8a88c270b9621c6f4f">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Enhance marketplace description and keywords for Three.js/R3F</code></dd></summary>
<hr>

tools/vscode/package.json

<ul><li>Extended description to highlight suitability for Three.js and React <br>Three Fiber (R3F) projects.<br> <li> Front-loaded keywords with <code>threejs</code>, <code>react-three-fiber</code>, <code>r3f</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/193/files#diff-023a543d3be3038d48fc851da92a6aec39182752b2676e2d4ff30d9c8b0d821c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio CodeLens titles to render correctly with consistent spacing around status icons, including **Unresolved**, **Searching…**, and **Not Found** states.
  - Made **Unresolved** audio lenses clickable and tied them to an explanation action.

- **New Features**
  - Added an **Explain Unresolved** command to inform why a sound can’t be previewed via static analysis.

- **Documentation**
  - Updated workspace fixture comments and test expectations to reflect the current lens behavior.

- **Chores**
  - Enhanced marketplace discoverability by updating the extension description and keywords for Three.js and React Three Fiber.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->