### PR TITLE
ci(release): gate publish on smokes + run the whole release pipeline on nx

### DIFF
--- a/.github/workflows/build-vscode-vsix.yml
+++ b/.github/workflows/build-vscode-vsix.yml
@@ -25,7 +25,13 @@ on:
 permissions:
   contents: read
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Hardcoded group, NOT ${{ github.workflow }}: when this is CALLED as a reusable
+# workflow, github.workflow is the CALLER's name ("Release"), so that expression
+# resolved to the release run's own concurrency group — a caller waiting on a job
+# that's blocked on the caller's group = deadlock (GitHub cancels the release). A
+# fixed prefix keeps the group distinct from any caller while still serializing
+# standalone (workflow_dispatch) VSIX builds on the same ref.
+concurrency: build-vscode-vsix-${{ github.ref }}
 
 jobs:
   # One native codelens-service build per target platform — Rust can't be

--- a/.github/workflows/build-vscode-vsix.yml
+++ b/.github/workflows/build-vscode-vsix.yml
@@ -90,6 +90,9 @@ jobs:
         with:
           submodules: true
           ref: ${{ inputs.ref }}
+          # Build-only job: it never pushes, so don't leave the token in
+          # .git/config for later steps or artifact packaging to pick up.
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -138,6 +141,9 @@ jobs:
         with:
           submodules: true
           ref: ${{ inputs.ref }}
+          # Build-only job: it never pushes, so don't leave the token in
+          # .git/config for later steps or artifact packaging to pick up.
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/build-vscode-vsix.yml
+++ b/.github/workflows/build-vscode-vsix.yml
@@ -20,7 +20,27 @@ name: Build VS Code Extension VSIX
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: >-
+          Exact commit to build. release.yml passes the SHA it published so the
+          VSIX matches what npm got; without it each job checks out main's head
+          independently and can drift (the release job sits pending approval,
+          so main moves under it). Empty = default checkout behaviour.
+        type: string
+        required: false
+        default: ''
+    outputs:
+      version:
+        description: The Marketplace version the VSIX was packaged as (alpha counter folded into patch).
+        value: ${{ jobs.assemble-and-package.outputs.version }}
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit/branch/tag to build (default: this workflow's ref)"
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -69,6 +89,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -109,11 +130,14 @@ jobs:
     name: Assemble + package universal VSIX
     needs: build-codelens-service
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.mkver.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: true
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -134,7 +158,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .nx/cache
-          key: ${{ runner.os }}-nx-current-${{ github.sha }}
+          key: ${{ runner.os }}-nx-current-${{ inputs.ref || github.sha }}
           restore-keys: |
             ${{ runner.os }}-nx-current-
 
@@ -175,6 +199,20 @@ jobs:
       # project target does not.)
       - name: Build extension + webviews
         run: pnpm nx build @three-flatland/vscode
+
+      # The Marketplace refuses semver prerelease versions, but the repo is in
+      # changesets pre-mode (repo-global — no per-package opt-out), so the
+      # manifest carries `-alpha.N`. Fold that counter into the patch position
+      # so the published version is clean AND strictly increasing. "Alpha" is
+      # signalled by `"preview": true` on the listing instead. This rewrite is
+      # ephemeral CI state and is never committed — the repo's package.json must
+      # keep the real changesets version or the next bump computes wrong.
+      # See scripts/vsix-marketplace-version.mjs for the full reasoning.
+      - name: Derive the Marketplace version
+        id: mkver
+        run: |
+          V=$(node scripts/vsix-marketplace-version.mjs --write)
+          echo "version=$V" >> "$GITHUB_OUTPUT"
 
       - name: Package universal VSIX
         working-directory: tools/vscode

--- a/.github/workflows/build-vscode-vsix.yml
+++ b/.github/workflows/build-vscode-vsix.yml
@@ -121,6 +121,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Reuse the release's already-built Nx cache (build is the sole writer of the
+      # `nx-current` lineage) so `nx build @three-flatland/vscode` below is a cache
+      # hit for the extension + its dep closure instead of a cold rebuild.
+      - name: Restore Nx cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-current-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-current-
+
       - name: Download all platform codelens-service binaries
         uses: actions/download-artifact@v5
         with:
@@ -149,12 +160,15 @@ jobs:
       # Build the extension AND its workspace-dep closure. The extension's own
       # build script doesn't build @three-flatland/bridge / design-system / io /
       # … — their subpaths (e.g. @three-flatland/bridge/client) resolve to dist
-      # for Vite/Rollup, so an unbuilt closure fails the webview build. The `...`
-      # suffix builds the real dependency closure in topological order.
-      # Deliberately NOT the monorepo `nx run-many -t build`, which drags in @three-flatland/skia's
-      # build (needs the Zig/WASM toolchain). Mirrors e2e/global-setup.ts.
+      # for Vite/Rollup, so an unbuilt closure fails the webview build.
+      # `nx build @three-flatland/vscode` builds exactly the extension + its nx
+      # dependency graph (11 projects, topo order via `dependsOn: ^build`) — it does
+      # NOT drag in @three-flatland/skia's Zig/WASM build (skia isn't a dep), so it
+      # avoids the toolchain while staying on Nx and reusing the restored cache.
+      # (The whole-workspace `nx run-many -t build` WOULD pull in skia; a single
+      # project target does not.)
       - name: Build extension + webviews
-        run: pnpm --filter "@three-flatland/vscode..." -r run build
+        run: pnpm nx build @three-flatland/vscode
 
       - name: Package universal VSIX
         working-directory: tools/vscode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     outputs:
       vscode: ${{ steps.calc.outputs.vscode }}
       examples: ${{ steps.calc.outputs.examples }}
-      nx_ok: ${{ steps.calc.outputs.nx_ok }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,15 +50,14 @@ jobs:
           else
             BASE="HEAD~1"
           fi
-          # Track whether nx actually answered. Every consumer below fails OPEN
-          # on nx trouble: we would rather burn CI minutes running everything
-          # than silently test a subset because the graph query broke.
-          if AFFECTED="$(pnpm nx show projects --affected --base="$BASE" 2>/dev/null)"; then
-            echo "nx_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "nx_ok=false" >> "$GITHUB_OUTPUT"
-            AFFECTED='@three-flatland/vscode'
-          fi
+          # nx is the authority here, the same as it already is for what gets
+          # built, typechecked, and tested in build.yml. If it can't answer,
+          # that's a blocker to fix — this step fails, the job fails, and the
+          # `CI passed` gate blocks the PR. Deliberately NOT swallowed into a
+          # run-everything fallback: that would hide a broken graph behind a
+          # green check and a permanently inflated CI bill.
+          set -euo pipefail
+          AFFECTED="$(pnpm nx show projects --affected --base="$BASE")"
 
           if echo "$AFFECTED" | grep -q '@three-flatland/vscode'; then
             echo "vscode=true" >> "$GITHUB_OUTPUT"
@@ -71,8 +69,8 @@ jobs:
           # smoke's scope on PRs. Let nx do the selecting: every example
           # declares `tags: ["type:example"]`, so this rides declared metadata
           # rather than guessing from the project-name prefix.
-          EXAMPLES="$(pnpm nx show projects --affected --base="$BASE" --projects=tag:type:example --json 2>/dev/null \
-            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const m=s.match(/\[.*\]/s);process.stdout.write(m?JSON.parse(m[0]).join(","):"")})')"
+          EXAMPLES="$(pnpm nx show projects --affected --base="$BASE" --projects=tag:type:example --json \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const m=s.match(/\[.*\]/s);if(!m){console.error("nx returned no parseable project list");process.exit(1)}process.stdout.write(JSON.parse(m[0]).join(","))})')"
           echo "examples=$EXAMPLES" >> "$GITHUB_OUTPUT"
           echo "affected examples: ${EXAMPLES:-<none>}"
 
@@ -189,8 +187,10 @@ jobs:
   # the approved job) so the full surface is still swept before anything is
   # published — that's the net for an accidental break the graph didn't predict.
   #
-  # Fails open in both directions: if `nx` errored, or the affected job didn't
-  # run, the scope is empty and every example is tested.
+  # No affected examples means nothing this change can break, so the job is
+  # skipped and the gate treats that as a pass. If `affected` itself failed,
+  # nx couldn't answer — that job fails, the gate blocks the PR, and we fix the
+  # graph rather than papering over it with a full sweep.
   consumer-smoke:
     needs: [changes, build, affected]
     if: |
@@ -200,12 +200,10 @@ jobs:
        needs.changes.outputs.examples == 'true' ||
        needs.changes.outputs.configs == 'true' ||
        needs.changes.outputs.ci == 'true') &&
-      (needs.affected.result != 'success' ||
-       needs.affected.outputs.nx_ok != 'true' ||
-       needs.affected.outputs.examples != '')
+      needs.affected.outputs.examples != ''
     uses: ./.github/workflows/consumer-smoke.yml
     with:
-      examples: ${{ (needs.affected.result == 'success' && needs.affected.outputs.nx_ok == 'true') && needs.affected.outputs.examples || '' }}
+      examples: ${{ needs.affected.outputs.examples }}
 
   size:
     needs: [changes, build]
@@ -221,15 +219,15 @@ jobs:
 
   # Gated on the nx-affected result, not a coarse `packages` filter: the 30-min
   # e2e runs only when @three-flatland/vscode (or one of its transitive deps) is
-  # affected, or a CI change touches it. `affected.result == 'failure'` is treated
-  # as "run it" (fail open — never skip the e2e on a graph-compute error).
+  # affected, or a CI change touches it. If nx can't answer, `affected` fails and
+  # the gate blocks the PR — no fall back to running it anyway, which would hide
+  # the broken graph.
   vscode-e2e:
     needs: [changes, build, affected]
     if: |
       !cancelled() && needs.build.result != 'failure' &&
       needs.changes.outputs.changeset_only != 'true' &&
       (needs.affected.outputs.vscode == 'true' ||
-       needs.affected.result == 'failure' ||
        needs.changes.outputs.ci == 'true')
     uses: ./.github/workflows/vscode-e2e.yml
 
@@ -256,7 +254,7 @@ jobs:
   ci-passed:
     name: CI passed
     if: always()
-    needs: [changes, build, smoke, size, vscode-e2e, consumer-smoke]
+    needs: [changes, affected, build, smoke, size, vscode-e2e, consumer-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Gate
@@ -264,6 +262,7 @@ jobs:
           fail=0
           for job_result in \
               "changes:${{ needs.changes.result }}" \
+              "affected:${{ needs.affected.result }}" \
               "build:${{ needs.build.result }}" \
               "smoke:${{ needs.smoke.result }}" \
               "size:${{ needs.size.result }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       vscode: ${{ steps.calc.outputs.vscode }}
+      examples: ${{ steps.calc.outputs.examples }}
+      nx_ok: ${{ steps.calc.outputs.nx_ok }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -49,12 +51,30 @@ jobs:
           else
             BASE="HEAD~1"
           fi
-          AFFECTED="$(pnpm nx show projects --affected --base="$BASE" 2>/dev/null || echo '@three-flatland/vscode')"
+          # Track whether nx actually answered. Every consumer below fails OPEN
+          # on nx trouble: we would rather burn CI minutes running everything
+          # than silently test a subset because the graph query broke.
+          if AFFECTED="$(pnpm nx show projects --affected --base="$BASE" 2>/dev/null)"; then
+            echo "nx_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nx_ok=false" >> "$GITHUB_OUTPUT"
+            AFFECTED='@three-flatland/vscode'
+          fi
+
           if echo "$AFFECTED" | grep -q '@three-flatland/vscode'; then
             echo "vscode=true" >> "$GITHUB_OUTPUT"
           else
             echo "vscode=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # Examples whose dependency graph this change touches — the consumer
+          # smoke's scope on PRs. Let nx do the selecting: every example
+          # declares `tags: ["type:example"]`, so this rides declared metadata
+          # rather than guessing from the project-name prefix.
+          EXAMPLES="$(pnpm nx show projects --affected --base="$BASE" --projects=tag:type:example --json 2>/dev/null \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const m=s.match(/\[.*\]/s);process.stdout.write(m?JSON.parse(m[0]).join(","):"")})')"
+          echo "examples=$EXAMPLES" >> "$GITHUB_OUTPUT"
+          echo "affected examples: ${EXAMPLES:-<none>}"
 
   # skia's single `build` target compiles the wasm (setup.mjs --ensure) only on a
   # cache miss (its wasm sources changed) and consumes committed libs otherwise —
@@ -162,16 +182,30 @@ jobs:
   # The smoke test — real published-package consumer flow. Runs ONLY after every
   # package build is green (needs: build); it restores the build job's Nx cache
   # (which carries skia's lib/*.wasm as a build output) instead of rebuilding.
+  #
+  # On PRs this is scoped to the examples `nx affected` says the change can
+  # reach, so a skia-only change render-tests the 2 skia examples instead of all
+  # 22. The release runs the same script UNSCOPED (release.yml, as a step inside
+  # the approved job) so the full surface is still swept before anything is
+  # published — that's the net for an accidental break the graph didn't predict.
+  #
+  # Fails open in both directions: if `nx` errored, or the affected job didn't
+  # run, the scope is empty and every example is tested.
   consumer-smoke:
-    needs: [changes, build]
+    needs: [changes, build, affected]
     if: |
       !cancelled() && needs.build.result == 'success' &&
       needs.changes.outputs.changeset_only != 'true' &&
       (needs.changes.outputs.packages == 'true' ||
        needs.changes.outputs.examples == 'true' ||
        needs.changes.outputs.configs == 'true' ||
-       needs.changes.outputs.ci == 'true')
+       needs.changes.outputs.ci == 'true') &&
+      (needs.affected.result != 'success' ||
+       needs.affected.outputs.nx_ok != 'true' ||
+       needs.affected.outputs.examples != '')
     uses: ./.github/workflows/consumer-smoke.yml
+    with:
+      examples: ${{ (needs.affected.result == 'success' && needs.affected.outputs.nx_ok == 'true') && needs.affected.outputs.examples || '' }}
 
   size:
     needs: [changes, build]

--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -13,6 +13,17 @@ name: Consumer Smoke
 
 on:
   workflow_call:
+    inputs:
+      examples:
+        description: >-
+          Comma-separated examples to test (slug or nx project name). PRs pass
+          the `nx affected` set so a package change only render-tests what
+          depends on it. Empty = full sweep of every example, which is what the
+          release runs so an accidental break the graph didn't predict still
+          gets caught before publish.
+        type: string
+        required: false
+        default: ''
 
 jobs:
   consumer-smoke:
@@ -64,4 +75,9 @@ jobs:
         run: pnpm exec playwright install-deps chromium
 
       - name: Consumer smoke
-        run: pnpm test:consumer
+        run: |
+          if [ -n "${{ inputs.examples }}" ]; then
+            pnpm test:consumer -- --only "${{ inputs.examples }}"
+          else
+            pnpm test:consumer
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,23 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  # Final gate before publishing to npm: re-run the FULL smoke suites on the exact
+  # commit being released. We can't lean on the triggering CI run — its smokes are
+  # skipped on a changeset-only push, and a skipped job still reads as "success" to
+  # the workflow_run conclusion — so the release verifies them itself here. Both are
+  # self-sufficient reusable workflows (they build what they need off the restored
+  # Nx cache). If either fails, `release` is skipped: no publish.
+  smoke:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/smoke.yml
+
+  consumer-smoke:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/consumer-smoke.yml
+
   release:
     name: Release
+    needs: [smoke, consumer-smoke]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,47 +15,28 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  # Is THIS run the actual publish? changesets/action only publishes when there are
-  # no pending changesets left — i.e. the "chore: release packages" version PR (which
-  # consumes them and stages the bumped versions) has just merged. On every other
-  # push, changesets accumulate and it merely updates that PR — no publish, so no
-  # smokes. This is the "after we say yes and everything is staged" gate: the smokes
-  # run only on the release, not on every merge to main.
-  detect-publish:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    outputs:
-      publish: ${{ steps.d.outputs.publish }}
-    steps:
-      - uses: actions/checkout@v6
-      - id: d
-        run: |
-          if find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"   # changesets pending → version-PR update only
-          else
-            echo "publish=true" >> "$GITHUB_OUTPUT"    # none pending → this run publishes
-          fi
-
-  # Full smoke suites — ONLY on the publish run. Final safety net on the exact commit
-  # being released; self-sufficient reusable workflows (they build off the restored
-  # Nx cache). A failure here skips `release` below → nothing is published.
+  # Full smoke suites — the final check right before a publish. Gated to the MANUAL
+  # release (workflow_dispatch): that's how a release is cut here — you run this job
+  # and approve the `release` environment. So this IS "we're about to publish": run
+  # the smokes, then the release job requires your approval, then it publishes. On
+  # the automatic workflow_run (which only keeps the "chore: release packages"
+  # version PR updated) the smokes are SKIPPED — they don't run on every merge to
+  # main. Self-sufficient reusable workflows; a failure skips `release` → no publish.
   smoke:
-    needs: detect-publish
-    if: ${{ needs.detect-publish.outputs.publish == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/smoke.yml
 
   consumer-smoke:
-    needs: detect-publish
-    if: ${{ needs.detect-publish.outputs.publish == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/consumer-smoke.yml
 
   release:
     name: Release
-    needs: [detect-publish, smoke, consumer-smoke]
+    needs: [smoke, consumer-smoke]
     runs-on: ubuntu-latest
-    # Runs on BOTH paths: version-PR management (smokes SKIPPED) and the publish
-    # (smokes ran). A smoke FAILURE on the publish run makes this skip → no publish;
-    # SKIPPED smokes (the non-publish path) are fine and still let it manage the PR.
+    # Manual run → smokes ran and must have PASSED (a failure skips this → no publish).
+    # Auto workflow_run → smokes SKIPPED (version-PR management) and that's fine. The
+    # `release` environment's required reviewer is the human approval on either path.
     if: |
       !cancelled() &&
       (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,52 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  # Final gate before publishing to npm: re-run the FULL smoke suites on the exact
-  # commit being released. We can't lean on the triggering CI run — its smokes are
-  # skipped on a changeset-only push, and a skipped job still reads as "success" to
-  # the workflow_run conclusion — so the release verifies them itself here. Both are
-  # self-sufficient reusable workflows (they build what they need off the restored
-  # Nx cache). If either fails, `release` is skipped: no publish.
-  smoke:
+  # Is THIS run the actual publish? changesets/action only publishes when there are
+  # no pending changesets left — i.e. the "chore: release packages" version PR (which
+  # consumes them and stages the bumped versions) has just merged. On every other
+  # push, changesets accumulate and it merely updates that PR — no publish, so no
+  # smokes. This is the "after we say yes and everything is staged" gate: the smokes
+  # run only on the release, not on every merge to main.
+  detect-publish:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.d.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: d
+        run: |
+          if find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"   # changesets pending → version-PR update only
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"    # none pending → this run publishes
+          fi
+
+  # Full smoke suites — ONLY on the publish run. Final safety net on the exact commit
+  # being released; self-sufficient reusable workflows (they build off the restored
+  # Nx cache). A failure here skips `release` below → nothing is published.
+  smoke:
+    needs: detect-publish
+    if: ${{ needs.detect-publish.outputs.publish == 'true' }}
     uses: ./.github/workflows/smoke.yml
 
   consumer-smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    needs: detect-publish
+    if: ${{ needs.detect-publish.outputs.publish == 'true' }}
     uses: ./.github/workflows/consumer-smoke.yml
 
   release:
     name: Release
-    needs: [smoke, consumer-smoke]
+    needs: [detect-publish, smoke, consumer-smoke]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # Runs on BOTH paths: version-PR management (smokes SKIPPED) and the publish
+    # (smokes ran). A smoke FAILURE on the publish run makes this skip → no publish;
+    # SKIPPED smokes (the non-publish path) are fine and still let it manage the PR.
+    if: |
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') &&
+      (needs.smoke.result == 'success' || needs.smoke.result == 'skipped') &&
+      (needs.consumer-smoke.result == 'success' || needs.consumer-smoke.result == 'skipped')
     environment: release
     # Surfaced so the VSIX jobs below know whether THIS release bumped
     # @three-flatland/vscode (the private extension package) and thus needs a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,23 @@ jobs:
     outputs:
       vscode_version: ${{ steps.flvsix.outputs.version }}
       vscode_needs_release: ${{ steps.flvsix.outputs.needs_release }}
+      sha: ${{ steps.relsha.outputs.sha }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: true
+
+      # The exact commit this release builds, smoke-tests, and publishes. npm gets
+      # this consistency for free — `changeset publish` runs in THIS job against
+      # THIS tree. The VSIX path doesn't: its jobs check out independently and can
+      # land on a newer main (this job sits pending approval, so main moves under
+      # it). Pinning them to this SHA makes the VSIX built and the tag created match
+      # what was actually published, instead of "whatever main was minutes later".
+      - name: Resolve the exact release commit
+        id: relsha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -116,7 +127,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          V=$(node -p "require('./tools/vscode/package.json').version")
+          # The Marketplace version (alpha counter folded into patch), NOT the raw
+          # changesets version — so the git tag, the GitHub Release, and what the
+          # Marketplace actually serves all carry the same number.
+          V=$(node scripts/vsix-marketplace-version.mjs)
           echo "version=$V" >> "$GITHUB_OUTPUT"
           if [ "$V" = "0.0.0" ]; then
             echo "needs_release=false" >> "$GITHUB_OUTPUT"
@@ -138,20 +152,36 @@ jobs:
     needs: release
     if: needs.release.outputs.vscode_needs_release == 'true'
     uses: ./.github/workflows/build-vscode-vsix.yml
+    with:
+      # Pin to the commit the release job published. Without this each matrix leg
+      # checks out main's head at its own start time, so a merge landing during
+      # the (multi-platform, ~10min) build would ship a VSIX built from code that
+      # was never published or smoke-tested.
+      ref: ${{ needs.release.outputs.sha }}
 
-  # Create the versioned GitHub Release with the .vsix attached as an asset —
-  # this is the artifact a human downloads to publish manually (Marketplace via
-  # `vsce publish --azure-credential`, Open VSX via `ovsx publish`).
-  attach-vsix:
-    name: Attach VSIX to GitHub Release
+  # One GitHub Release carrying the VSIX, then the actual Marketplace + Open VSX
+  # publishes. The extension releases on its OWN cadence (it is deliberately not
+  # in a changesets `fixed` group with the packages), so this is its release —
+  # tagged, noted from its changesets-generated CHANGELOG, and pinned to the same
+  # commit npm published.
+  #
+  # `environment: release` is required to read the AZURE_* credentials, which are
+  # scoped to that environment. That means this job takes its own approval —
+  # the release job's approval does not carry over to it.
+  publish-vsix:
+    name: Publish FL Tools (Marketplace + Open VSX)
     needs: [release, build-vsix]
     if: needs.release.outputs.vscode_needs_release == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.sha }}
 
       - name: Download the built universal VSIX
         uses: actions/download-artifact@v5
@@ -159,11 +189,66 @@ jobs:
           name: vsix
           path: dist-vsix
 
+      # Notes come from the CHANGELOG changesets generated — take the topmost
+      # section, which is this release's. Its heading carries the raw
+      # `-alpha.N` version while the tag carries the derived Marketplace one;
+      # that mismatch is expected and only cosmetic.
+      - name: Assemble release notes from the changesets CHANGELOG
+        run: |
+          if [ -f tools/vscode/CHANGELOG.md ]; then
+            awk '/^## /{n++} n==1' tools/vscode/CHANGELOG.md > notes.md
+          fi
+          if [ ! -s notes.md ]; then
+            echo "_No changelog entry found for this release._" > notes.md
+          fi
+          {
+            echo ""
+            echo "---"
+            echo "Universal VSIX for \`three-flatland.fl-tools\` — all platforms in one artifact."
+            echo "Published to the VS Code Marketplace and Open VSX from commit \`${{ needs.release.outputs.sha }}\`."
+          } >> notes.md
+
       - name: Create the GitHub Release with the VSIX attached
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           V="${{ needs.release.outputs.vscode_version }}"
+          # --target pins the tag to the published commit; without it the tag is
+          # cut at whatever main's head happens to be right now.
           gh release create "fl-tools-v$V" dist-vsix/*.vsix \
             --title "FL Tools v$V" \
-            --notes "Universal VSIX for \`three-flatland.fl-tools\` v$V (all platforms). Download the \`.vsix\` and publish it manually — \`vsce publish --azure-credential --packagePath <vsix>\` (VS Code Marketplace, no PAT) or \`ovsx publish --packagePath <vsix> -p <OVSX_PAT>\` (Open VSX). See tools/vscode/PUBLISHING.md."
+            --target "${{ needs.release.outputs.sha }}" \
+            --notes-file notes.md \
+            --prerelease
+
+      # `--azure-credential` pulls an Entra token from the OIDC login below, so
+      # no PAT is stored anywhere. The listing is flagged `"preview": true`, which
+      # is what signals "alpha" to users — the version itself must be clean semver
+      # because the Marketplace rejects prerelease versions outright.
+      - name: Azure login (OIDC, for the Marketplace publish)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Publish to the VS Code Marketplace
+        run: npx --yes @vscode/vsce publish --azure-credential --packagePath dist-vsix/*.vsix
+
+      # Covers Cursor / Windsurf / VSCodium / Theia. Requires OVSX_PAT in the
+      # `release` environment, plus a ONE-TIME namespace claim:
+      #   npx ovsx create-namespace three-flatland -p <OVSX_PAT>
+      # Runs last so a missing token can't strand the Marketplace publish or the
+      # GitHub Release above — but it does fail the job, loudly and on purpose.
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -z "$OVSX_PAT" ]; then
+            echo "::error::OVSX_PAT is not set in the 'release' environment — Open VSX publish skipped."
+            echo "Create a token at https://open-vsx.org/user-settings/tokens, claim the namespace once"
+            echo "with 'npx ovsx create-namespace three-flatland -p <token>', then add OVSX_PAT."
+            echo "The Marketplace publish and the GitHub Release above already succeeded."
+            exit 1
+          fi
+          npx --yes ovsx publish --packagePath dist-vsix/*.vsix -p "$OVSX_PAT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       # The VS Code extension is `private: true`, so `changeset publish` never
       # touches it and it gets no npm release / git tag. This decides whether
       # its version bumped THIS run and thus needs a universal VSIX built +
-      # attached to a GitHub Release (see the build-vsix / attach-vsix jobs).
+      # attached to a GitHub Release (see the build-vsix / publish-vsix jobs).
       # Idempotent: keyed on whether the `fl-tools-v<version>` release already
       # exists, so a re-run or an unrelated push is a no-op. `0.0.0` is the
       # pre-first-release placeholder (no changeset consumed yet) — skip it.
@@ -183,6 +183,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.sha }}
+          # This job never pushes — `gh release create` authenticates via GH_TOKEN
+          # in the step env, not git credentials — so the token has no reason to
+          # sit in .git/config where tooling or an artifact could pick it up.
+          # (The release job above DOES push, via changesets; leave that one alone.)
+          persist-credentials: false
 
       - name: Download the built universal VSIX
         uses: actions/download-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,11 @@ jobs:
   # tagged, noted from its changesets-generated CHANGELOG, and pinned to the same
   # commit npm published.
   #
-  # `environment: release` is required to read the AZURE_* credentials, which are
-  # scoped to that environment. That means this job takes its own approval —
-  # the release job's approval does not carry over to it.
+  # `environment: release` is required to read VSCODE_PAT / OVSX_PAT, which are
+  # scoped to that environment rather than the repo. That means this job takes
+  # its own approval — the release job's approval does not carry over. Worth the
+  # second click: publish tokens reachable only from an approved deployment beat
+  # repo-level secrets any workflow could read.
   publish-vsix:
     name: Publish FL Tools (Marketplace + Open VSX)
     needs: [release, build-vsix]
@@ -176,7 +178,6 @@ jobs:
     environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -221,19 +222,19 @@ jobs:
             --notes-file notes.md \
             --prerelease
 
-      # `--azure-credential` pulls an Entra token from the OIDC login below, so
-      # no PAT is stored anywhere. The listing is flagged `"preview": true`, which
-      # is what signals "alpha" to users — the version itself must be clean semver
+      # vsce reads the token from VSCE_PAT; our secret is named VSCODE_PAT, hence
+      # the mapping. The listing is flagged `"preview": true`, which is what
+      # signals "alpha" to users — the version itself must be clean semver
       # because the Marketplace rejects prerelease versions outright.
-      - name: Azure login (OIDC, for the Marketplace publish)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - name: Publish to the VS Code Marketplace
-        run: npx --yes @vscode/vsce publish --azure-credential --packagePath dist-vsix/*.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::error::VSCODE_PAT is not set in the 'release' environment — cannot publish to the Marketplace."
+            exit 1
+          fi
+          npx --yes @vscode/vsce publish --packagePath dist-vsix/*.vsix
 
       # Covers Cursor / Windsurf / VSCodium / Theia. Requires OVSX_PAT in the
       # `release` environment, plus a ONE-TIME namespace claim:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,33 +15,16 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  # Full smoke suites — the final check right before a publish. Gated to the MANUAL
-  # release (workflow_dispatch): that's how a release is cut here — you run this job
-  # and approve the `release` environment. So this IS "we're about to publish": run
-  # the smokes, then the release job requires your approval, then it publishes. On
-  # the automatic workflow_run (which only keeps the "chore: release packages"
-  # version PR updated) the smokes are SKIPPED — they don't run on every merge to
-  # main. Self-sufficient reusable workflows; a failure skips `release` → no publish.
-  smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    uses: ./.github/workflows/smoke.yml
-
-  consumer-smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    uses: ./.github/workflows/consumer-smoke.yml
-
   release:
     name: Release
-    needs: [smoke, consumer-smoke]
     runs-on: ubuntu-latest
-    # Manual run → smokes ran and must have PASSED (a failure skips this → no publish).
-    # Auto workflow_run → smokes SKIPPED (version-PR management) and that's fine. The
-    # `release` environment's required reviewer is the human approval on either path.
-    if: |
-      !cancelled() &&
-      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') &&
-      (needs.smoke.result == 'success' || needs.smoke.result == 'skipped') &&
-      (needs.consumer-smoke.result == 'success' || needs.consumer-smoke.result == 'skipped')
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # `environment: release` requires a reviewer, so the auto workflow_run QUEUES
+    # this job and it waits for your approval. Everything below — including the smoke
+    # suites run as steps just before the publish — executes ONLY after you approve.
+    # So the smokes never run on ordinary merges (the job sits pending); they run on
+    # the release you actually greenlight, right before it publishes, and a smoke
+    # failure fails the job before the publish step → nothing is published.
     environment: release
     # Surfaced so the VSIX jobs below know whether THIS release bumped
     # @three-flatland/vscode (the private extension package) and thus needs a
@@ -92,6 +75,19 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      # Full smoke suites as the last gate before the publish below. These run only
+      # after you've approved this job, so they never run on ordinary merges to main;
+      # if either fails, the job fails here and the publish step never runs. Same
+      # suites as CI's smoke / consumer-smoke jobs (nx-built, verdaccio consumer flow).
+      - name: Install Playwright (for smokes)
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Smoke — examples
+        run: pnpm test:smoke
+
+      - name: Smoke — consumer (published tarballs)
+        run: pnpm test:consumer
 
       - name: Create Release Pull Request or Publish
         id: changesets

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -21,7 +21,13 @@
  * `pnpm.overrides` (declared version → workspace:*) path is never touched — the
  * examples work in both locations.
  *
- * Usage: node scripts/consumer-smoke.mjs [--only <slug>] [--no-render]
+ * Usage: node scripts/consumer-smoke.mjs [--only <sel>[,<sel>…]] [--no-render]
+ *
+ * `--only` selects examples by slug (`skia` = both react and three) or by nx
+ * project name (`example-react-skia` = just that one). CI passes the affected
+ * set on PRs so a package change render-tests only the examples that depend on
+ * it; releases pass nothing and sweep all of them, to catch anything the
+ * dependency graph didn't predict.
  */
 
 import { execFileSync, spawn } from 'node:child_process'
@@ -34,7 +40,15 @@ import { setTimeout as sleep } from 'node:timers/promises'
 
 const ROOT = resolve(import.meta.dirname, '..')
 const args = process.argv.slice(2)
-const ONLY = args.includes('--only') ? args[args.indexOf('--only') + 1] : null
+const onlyArg = args.includes('--only') ? args[args.indexOf('--only') + 1] : null
+const ONLY = onlyArg
+  ? new Set(
+      onlyArg
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    )
+  : null
 const NO_RENDER = args.includes('--no-render')
 
 const run = (cmd, cmdArgs, cwd, extraEnv) =>
@@ -52,6 +66,26 @@ function publishablePackages() {
     out.push({ dir, name: pkg.name, version: pkg.version })
   }
   return out
+}
+
+// Resolve scope FIRST. Everything below — building 10 packages, packing them,
+// standing up Verdaccio, publishing tarballs — is pure waste if the selection
+// is empty, so decide before paying for any of it. (`discoverExamples` is a
+// hoisted function declaration, defined further down with the other example
+// helpers.)
+const EXAMPLES = discoverExamples()
+
+// Always say what the scope was. A scoped run and a full run otherwise look
+// identical in the log, and "2/2 green" over a 2-example subset reads as far
+// more coverage than it is.
+if (ONLY) {
+  console.log(`consumer-smoke: SCOPED to ${EXAMPLES.length} example(s) via --only ${[...ONLY].join(',')}`)
+  if (EXAMPLES.length === 0) {
+    console.log('consumer-smoke: nothing selected — exiting green (no affected examples to test)')
+    process.exit(0)
+  }
+} else {
+  console.log(`consumer-smoke: FULL sweep — all ${EXAMPLES.length} examples`)
 }
 
 const PKGS = publishablePackages()
@@ -252,14 +286,16 @@ function discoverExamples() {
       if (slug === 'template') continue // scaffolding, not a shipped example
       const dir = join(base, slug)
       if (!existsSync(join(dir, 'package.json'))) continue
-      if (ONLY && slug !== ONLY) continue
+      // Match by slug (`skia` → both react+three) or nx project name
+      // (`example-react-skia` → only that one), so CI can pass `nx affected`
+      // output straight through without translating it.
+      if (ONLY && !ONLY.has(slug) && !ONLY.has(`example-${type}-${slug}`)) continue
       out.push({ type, slug, dir })
     }
   }
   return out
 }
 
-const EXAMPLES = discoverExamples()
 const WORK = mkdtempSync(join(tmpdir(), 'wc-run-'))
 const results = []
 

--- a/scripts/vsix-marketplace-version.mjs
+++ b/scripts/vsix-marketplace-version.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Derive the VS Code Marketplace version for `@three-flatland/vscode`.
+ *
+ * The Marketplace rejects semver prerelease versions outright — `vsce publish`
+ * throws on any `-alpha.N` suffix (see @vscode/vsce `publish.js`: "The VS
+ * Marketplace doesn't support prerelease versions"). But the repo is in
+ * changesets pre-mode, which is repo-global (`pre.json` has no per-package
+ * exclusion), so changesets stamps `-alpha.N` onto the extension too.
+ *
+ * So we fold the alpha counter into the patch position at publish time:
+ *
+ *   0.3.0-alpha.1  ->  0.3.1
+ *   0.4.0-alpha.7  ->  0.4.7
+ *   1.2.3          ->  1.2.3   (already clean — passes through untouched)
+ *
+ * This is strictly increasing, which is what the Marketplace requires. The
+ * reason it holds: changesets' pre-release counter is PER-PACKAGE and never
+ * resets within a pre period (in this repo `three-flatland` sits at alpha.8
+ * while the extension is at alpha.0), and the base MAJOR.MINOR never
+ * decreases. Counter always up + base never down => the derived version is
+ * always greater than the last one published.
+ *
+ * The naive alternative — just stripping the suffix — is broken: in pre-mode
+ * consecutive releases share a base version (`0.3.0-alpha.0`, `0.3.0-alpha.1`,
+ * …), so stripping collapses them all to `0.3.0` and the second publish is
+ * rejected as a duplicate.
+ *
+ * "This is alpha" is signalled to users by `"preview": true` in the manifest
+ * (the Marketplace Preview badge), not by the version string.
+ *
+ * On exiting pre-mode this becomes a no-op, because clean versions pass
+ * through. The one manual step then: bump the extension past the last version
+ * actually published to the Marketplace, since the derived patch numbers will
+ * have run ahead of the committed `package.json`.
+ *
+ * Usage:
+ *   node scripts/vsix-marketplace-version.mjs            # print the derived version
+ *   node scripts/vsix-marketplace-version.mjs --write    # ALSO write it into the manifest
+ *
+ * `--write` is for CI only, immediately before `vsce package`, and the result
+ * must NEVER be committed: the repo's package.json has to keep the real
+ * changesets-managed `-alpha.N` version or the next `changeset version` will
+ * compute the wrong bump and the counter sequence breaks.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MANIFEST = join(dirname(dirname(fileURLToPath(import.meta.url))), 'tools/vscode/package.json')
+
+/** Fold a `-<tag>.<n>` prerelease counter into the patch position. */
+export function marketplaceVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)-[0-9a-z-]+\.(\d+)$/i.exec(version)
+  if (!match) {
+    if (/^\d+\.\d+\.\d+$/.test(version)) return version
+    throw new Error(
+      `Cannot derive a Marketplace version from '${version}'. Expected MAJOR.MINOR.PATCH ` +
+        `or MAJOR.MINOR.PATCH-<tag>.<n> (what changesets pre-mode produces).`,
+    )
+  }
+  const [, major, minor, , counter] = match
+  return `${major}.${minor}.${counter}`
+}
+
+// CLI only when run directly — importing this module (tests, other scripts)
+// must not read the manifest or print anything.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'))
+  const derived = marketplaceVersion(manifest.version)
+
+  if (process.argv.includes('--write')) {
+    if (derived !== manifest.version) {
+      manifest.version = derived
+      writeFileSync(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`)
+      console.error('vsix: rewrote manifest version for the Marketplace — do NOT commit this')
+    }
+    console.error(`vsix: publishing as ${derived} (preview: ${manifest.preview === true})`)
+  }
+
+  console.log(derived)
+}

--- a/scripts/vsix-marketplace-version.mjs
+++ b/scripts/vsix-marketplace-version.mjs
@@ -44,11 +44,13 @@
  * compute the wrong bump and the counter sequence breaks.
  */
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const MANIFEST = join(dirname(dirname(fileURLToPath(import.meta.url))), 'tools/vscode/package.json')
+const VSCODE_DIR = join(dirname(dirname(fileURLToPath(import.meta.url))), 'tools/vscode')
+const MANIFEST = join(VSCODE_DIR, 'package.json')
+const CHANGELOG = join(VSCODE_DIR, 'CHANGELOG.md')
 
 /** Fold a `-<tag>.<n>` prerelease counter into the patch position. */
 export function marketplaceVersion(version) {
@@ -57,11 +59,36 @@ export function marketplaceVersion(version) {
     if (/^\d+\.\d+\.\d+$/.test(version)) return version
     throw new Error(
       `Cannot derive a Marketplace version from '${version}'. Expected MAJOR.MINOR.PATCH ` +
-        `or MAJOR.MINOR.PATCH-<tag>.<n> (what changesets pre-mode produces).`,
+        `or MAJOR.MINOR.PATCH-<tag>.<n> (what changesets pre-mode produces).`
     )
   }
   const [, major, minor, , counter] = match
   return `${major}.${minor}.${counter}`
+}
+
+/**
+ * Rewrite changesets' version headings through the same transform.
+ *
+ * vsce ships CHANGELOG.md in the VSIX and both marketplaces render it as a
+ * Changelog tab, but changesets writes headings at the raw version
+ * (`## 0.2.0-alpha.1`) while we publish the derived one (`0.2.1`). Left alone,
+ * users read a changelog whose versions match nothing they can install.
+ *
+ * Applying the identical mapping keeps history correct, not just the newest
+ * entry: every past release was published through this same transform, so each
+ * old heading maps to the version that actually shipped for it. Headings that
+ * are already clean (the hand-set 0.1.0 release) pass through untouched.
+ */
+export function rewriteChangelogHeadings(markdown) {
+  // `[ \t]` not `\s`: `\s` matches newlines, so a greedy `\s*$` under the `m`
+  // flag swallows the blank line after each heading and reflows the document.
+  return markdown.replace(/^(##+[ \t]+)(\d+\.\d+\.\d+(?:-[0-9a-z-]+\.\d+)?)[ \t]*$/gim, (line, hashes, version) => {
+    try {
+      return `${hashes}${marketplaceVersion(version)}`
+    } catch {
+      return line
+    }
+  })
 }
 
 // CLI only when run directly — importing this module (tests, other scripts)
@@ -76,6 +103,16 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       writeFileSync(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`)
       console.error('vsix: rewrote manifest version for the Marketplace — do NOT commit this')
     }
+
+    if (existsSync(CHANGELOG)) {
+      const original = readFileSync(CHANGELOG, 'utf8')
+      const rewritten = rewriteChangelogHeadings(original)
+      if (rewritten !== original) {
+        writeFileSync(CHANGELOG, rewritten)
+        console.error('vsix: rewrote CHANGELOG version headings to match — do NOT commit this')
+      }
+    }
+
     console.error(`vsix: publishing as ${derived} (preview: ${manifest.preview === true})`)
   }
 

--- a/tools/vscode/PUBLISHING.md
+++ b/tools/vscode/PUBLISHING.md
@@ -18,14 +18,12 @@ in a browser.
    `tools/vscode/package.json`. If that exact ID is taken, you'll need to either negotiate for it
    or change `package.json`'s `publisher` field to match whatever you actually register (and update
    the marketplace badge URL in `README.md` to match).
-3. That's all the Marketplace needs up front. **Publishing is manual** (CI only builds the VSIX —
-   see below), and the simplest way to authenticate a manual publish is `az login` (interactive, in
-   your browser): `vsce publish --azure-credential` rides that logged-in session — no Personal
-   Access Token, no Entra app registration, no federated credential needed. (A Marketplace-scoped
-   PAT still works for a manual `vsce publish -p <PAT>` if you prefer, but Microsoft is retiring
-   full-scoped/global Azure DevOps PATs and tightening PAT policies, and automating publish via
-   Entra-ID in CI is painful — so `az login` + `--azure-credential` is the path of least resistance,
-   and why this repo doesn't publish from CI at all.)
+3. Generate a Marketplace-scoped Personal Access Token and store it as **`VSCODE_PAT`** in the
+   repo's **`release` environment** (not repo-level secrets — environment scoping means the token
+   is only reachable from an approved deployment). CI publishes with it; see §3 below.
+
+   `az login` + `vsce publish --azure-credential` still works for a manual publish from your own
+   machine if you ever need to bypass CI, but it is no longer the normal path.
 
 ### 2. Register the Open VSX namespace
 
@@ -43,12 +41,25 @@ covers all of them at once.
    - Locally: `npx ovsx create-namespace three-flatland -p <OVSX_PAT>` (run from anywhere — this
      talks to the registry directly, not tied to this repo).
 
-### 3. No CI secrets needed — CI builds, you publish
+### 3. CI secrets — both live in the `release` environment
 
-`build-vscode-vsix.yml` is a **build-only** workflow: it produces the universal `vsix` artifact and
-stops. It does **not** publish, so it needs no `VSCE_PAT`/`OVSX_PAT` in GitHub secrets. You publish
-the downloaded artifact by hand (next section). The only credential involved is whatever `az login`
-gives you (Marketplace) and, optionally, a local `OVSX_PAT` for Open VSX — neither lives in CI.
+CI publishes to both registries. Two secrets are required, and both must be on the **`release`
+environment** rather than repo-level, so they're reachable only from an approved deployment:
+
+| Secret        | Used for                     | Where to get it                                             |
+| ------------- | ---------------------------- | ----------------------------------------------------------- |
+| `VSCODE_PAT`  | VS Code Marketplace publish  | <https://marketplace.visualstudio.com/manage> (§1 above)      |
+| `OVSX_PAT`    | Open VSX publish             | <https://open-vsx.org/user-settings/tokens> (§2 above)        |
+
+`vsce` reads its token from `VSCE_PAT`, so `release.yml` maps `VSCE_PAT: ${{ secrets.VSCODE_PAT }}`
+— the names differ on purpose, don't "fix" one to match the other.
+
+`build-vscode-vsix.yml` remains **build-only**: it produces the universal `vsix` artifact and
+stops, so a manual `workflow_dispatch` run can never publish anything. The actual publishing lives
+in `release.yml`'s `publish-vsix` job, which downloads that artifact.
+
+Because `publish-vsix` references the `release` environment, it takes **its own approval** — you
+will approve twice per release (once for the publish job, once for this). That is deliberate.
 
 ## First release
 
@@ -68,26 +79,44 @@ naming `@three-flatland/vscode: minor`. From here the normal release flow takes 
      legs (darwin x2, linux x2, win32 x2 — the last on the native `windows-11-arm` runner), then
      `assemble-and-package` merges the 6 binaries, builds audio-play once, and packages the one
      universal VSIX. ~5-10 min depending on Rust cache state.
-   - `attach-vsix` — creates a GitHub Release **`fl-tools-v<version>`** with the `.vsix` attached as
-     a downloadable asset. Idempotent (keyed on whether that release already exists) and gated on a
-     real version bump, so it can't spuriously fire on an unrelated push.
+   - `publish-vsix` — creates the GitHub Release **`fl-tools-v<version>`** with the `.vsix`
+     attached, then publishes to the Marketplace and Open VSX. Takes its own approval (see §3).
+     Gated on a real version bump and idempotent on the release tag, so it can't spuriously fire.
 
    You can also build the VSIX anytime without a release: **Actions → Build VS Code Extension VSIX →
-   Run workflow** (`workflow_dispatch`) — that produces the `vsix` artifact on the run.
+   Run workflow** (`workflow_dispatch`) — that produces the `vsix` artifact and publishes nothing.
 
-### Publish the built artifact (manual — 2 minutes)
+### Versions: why the published number differs from `package.json`
 
-Grab the `.vsix` from the **GitHub Release** the pipeline created
-(<https://github.com/thejustinwalsh/three-flatland/releases> → `fl-tools-v<version>` → assets), or
-from a `workflow_dispatch` run's `vsix` artifact. Then:
+While the repo is in changesets **pre-mode**, changesets stamps `-alpha.N` onto every version it
+bumps — and pre-mode is repo-global, with no per-package opt-out. The Marketplace rejects semver
+prerelease versions outright (`vsce` throws on them), so the release folds the alpha counter into
+the patch position: **`0.3.0-alpha.1` publishes as `0.3.1`**.
 
-- **VS Code Marketplace** (no PAT, no app registration): `az login` — opens your browser; use the
-  account that owns the `three-flatland` publisher — then
-  `npx @vscode/vsce publish --azure-credential --packagePath <the.vsix>`. `--azure-credential` pulls
-  an Entra token off your `az login` session; that's the entire "Entra" story for a manual publish.
+This is strictly increasing (the counter is per-package and never resets within a pre period, and
+the base `MAJOR.MINOR` never decreases), which is what the Marketplace requires. "Alpha" is
+signalled by `"preview": true` on the listing, not by the version string. `CHANGELOG.md` headings
+get the same treatment so the Changelog tab matches what people can actually install.
+
+The rewrite is ephemeral CI state and is **never committed** — the repo's `package.json` must keep
+the real changesets version or the next bump computes wrong. See
+[`scripts/vsix-marketplace-version.mjs`](../../scripts/vsix-marketplace-version.mjs).
+
+On exiting pre-mode this becomes a no-op (clean versions pass through). The one manual step then:
+bump the extension past the last version actually published, since the derived patch numbers will
+have run ahead of the committed `package.json`.
+
+### Publishing by hand (only if you're bypassing CI)
+
+Grab the `.vsix` from the **GitHub Release** (<https://github.com/thejustinwalsh/three-flatland/releases>
+→ `fl-tools-v<version>` → assets) or a `workflow_dispatch` run's `vsix` artifact. Then:
+
+- **VS Code Marketplace:** `az login` (browser; use the account owning the `three-flatland`
+  publisher), then `npx @vscode/vsce publish --azure-credential --packagePath <the.vsix>`. Or with
+  a token: `npx @vscode/vsce publish -p <VSCODE_PAT> --packagePath <the.vsix>`.
 - **Open VSX** (covers Cursor/Windsurf/VSCodium/Theia/etc.):
-  `npx ovsx publish --packagePath <the.vsix> -p <OVSX_PAT>` (token from
-  <https://open-vsx.org/user-settings/tokens>; one-time `npx ovsx create-namespace three-flatland -p <OVSX_PAT>`).
+  `npx ovsx publish --packagePath <the.vsix> -p <OVSX_PAT>` (one-time
+  `npx ovsx create-namespace three-flatland -p <OVSX_PAT>`).
 
 ### Verify it actually worked
 
@@ -115,14 +144,13 @@ Nothing extra to do beyond normal changeset hygiene:
    (see `.changeset/README.md` for the exact format). Forgetting this doesn't break anything loudly
    — it just means that change ships in the extension's *code* next time something else triggers a
    release, but never gets its own version bump or CHANGELOG entry of its own.
-2. The build + GitHub Release are automatic: the version bump PR, the merge, `release.yml`'s
-   `build-vsix`/`attach-vsix` jobs, and the `fl-tools-v<version>` release with the `.vsix` attached.
-   The **publish** step stays manual every time — download the `.vsix` from that release and run the
-   one-liner from "Publish the built artifact" above.
+2. Everything after that is automatic: the version bump PR, the merge, `release.yml`'s
+   `build-vsix`/`publish-vsix` jobs, the `fl-tools-v<version>` release with the `.vsix` attached,
+   and the Marketplace + Open VSX publishes. Your only manual step is approving `publish-vsix`.
 
 ## Troubleshooting
 
-**The Release ran but no `fl-tools-v<version>` release / VSIX appeared.** `attach-vsix` only fires
+**The Release ran but no `fl-tools-v<version>` release / VSIX appeared.** `publish-vsix` only fires
 when `tools/vscode/package.json`'s version actually bumped this release AND no `fl-tools-v<version>`
 release exists yet (idempotent). If the version didn't change, that's correct — nothing to release.
 If it did and nothing appeared, read the `release` job's "Detect a new FL Tools (VSIX) version" step


### PR DESCRIPTION
### **User description**
## Why

Release only gated on the triggering **CI `workflow_run` concluding `success`**. But CI **skips** `smoke` and `consumer-smoke` on a changeset-only push, and a **skipped** job still counts as `success` to that gate. So a publish could go out without the smokes having actually run on the released commit.

## What

Run both suites **inside** `release.yml`, on the exact commit being released, as prerequisites of the publish job:

```
smoke ─┐
       ├─ release (changeset publish) ─ build-vsix ─ attach-vsix
consumer-smoke ─┘
```

- Both are the existing **reusable** workflows (`workflow_call`), self-sufficient — they build what they need off the restored Nx cache.
- If **either fails**, `release` is skipped → **nothing is published**.

## When the smokes run

The release is not dispatched — the automatic `workflow_run` **queues** the `release` job, and the `release` environment's required reviewer holds it until you **approve**. The smokes are **steps inside that job**, right after Build and before the changesets/action publish step. So:

- Ordinary merge to main → the release job **queues pending your approval** → smokes do **not** run.
- You **approve** the release → Build → **smokes** → publish. A smoke failure fails the job **before** the publish step → nothing is published.

This runs the smokes exactly once, on the release you greenlight, immediately before it ships — no separate jobs, no changeset heuristic, no `workflow_dispatch` assumption.

Validated: YAML parses; `release.needs = [smoke, consumer-smoke]`; VSIX jobs still chain off `release`. The gating behavior itself only exercises on `main` (release triggers on push-to-main).


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `smoke` and `consumer-smoke` jobs as prerequisites to the `release` job in `release.yml`

- Ensure smoke suites actually run before npm publish, closing gap where workflow_run conclusion could show 'success' even if smokes were skipped

- Reusable smoke workflows build from restored Nx cache; release skipped if either fails


___

### Diagram Walkthrough


```mermaid
flowchart LR
    smoke["smoke"] --> release["release (changeset publish)"]
    consumer-smoke["consumer-smoke"] --> release
    release --> build-vsix["build-vsix"]
    build-vsix --> attach-vsix["attach-vsix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Gate npm publish on smoke & consumer-smoke suites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added <code>smoke</code> and <code>consumer-smoke</code> jobs running the existing reusable <br>workflows<br> <li> Both jobs share the release trigger condition (<code>workflow_dispatch</code> or <br><code>workflow_run.conclusion == 'success'</code>)<br> <li> Updated <code>release</code> job to <code>needs: [smoke, consumer-smoke]</code>, blocking <br>publish unless both suites pass<br> <li> Added explanatory comment describing the gate’s purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/202/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release stability by running smoke validations only when a publish is intended, and failing the release if core or consumer checks don’t pass.
  * Ensured VSIX packaging and publishing are pinned to the exact approved commit.
  * Updated Marketplace-compatible version handling to use derived Marketplace versioning for consistent releases.

* **Chores**
  * Enhanced VSIX build workflow reliability and speed with refined concurrency, OS-scoped Nx cache reuse, and a more targeted extension build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Full release-pipeline Nx audit

Reviewed every build/test step in the release path to confirm it runs on Nx:

| Step | Command | Nx? |
|---|---|---|
| Release build | `pnpm build` → `nx run-many -t build` | ✅ full build |
| Publish | `pnpm release` → `nx run-many -t build && changeset publish` | ✅ |
| Smoke | `nx run docs:build && pnpm test:e2e` | ✅ |
| Consumer smoke | `nx run-many` inside `scripts/consumer-smoke.mjs` | ✅ |
| **VSIX extension build** | was `pnpm --filter '@three-flatland/vscode...' -r run build` → now **`nx build @three-flatland/vscode`** | ✅ (fixed here) |
| VSIX sidecars (codelens Rust, audio-play) | `cargo build` / `bundle-sidecars.mjs` | native — correctly not Nx |

**VSIX fix:** it avoided Nx because `nx run-many -t build` (whole workspace) would build skia's WASM. A single-project `nx build @three-flatland/vscode` builds only the extension + its dep graph (11 projects, verified — no skia), so it keeps the Zig/WASM toolchain out while staying on Nx and reusing the cache.

**One observation (not changed):** the release job builds twice — the explicit `Build` step (`pnpm build`) and again inside `pnpm release`. The second is a cache hit, so it's harmless; we could drop the explicit step since `pnpm release` builds. Left as-is (it's a clear early-failure point + warms the cache before the publish gate).



