### PR TITLE
fix(vscode): onboarding walkthrough + prod-readiness follow-ups

### DIFF
--- a/.changeset/vscode-onboarding-walkthrough.md
+++ b/.changeset/vscode-onboarding-walkthrough.md
@@ -1,0 +1,5 @@
+---
+'@three-flatland/vscode': minor
+---
+
+Add a Get Started walkthrough — VS Code opens it on install to introduce the five tools (Sprite Atlas, Image Encoder, Normal Baker, Atlas Merge, Audio) and how they surface: right-click asset files in the Explorer, and a ▶ Play CodeLens above audio calls in your code.

--- a/tools/vscode/extension/toolRegistry.ts
+++ b/tools/vscode/extension/toolRegistry.ts
@@ -180,13 +180,27 @@ export function watchToolConfiguration(context: vscode.ExtensionContext): void {
         if (action === 'noop') continue
 
         if (action === 'register') {
-          const disposable = descriptor.register(context)
-          live.set(descriptor.id, disposable)
-          context.subscriptions.push(disposable)
-          log(`toolRegistry: ${descriptor.label} enabled live`)
+          // Isolate, same as activateTools: a throw here would crash the
+          // onDidChangeConfiguration handler and stop later tools in this loop
+          // from reacting to the same config change.
+          try {
+            const disposable = descriptor.register(context)
+            live.set(descriptor.id, disposable)
+            context.subscriptions.push(disposable)
+            log(`toolRegistry: ${descriptor.label} enabled live`)
+          } catch (err) {
+            log(
+              `toolRegistry: ${descriptor.label} failed to register live — skipping. ` +
+                (err instanceof Error ? (err.stack ?? err.message) : String(err))
+            )
+          }
         } else if (action === 'dispose') {
           const disposable = live.get(descriptor.id)
-          disposable?.dispose()
+          try {
+            disposable?.dispose()
+          } catch (err) {
+            log(`toolRegistry: ${descriptor.label} failed to dispose cleanly: ${err}`)
+          }
           live.delete(descriptor.id)
           // Also drop it from context.subscriptions (it was pushed there on
           // register): leaving disposed entries accumulates them across every

--- a/tools/vscode/extension/toolRegistry.ts
+++ b/tools/vscode/extension/toolRegistry.ts
@@ -185,8 +185,16 @@ export function watchToolConfiguration(context: vscode.ExtensionContext): void {
           context.subscriptions.push(disposable)
           log(`toolRegistry: ${descriptor.label} enabled live`)
         } else if (action === 'dispose') {
-          live.get(descriptor.id)?.dispose()
+          const disposable = live.get(descriptor.id)
+          disposable?.dispose()
           live.delete(descriptor.id)
+          // Also drop it from context.subscriptions (it was pushed there on
+          // register): leaving disposed entries accumulates them across every
+          // off/on cycle and double-disposes each at deactivate().
+          if (disposable) {
+            const i = context.subscriptions.indexOf(disposable)
+            if (i !== -1) context.subscriptions.splice(i, 1)
+          }
           log(`toolRegistry: ${descriptor.label} disabled live`)
         } else {
           // 'reload-prompt-enable' | 'reload-prompt-disable' — context key

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -59,6 +59,10 @@
     "color": "#111418",
     "theme": "dark"
   },
+  "qna": false,
+  "extensionKind": [
+    "workspace"
+  ],
   "engines": {
     "vscode": "^1.94.0"
   },
@@ -80,6 +84,33 @@
     }
   },
   "contributes": {
+    "walkthroughs": [
+      {
+        "id": "flatlandGettingStarted",
+        "title": "Get Started with Flatland Tools",
+        "description": "Sprite atlases, image encoding, normal maps, and inline audio — visual editors right in your editor.",
+        "steps": [
+          {
+            "id": "flatland.overview",
+            "title": "Five tools, one extension",
+            "description": "Flatland Tools adds five visual editors for game & multimedia assets. They surface two ways: **right-click asset files** in the Explorer, and a **▶ Play** CodeLens above audio calls in your code.\n\n[Open Flatland Tools settings](command:workbench.action.openSettings?%22threeFlatland%22)",
+            "media": { "markdown": "walkthroughs/overview.md" }
+          },
+          {
+            "id": "flatland.assets",
+            "title": "Edit sprites, images & normal maps",
+            "description": "Right-click a **.png**, **.ktx2**, or **.atlas.json** in the Explorer → **Flatland Tools** to open the Sprite Atlas, Image Encoder, Normal Baker, or Atlas Merge editor.",
+            "media": { "markdown": "walkthroughs/assets.md" }
+          },
+          {
+            "id": "flatland.audio",
+            "title": "Play audio inline",
+            "description": "Open a **.js** / **.ts** file with a `zzfx(...)`, `Tone`, or `Wad` sound call — a **▶ Play** CodeLens appears above it. Click to hear the sound without running your game.",
+            "media": { "markdown": "walkthroughs/audio.md" }
+          }
+        ]
+      }
+    ],
     "commands": [
       {
         "command": "threeFlatland.atlas.openEditor",

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -94,7 +94,7 @@
           {
             "id": "flatland.overview",
             "title": "Five tools, one extension",
-            "description": "Flatland Tools adds five visual editors for game & multimedia assets. They surface two ways: **right-click asset files** in the Explorer, and a **▶ Play** CodeLens above audio calls in your code.\n\n[Open Flatland Tools settings](command:workbench.action.openSettings?%22threeFlatland%22)",
+            "description": "Flatland Tools adds five visual editors for game & multimedia assets. They surface two ways: **right-click asset files** in the Explorer, and a **▶ Play** CodeLens above audio calls in your code.\n\n[Open Flatland Tools settings](command:workbench.action.openSettings?%5B%22threeFlatland%22%5D)",
             "media": { "markdown": "walkthroughs/overview.md" }
           },
           {

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -59,6 +59,7 @@
     "color": "#111418",
     "theme": "dark"
   },
+  "preview": true,
   "qna": false,
   "extensionKind": [
     "workspace"

--- a/tools/vscode/walkthroughs/assets.md
+++ b/tools/vscode/walkthroughs/assets.md
@@ -1,0 +1,9 @@
+# Image & atlas tools
+
+Right-click any asset file in the Explorer → **Flatland Tools**:
+
+- A **`.png`** → _Open in Sprite Atlas_, _Encode Image_, or _Bake Normal Map_
+- A **`.webp` / `.avif` / `.ktx2`** → _Encode Image_ (a `.ktx2` opens in the encoder by default)
+- A **`.atlas.json`** → _Open in Sprite Atlas_ or _Merge Atlases_
+
+Each opens a full editor panel — no leaving VS Code, no external app. Edits save back to a sidecar JSON next to your image.

--- a/tools/vscode/walkthroughs/audio.md
+++ b/tools/vscode/walkthroughs/audio.md
@@ -1,0 +1,10 @@
+# Inline audio — FL Audio
+
+Open any JavaScript or TypeScript file with a sound call and a **▶ Play** CodeLens appears right above it:
+
+- `zzfx(...)` and `zzfxM(...)` — the tiny ZzFX / ZzFXM sound engine
+- `new Tone.Synth()` … and `new Wad(...)` — Tone.js & Wad
+
+Click **▶ Play** to hear it without running your game. When a sound can't be determined statically (a live value, a preset), the lens says so instead of guessing.
+
+The **ZzFX Studio** tuner panel lets you dial a sound in and copy the result straight back into your code.

--- a/tools/vscode/walkthroughs/overview.md
+++ b/tools/vscode/walkthroughs/overview.md
@@ -1,0 +1,13 @@
+# Flatland Tools
+
+Five visual editors for game & multimedia assets, right in your editor:
+
+- **FL Sprite Atlas** — pack sprite sheets, edit frames & animations (reads/writes TexturePacker & Aseprite)
+- **FL Image Encoder** — compare & encode PNG / WebP / AVIF / KTX2
+- **FL Normal Baker** — bake normal maps from a region editor
+- **FL Atlas Merge** — combine several atlases into one
+- **FL Audio** — play ZzFX / ZzFXM / Tone.js / Wad sounds inline via CodeLens
+
+They surface two ways: **right-click asset files** in the Explorer, and a **▶ Play** CodeLens above audio calls in your code.
+
+Ideal for Three.js & React Three Fiber projects — every tool also works standalone.


### PR DESCRIPTION
### **User description**
## What

Closes out the VS Code extension prod-readiness pass. The **critical fixes already landed on `main`** this session (activation deadlock, palette gate, `0.0.0` publish guard, workspace-trust capabilities, per-tool activation isolation, and restoring `darwin-x64` on the `macos-26-intel` runner). This PR is the remaining, lower-urgency batch — split out for a review pass.

### Changes

- **Onboarding walkthrough** (`contributes.walkthroughs` + `walkthroughs/*.md`). VS Code auto-opens it on install, so a freshly-installed user can immediately tell the extension loaded and where the five tools live. Direct antidote to the "loaded-but-invisible" class that caused the activation bug — the audit's top UX finding.
- **`context.subscriptions` leak fix** (`toolRegistry.ts`). Turning a `liveToggle` tool off now removes its disposable from `context.subscriptions`, so repeated setting-flips don't accumulate disposed entries (and don't double-dispose at `deactivate()`).
- **Manifest fields**: `qna: false` (support routes to GitHub Issues, not a split Marketplace Q&A tab) and `extensionKind: ["workspace"]` (explicit — the native-sidecar architecture requires the workspace host).

### Deliberately deferred (not in this PR)

Two audit findings I chose **not** to rush:
- **`THIRD_PARTY_LICENSES`** — needs real `license-checker` (JS) + `cargo-about` (Rust) generation over the bundled surface. A hand-stub would be inaccurate — worse than none. Follow-up.
- **Inline-audio async spawn-failure signal** — the correct fix touches the `audio-play` client's spawn lifecycle, which has a fragile history (deaf-sidecar, determinism flakes). Minor edge case; not worth destabilizing that path in a batch.

## Verification

- `typecheck` clean.
- Manifest valid; walkthrough wired with 3 steps + all media files present.
- No new changeset needed — this ships in the initial `0.1.0` VSIX via the existing `.changeset/vscode-tools-initial-release.md`.

## Review notes

- Walkthrough copy is functional onboarding, not marketing — happy to tune tone/wording.
- `preview: true` was considered (audit nice-to-have; honest for a 0.x initial release) but left off as a branding call — trivial to add if wanted.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add onboarding walkthrough that auto-opens on VS Code install, introducing the five tools (sprite atlas, image encoder, normal baker, atlas merge, audio) and how to access them via right-click and CodeLens.

- Fix tool registry subscription leak: when a tool is toggled off, its disposable is now removed from `context.subscriptions` to prevent accumulation and double-disposal.

- Declare `qna: false` and `extensionKind: ["workspace"]` to route support to GitHub Issues and require workspace trust for native sidecars.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VS Code Extension Install"] -- "auto-opens" --> B["Get Started Walkthrough"];
  B -- "introduces" --> C["Five Tools (assets, audio, atlas, etc.)"];
  C -- "accessed via" --> D["Right-click Explorer / CodeLens Play"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolRegistry.ts</strong><dd><code>Fix subscription leak when toggling tool off</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/extension/toolRegistry.ts

<ul><li>In <code>watchToolConfiguration</code>, for <code>dispose</code> action: after calling <br><code>dispose()</code>, remove the disposable from <code>context.subscriptions</code> using <br><code>indexOf</code> and <code>splice</code> to prevent accumulation and double-disposal.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/195/files#diff-e21cd5e88c522bb62fdc79dc3eced72d28c636c33c3b544c94a57d6ca5184eba">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add walkthrough and manifest configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/package.json

<ul><li>Added a <code>walkthroughs</code> contribution with three steps (overview, assets, <br>audio) and linked markdown media files.<br> <li> Set <code>qna: false</code> to redirect support queries to GitHub Issues.<br> <li> Set <code>extensionKind</code> to <code>["workspace"]</code> to enforce workspace host <br>requirement for native sidecars.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/195/files#diff-023a543d3be3038d48fc851da92a6aec39182752b2676e2d4ff30d9c8b0d821c">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>overview.md</strong><dd><code>Add walkthrough overview markdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/walkthroughs/overview.md

<ul><li>Markdown file providing an overview of the five visual editors and <br>their access methods (right-click, CodeLens).</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/195/files#diff-272175cb93271db5dcd1b75f01f8653aab8db22b0a109247a225363ca985104f">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>assets.md</strong><dd><code>Add asset tools walkthrough markdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/walkthroughs/assets.md

<ul><li>Describes how to right-click asset files to open editors for .png, <br>.webp, .avif, .ktx2, .atlas.json.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/195/files#diff-94434268cc78da58208ab8bee3873e288fd29ad4aeae0be4b5329b0d3ef40d44">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>audio.md</strong><dd><code>Add audio tool walkthrough markdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/walkthroughs/audio.md

<ul><li>Explains Play CodeLens for zzfx/zzfxM, Tone.js, Wad sound calls and <br>the ZzFX Studio tuner panel.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/195/files#diff-2908c6e2d7d09dce8d63f3997137a37fefb8fc8db5cb5e15d1cf21be2d7ef113">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a VS Code “Flatland Tools” walkthrough covering asset workflows and inline audio playback.
  - Added guidance for image, atlas, encoding, normal map, and audio tools.
  - Added inline **▶ Play** controls for recognized audio calls, plus access to ZzFX Studio.
  - Added Explorer actions for supported image and atlas files, with edits saved alongside source assets.

- **Bug Fixes**
  - Improved tool enable/disable handling to prevent stale resources from accumulating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->