### PR TITLE
fix(changeset): move .changeset/CLAUDE.md to README.md so the release parser doesn't choke

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,5 +1,13 @@
 # Changeset and Release Flow
 
+> **Agents & contributors:** this is the changeset guidance for the repo (the file that used to
+> be `.changeset/CLAUDE.md`). It **must** live as `README.md` and nowhere else in this directory.
+> `changesets` parses **every** `.md` file in `.changeset/` as a changeset **except `README.md`** —
+> a `CLAUDE.md`, `AGENTS.md`, or any other doc here makes `changesets/action` (its own bundled
+> reader) throw `could not parse changeset - invalid YAML in frontmatter` and **breaks the release**.
+> Keep prose docs in this one file. Only `README.md`, `config.json`, `pre.json`, and real
+> `---`-frontmatter changesets belong in `.changeset/`.
+
 ## How changesets are generated
 
 CI generates changesets automatically — contributors do **not** hand-write them for normal feature and fix work. The exception is when a changeset cannot be derived from commits alone (initial package releases, renames, unusual version bumps); those are hand-written and committed directly to `.changeset/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 
 ## Workflow
 
-- Use Conventional Commits — releases are cut from changesets generated from the commit history. CI auto-generates the changesets from commit history; we do NOT hand-write them. A package is release-visible iff `private !== true` and it's not in `.changeset/config.json`'s `ignore` list. See [.changeset/CLAUDE.md](.changeset/CLAUDE.md) for the full flow (commit-type → bump mapping, the generator script, alpha pre-release mode).
+- Use Conventional Commits — releases are cut from changesets generated from the commit history. CI auto-generates the changesets from commit history; we do NOT hand-write them. A package is release-visible iff `private !== true` and it's not in `.changeset/config.json`'s `ignore` list. See [.changeset/README.md](.changeset/README.md) for the full flow (commit-type → bump mapping, the generator script, alpha pre-release mode). (It lives as `README.md` because `changesets` parses every other `.md` in `.changeset/` as a changeset — a doc named `CLAUDE.md`/`AGENTS.md` there breaks the release.)
 - **Stage by exact path** — `git add tools/io/src/foo.ts`, never `git add -A` / `git add .` / `git commit -a`. This branch routinely has WIP modifications across many files; bundling them is a recoverable but disruptive mistake.
 
 ## Engineering discipline (iron law)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 
 ## Workflow
 
-- Use Conventional Commits — releases are cut from changesets generated from the commit history. CI auto-generates the changesets from commit history; we do NOT hand-write them. A package is release-visible iff `private !== true` and it's not in `.changeset/config.json`'s `ignore` list. See [.changeset/README.md](.changeset/README.md) for the full flow (commit-type → bump mapping, the generator script, alpha pre-release mode). (It lives as `README.md` because `changesets` parses every other `.md` in `.changeset/` as a changeset — a doc named `CLAUDE.md`/`AGENTS.md` there breaks the release.)
+- Use Conventional Commits — releases are cut from changesets generated from the commit history. CI auto-generates changesets for normal feature/fix work; hand-write them only for what the generator can't derive from commits (initial package releases, renames, unusual bumps, or packages outside `packages/` like `skills`/`minis`/`tools`, which the scanner never sees). Within `packages/`, a package is release-visible iff `private !== true` and it's not in `.changeset/config.json`'s `ignore` list. See [.changeset/README.md](.changeset/README.md) for the full flow (commit-type → bump mapping, the generator script, alpha pre-release mode). (It lives as `README.md` because `changesets` parses every other `.md` in `.changeset/` as a changeset — a doc named `CLAUDE.md`/`AGENTS.md` there breaks the release.)
 - **Stage by exact path** — `git add tools/io/src/foo.ts`, never `git add -A` / `git add .` / `git commit -a`. This branch routinely has WIP modifications across many files; bundling them is a recoverable but disruptive mistake.
 
 ## Engineering discipline (iron law)

--- a/tools/vscode/PUBLISHING.md
+++ b/tools/vscode/PUBLISHING.md
@@ -112,7 +112,7 @@ Nothing extra to do beyond normal changeset hygiene:
 1. `tools/vscode` lives outside `packages/`, so — same as `minis/` and `skills/` — it's **never**
    auto-detected by `scripts/generate-changesets.ts`'s commit-scanning bot. Any change you want
    reflected in the next VSIX needs a **hand-written changeset** naming `@three-flatland/vscode`
-   (see `.changeset/CLAUDE.md` for the exact format). Forgetting this doesn't break anything loudly
+   (see `.changeset/README.md` for the exact format). Forgetting this doesn't break anything loudly
    — it just means that change ships in the extension's *code* next time something else triggers a
    release, but never gets its own version bump or CHANGELOG entry of its own.
 2. The build + GitHub Release are automatic: the version bump PR, the merge, `release.yml`'s


### PR DESCRIPTION
### **User description**
## Unbreaks the Release job on `main`

The [Release run for the #196 merge](https://github.com/thejustinwalsh/three-flatland/actions/runs/29607940595/job/87993918759) failed at **Create Release Pull Request or Publish**:

```
Error: could not parse changeset - invalid YAML in frontmatter.
YAML error: end of the stream or a document separator is expected (11:1)
```

### Root cause
`changesets/action@v1` (via its own bundled `@changesets/read`) parses **every** `.md` file in `.changeset/` as a changeset **except `README.md`**. `.changeset/CLAUDE.md` is a prose doc with no `---` frontmatter, so the parse throws and the release aborts.

It's a pre-existing landmine (introduced in `a5fe984e`); this was simply the first release to hit it. Confirmed it's the *only* offender — the other 63 `.md` files all have valid frontmatter.

### Fix
- Move the doc **verbatim** into `.changeset/README.md` — the one filename the parser skips — prefixed with a note explaining why it must live under that exact name (so nobody re-introduces a `CLAUDE.md`/`AGENTS.md` here).
- Repoint the two references (`CLAUDE.md`, `tools/vscode/PUBLISHING.md`).

The parser-level "just skip CLAUDE.md/AGENTS.md" isn't reachable — the action bundles its own reader — so relocating to `README.md` is the real fix.

### Verification
`pnpm changeset status` now exits 0 (was throwing the parse error). Build already passed in the failing run; only the changesets step was blocked.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Move `.changeset/CLAUDE.md` to `README.md` to avoid breaking the release parser.

- Add a prominent guard in `README.md` explaining that only `README.md` is safe from the changesets parser.

- Update references in `CLAUDE.md` and `tools/vscode/PUBLISHING.md` to point to the new location.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add parser‑avoidance warning to `.changeset/README.md`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/README.md

<ul><li>Insert a bold warning block detailing why only <code>README.md</code> can hold <br>prose docs in <code>.changeset/</code>.<br> <li> Explain that any other <code>.md</code> file breaks the changesets action due to <br>missing frontmatter.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/198/files#diff-a34534bc93c6a37355abf0bdd229cb9fa11a8b3a2de4ca2d97e71356d361b459">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update link in root `CLAUDE.md` to new changeset doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Update a link from <code>.changeset/CLAUDE.md</code> to <code>.changeset/README.md</code>.<br> <li> Append a parenthetical note explaining the name restriction.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/198/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PUBLISHING.md</strong><dd><code>Update link in VS Code publishing guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/PUBLISHING.md

<ul><li>Replace a reference to the old changeset doc with the new <code>README.md</code> <br>path.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/198/files#diff-dd551add1a65f0a5310cae6a3ae1d0a9a00cf80ff1e648319dc187d6b22814cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating and formatting release changesets.
  * Updated release workflow documentation to reference the correct changeset instructions.
  * Clarified which files are recognized as changesets to help prevent release errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->