### PR TITLE
fix(three-flatland): hit testing for objects added via flatland.add()

### DIFF
--- a/.changeset/batched-raycast-fix.md
+++ b/.changeset/batched-raycast-fix.md
@@ -1,0 +1,15 @@
+---
+'three-flatland': patch
+---
+
+Fix pointer hit testing on objects added via `flatland.add()`.
+
+`Flatland`'s internal scene disables `matrixWorldAutoUpdate` — matrices refresh
+once per frame inside `render()` — so a raycast from user code read an identity
+`matrixWorld`. `hitTestMode: 'radius'` then tested a 0.5-unit disc against a
+sprite drawn at 150 units: only a dead-centre ray hit, and hover appeared dead
+everywhere else.
+
+`Sprite2D.raycast()` and `TileMap2D.raycast()` now refresh their own world
+matrix first. Examples never hit this because they use `scene.add()` and plain
+R3F children; batched objects were the untested path.

--- a/packages/three-flatland/src/events/batchedRaycast.test.ts
+++ b/packages/three-flatland/src/events/batchedRaycast.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { Raycaster, Vector2, Texture } from 'three'
+import { Flatland } from '../Flatland'
+import { Sprite2D } from '../sprites/Sprite2D'
+
+/**
+ * Objects added via `flatland.add()` live in Flatland's internal scene, which
+ * has `matrixWorldAutoUpdate` disabled — matrices refresh once per frame inside
+ * `render()`. A raycast from user code runs outside that, so `raycast()` must
+ * refresh its own world matrix or it tests against an identity transform.
+ */
+describe('raycasting objects added via flatland.add()', () => {
+  it('hits away from the origin, not just dead centre', () => {
+    const flatland = new Flatland({ viewSize: 400 })
+    flatland.resize(800, 450)
+
+    const sprite = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+    sprite.scale.set(150, 150, 1)
+    flatland.add(sprite)
+
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(0, 0), flatland.camera)
+    const centre = rc.intersectObject(sprite).length
+
+    // ~53 world units in: well inside a 150-unit sprite, and far outside the
+    // 0.5-unit radius an unrefreshed identity matrix would imply.
+    rc.setFromCamera(new Vector2(0.15, 0.15), flatland.camera)
+    const offCentre = rc.intersectObject(sprite).length
+
+    expect({ centre, offCentre, scaleInMatrix: sprite.matrixWorld.elements[0] }).toEqual({
+      centre: 1,
+      offCentre: 1,
+      scaleInMatrix: 150,
+    })
+  })
+
+  it('misses outside the sprite', () => {
+    const flatland = new Flatland({ viewSize: 400 })
+    flatland.resize(800, 450)
+    const sprite = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+    sprite.scale.set(150, 150, 1)
+    flatland.add(sprite)
+
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(0.9, 0.9), flatland.camera)
+    expect(rc.intersectObject(sprite)).toHaveLength(0)
+  })
+})

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -1899,6 +1899,10 @@ export class Sprite2D extends Mesh {
     // this object at registration (the zero-cost path); this guard is
     // defense-in-depth for direct raycast() calls.
     if (this._hitTestMode === 'none') return
+    // Flatland's internal scene disables matrixWorldAutoUpdate — matrices are
+    // refreshed once per frame inside render() — so a raycast from user code
+    // would otherwise read an identity matrixWorld and test a half-unit disc.
+    this.updateMatrixWorld()
     const hit = rayPlaneZ0(raycaster, this)
     if (!hit) return
 

--- a/packages/three-flatland/src/tilemap/TileMap2D.ts
+++ b/packages/three-flatland/src/tilemap/TileMap2D.ts
@@ -547,6 +547,9 @@ export class TileMap2D extends Group {
    * (spec §7.2 / §11.1).
    */
   override raycast(raycaster: Raycaster, intersects: Intersection[]): false {
+    // See Sprite2D.raycast — Flatland's internal scene disables
+    // matrixWorldAutoUpdate, so refresh before reading matrixWorld.
+    this.updateMatrixWorld()
     const hit = rayPlaneZ0(raycaster, this)
     if (!hit) return false
     const { localX, localY } = hit


### PR DESCRIPTION
### **User description**
## What

Pointer hit testing never worked on objects added via `flatland.add()`. `Sprite2D.raycast()` and `TileMap2D.raycast()` now refresh their own world matrix before reading it.

## Why it was broken

Objects enrolled through `flatland.add()` are ECS-only — they never become scene-graph children, so nothing ever updates their `matrixWorld`. A raycast from user code read an identity matrix, and `hitTestMode: 'radius'` then tested a **0.5-unit disc** against a sprite drawn at **150 units**. A ray through dead centre hit; everything else missed, so hover looked simply dead.

Reproduced headlessly:

```
parentName: 'NONE'     ← flatland.add() never parents the sprite
before: 1 → after: 1   ← scene.updateMatrixWorld(true) cannot reach it
offCentre: 0           ← miss, well inside a 150-unit sprite
```

## Why nobody noticed

Every example uses `scene.add()` or plain R3F children, which three keeps updated normally. Nothing in the repo combined batching with hit testing until the `create-three-flatland` starter templates, which use `Flatland` as their root.

The tests split the same way: `Sprite2D.raycast.test.ts` raycasts bare sprites and never constructs a `Flatland`; `flatlandEvents.test.ts` constructs one but only checks the pointer re-cast, never adding or hitting an object. Two halves covered, the combination not.

## Scope, and what this does NOT do

This fixes **direct** raycasting — `raycaster.intersectObject(sprite)` — which is what a consumer writes today.

It does **not** make batched sprites discoverable by scene traversal. That is the D1 gap in `planning/superpowers/specs/2026-06-12-event-system-design.md`, tracked as **#127**, which depends on batched sprites becoming scene-graph citizens.

Worth flagging for that issue: **#127's dependency, #85, is closed as completed, but the graph-citizenship it was supposed to deliver did not land** — `sprite.parent` is still `undefined` after `flatland.add()`. That is why this gap stayed invisible.

## Verification

`batchedRaycast.test.ts` covers a hit away from the origin and a miss outside the sprite. Mutation-tested: remove the fix and it reproduces the production symptom exactly (`offCentre: 0`, `scaleInMatrix: 1`).

Existing raycast suites unchanged — 28 tests pass across `batchedRaycast`, `Sprite2D.raycast`, `TileMap2D.raycast`, and `flatlandEvents`. Confirmed working in a real browser in both starter templates.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `Sprite2D.raycast()` and `TileMap2D.raycast()` to refresh world matrix before hit test

- Add unit tests for raycasting batched sprites added via `flatland.add()`

- Document fix in changeset


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User calls raycaster.intersectObject()"] --> B["Sprite2D.raycast()"]
  B --> C["this.updateMatrixWorld()"]
  C --> D["rayPlaneZ0()"]
  D --> E["Hit result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batchedRaycast.test.ts</strong><dd><code>Add batched raycast test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/three-flatland/src/events/batchedRaycast.test.ts

<ul><li>Added new test file for raycasting objects added via <code>flatland.add()</code><br> <li> Tests verify hit detection off-centre and miss outside the sprite<br> <li> Validates that the fix resolves the identity-matrix issue with batched <br>sprites</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/204/files#diff-355c13c9e6707f0273c169b125a6fed5b5a88804555a032a6102bc523bf110c9">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sprite2D.ts</strong><dd><code>Refresh matrix in Sprite2D raycast</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/three-flatland/src/sprites/Sprite2D.ts

<ul><li>In <code>raycast()</code>, call <code>this.updateMatrixWorld()</code> before performing the <br>ray-plane hit test<br> <li> Ensures the world matrix is up-to-date when raycasting outside the <br>render loop (e.g., from user code)</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/204/files#diff-0282b70dd27b9d92567fc9b64f76c8f669c5c20de23490458b6a364d6abaf58f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TileMap2D.ts</strong><dd><code>Refresh matrix in TileMap2D raycast</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/three-flatland/src/tilemap/TileMap2D.ts

<ul><li>In <code>raycast()</code>, call <code>this.updateMatrixWorld()</code> before performing the tile <br>lookup<br> <li> Mirrors the same fix applied to <code>Sprite2D</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/204/files#diff-526835f105660a04a1bcff9b23f81cb27c1cc15e21120405fb0ec123544d4f1d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batched-raycast-fix.md</strong><dd><code>Document batched raycast fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/batched-raycast-fix.md

<ul><li>Added patch changeset for <code>three-flatland</code><br> <li> Describes the bug where <code>flatland.add()</code> objects had broken pointer hit <br>testing and the fix</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/204/files#diff-2667d7b9293152b6692daa7a73825cb5e4e528b6b3e68fdbd5c4830a5efef451">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raycasting for sprites and tile maps added through Flatland.
  * Improved hit detection for transformed objects, including center, off-center, and hover interactions.
  * Prevented incorrect results when objects are tested before their world transforms are refreshed.

* **Tests**
  * Added coverage for successful and unsuccessful raycast scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->