### PR TITLE
fix(three-flatland): pointer hit testing + world transform for batched sprites (#127)

### DIFF
--- a/.changeset/batch-broadphase-picking.md
+++ b/.changeset/batch-broadphase-picking.md
@@ -1,0 +1,15 @@
+---
+'three-flatland': minor
+---
+
+Batch-root broadphase picking. `SpriteBatch.raycast` now does a spatial-grid
+broadphase over its sprites instead of being a no-op, so scene traversal
+(`raycaster.intersectObjects(scene.children, true)`) finds batched sprites in
+roughly constant time per click rather than not at all.
+
+A uniform hash grid (`SpriteSpatialGrid`) holds each batch's `Sprite2D`
+references keyed by world position, maintained where slots are assigned/moved/
+freed. `raycast` intersects the ray with z=0, queries the covering cell, and
+delegates each candidate to the sprite's own `raycast()` — reusing the per-sprite
+hit-test and returning `intersection.object === sprite`. Pick cost stays ~flat
+to 50k sprites in a shared-texture scene.

--- a/.changeset/batch-broadphase-picking.md
+++ b/.changeset/batch-broadphase-picking.md
@@ -13,3 +13,12 @@ freed. `raycast` intersects the ray with z=0, queries the covering cell, and
 delegates each candidate to the sprite's own `raycast()` — reusing the per-sprite
 hit-test and returning `intersection.object === sprite`. Pick cost stays ~flat
 to 50k sprites in a shared-texture scene.
+
+React (`three-flatland/react`) gets the same win. R3F raycasts every interactive
+object in `state.internal.interaction` per pointer event — O(n) in sprite count.
+When a batched sprite is R3F-managed, its picking is now proxied to the owning
+batch: the sprite is spliced out of the interaction list (handlers preserved) and
+the batch is registered once in its place. `<sprite2D onClick>` fires exactly as
+before, with `event.object === sprite`, but a 3000-sprite shared-texture batch now
+presents a single raycast target instead of 3000 — the interaction list holds one
+object, not one per sprite. Vanilla (non-R3F) sprites are untouched.

--- a/.changeset/batched-sprite-world-transform.md
+++ b/.changeset/batched-sprite-world-transform.md
@@ -10,10 +10,12 @@ under a transformed `SpriteGroup` rendered at the wrong place, and
 `raycaster.intersectObject(sprite)` (the one hit-test contract, per the
 `hit-test` example) tested against an identity matrix and missed.
 
-`transformSyncSystem` now composes each sprite's world transform (folding the
-group's 2D affine once per frame, identity-fast-pathed) and writes it to both the
-instance slot and `sprite.matrixWorld`. `SpriteBatch.matrixWorld` is pinned to
-identity so instances carry world exactly. `sceneGraphSyncSystem`'s prune is
+`transformSyncSystem` composes each sprite's world transform (folding the
+group's 2D affine once per frame, identity-fast-pathed) into the instance slot.
+It does NOT write `sprite.matrixWorld` per frame — rendering reads the slot, and
+the only per-frame consumer of a batched sprite's matrixWorld is `raycast()`,
+which composes it on demand for the one sprite being cast. `SpriteBatch.matrixWorld`
+is pinned to identity so instances carry world exactly. `sceneGraphSyncSystem`'s prune is
 gated to actual batch meshes so a `renderOrder`-demoted sprite is no longer
 evicted from the graph. `Sprite2D`/`TileMap2D` `raycast()` refresh their world
 matrix for casts issued outside the frame loop.

--- a/.changeset/batched-sprite-world-transform.md
+++ b/.changeset/batched-sprite-world-transform.md
@@ -1,0 +1,22 @@
+---
+'three-flatland': patch
+---
+
+Fix rendering and pointer hit testing for sprites added via `flatland.add()`.
+
+Batched sprites are composed into a `SpriteBatch` instance matrix from their
+local transform, and their `matrixWorld` was never maintained — so a sprite
+under a transformed `SpriteGroup` rendered at the wrong place, and
+`raycaster.intersectObject(sprite)` (the one hit-test contract, per the
+`hit-test` example) tested against an identity matrix and missed.
+
+`transformSyncSystem` now composes each sprite's world transform (folding the
+group's 2D affine once per frame, identity-fast-pathed) and writes it to both the
+instance slot and `sprite.matrixWorld`. `SpriteBatch.matrixWorld` is pinned to
+identity so instances carry world exactly. `sceneGraphSyncSystem`'s prune is
+gated to actual batch meshes so a `renderOrder`-demoted sprite is no longer
+evicted from the graph. `Sprite2D`/`TileMap2D` `raycast()` refresh their world
+matrix for casts issued outside the frame loop.
+
+No API change — batched sprites now behave like `scene.add()` sprites under the
+existing `Raycaster`/`onPointer*` idiom.

--- a/packages/three-flatland/src/ecs/batchUtils.ts
+++ b/packages/three-flatland/src/ecs/batchUtils.ts
@@ -9,6 +9,7 @@ import {
 } from '../materials/Sprite2DMaterial'
 import { SpriteBatch } from '../pipeline/SpriteBatch'
 import { getAtlasMesh } from '../loaders/atlasMeshRegistry'
+import { retireBatchPicking, unproxyPickFromBatch } from '../react/batchPicking'
 import {
   BatchGeometryStrategy,
   BatchMesh,
@@ -337,6 +338,10 @@ export function recycleBatchIfEmpty(registry: RegistryData, batchEntity: Entity,
   const batchMesh = batchEntity.get(BatchMesh)
   if (!batchMesh?.mesh || !batchMesh.mesh.isEmpty) return
 
+  // Defensive: a pooled mesh must never linger in an R3F interaction
+  // list (the last member's unproxy normally already retired it).
+  retireBatchPicking(batchMesh.mesh)
+
   // Remove from run
   const idx = run.batches.indexOf(batchEntity)
   if (idx >= 0) run.batches.splice(idx, 1)
@@ -534,7 +539,11 @@ function evictMatchingBatchedEntities(
 
       // Drop the picking-broadphase entry with the slot — re-assignment
       // (IsRenderable re-trigger below) re-indexes into the new batch.
-      if (sprite && batchMesh?.mesh) batchMesh.mesh.grid.remove(sprite)
+      // The R3F pick proxy is handed back too; re-assignment re-proxies.
+      if (sprite && batchMesh?.mesh) {
+        batchMesh.mesh.grid.remove(sprite)
+        unproxyPickFromBatch(sprite, batchMesh.mesh)
+      }
 
       entity.remove(InBatch(batchEntity))
 

--- a/packages/three-flatland/src/ecs/batchUtils.ts
+++ b/packages/three-flatland/src/ecs/batchUtils.ts
@@ -519,6 +519,8 @@ function evictMatchingBatchedEntities(
     const matRef = entity.get(SpriteMaterialRef)
     if (!matRef || !shouldEvict(matRef)) continue
 
+    const sprite = registry.spriteArr[(entity as unknown as number) & ENTITY_ID_MASK]
+
     const batchEntity = entity.targetFor(InBatch)
     if (batchEntity) {
       // BatchSlot.slot is the authoritative live slot (kept in sync by
@@ -529,6 +531,10 @@ function evictMatchingBatchedEntities(
         batchMesh.mesh.freeSlot(slot)
         batchMesh.mesh.syncCount()
       }
+
+      // Drop the picking-broadphase entry with the slot — re-assignment
+      // (IsRenderable re-trigger below) re-indexes into the new batch.
+      if (sprite && batchMesh?.mesh) batchMesh.mesh.grid.remove(sprite)
 
       entity.remove(InBatch(batchEntity))
 
@@ -545,7 +551,6 @@ function evictMatchingBatchedEntities(
     }
 
     // Clear the sprite's cached direct-write refs — its slot is gone.
-    const sprite = registry.spriteArr[(entity as unknown as number) & ENTITY_ID_MASK]
     if (sprite) {
       sprite._batchMesh = null
       sprite._batchSlot = -1

--- a/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
@@ -19,7 +19,11 @@ import type { Sprite2D } from '../../sprites/Sprite2D'
 import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 import type { RegistryData } from '../batchUtils'
 import { computeRunKey, getOrCreateRun, findOrCreateBatch } from '../batchUtils'
+import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
 import { ENTITY_ID_MASK } from '../snapshot'
+
+/** Scratch for quadHalfExtents — systems are single-threaded. */
+const _he = { hx: 0, hy: 0 }
 
 /**
  * Create a batch-assign system bound to its own scratch state.
@@ -188,6 +192,15 @@ function syncSlotBuffers(
   // Transform — use Sprite2D's updateMatrix for full 3D support
   sprite.updateMatrix()
   mesh.writeMatrix(slot, sprite.matrix)
+
+  // Picking broadphase: index the sprite at its local translation. The
+  // group-folded WORLD position lands via transformSyncSystem's
+  // `grid.update` later in the same schedule run; when transform sync is
+  // disabled the instance matrix above is this same local affine, so the
+  // grid and the rendered position agree either way.
+  const te = sprite.matrix.elements
+  quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
+  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy)
 
   // Lighting system flags (lit/receiveShadows/castsShadow → instanceSystem.z)
   // and per-instance shadow radius (instanceExtras.x). Written for every

--- a/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
@@ -20,6 +20,7 @@ import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 import type { RegistryData } from '../batchUtils'
 import { computeRunKey, getOrCreateRun, findOrCreateBatch } from '../batchUtils'
 import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
+import { proxyPickToBatch } from '../../react/batchPicking'
 import { ENTITY_ID_MASK } from '../snapshot'
 
 /** Scratch for quadHalfExtents — systems are single-threaded. */
@@ -127,6 +128,11 @@ export function createBatchAssignSystem(): (
       sprite._batchMesh = mesh
       sprite._batchSlot = slot
       sprite._batchIdx = batchIdx
+
+      // R3F batch-root picking: route the sprite's raycast through the
+      // batch's broadphase instead of R3F's O(n) per-object list. No-op
+      // for vanilla (non-R3F) sprites.
+      proxyPickToBatch(sprite, mesh)
 
       // Auto-orchestrated sprites live in the user's scene tree — once a
       // batch draws them, their own Mesh must stop rendering. Explicit

--- a/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
@@ -206,7 +206,7 @@ function syncSlotBuffers(
   // grid and the rendered position agree either way.
   const te = sprite.matrix.elements
   quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
-  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy)
+  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy, te[14]!)
 
   // Lighting system flags (lit/receiveShadows/castsShadow → instanceSystem.z)
   // and per-instance shadow radius (instanceExtras.x). Written for every

--- a/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchAssignSystem.ts
@@ -19,12 +19,8 @@ import type { Sprite2D } from '../../sprites/Sprite2D'
 import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 import type { RegistryData } from '../batchUtils'
 import { computeRunKey, getOrCreateRun, findOrCreateBatch } from '../batchUtils'
-import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
 import { proxyPickToBatch } from '../../react/batchPicking'
 import { ENTITY_ID_MASK } from '../snapshot'
-
-/** Scratch for quadHalfExtents — systems are single-threaded. */
-const _he = { hx: 0, hy: 0 }
 
 /**
  * Create a batch-assign system bound to its own scratch state.
@@ -199,14 +195,9 @@ function syncSlotBuffers(
   sprite.updateMatrix()
   mesh.writeMatrix(slot, sprite.matrix)
 
-  // Picking broadphase: index the sprite at its local translation. The
-  // group-folded WORLD position lands via transformSyncSystem's
-  // `grid.update` later in the same schedule run; when transform sync is
-  // disabled the instance matrix above is this same local affine, so the
-  // grid and the rendered position agree either way.
-  const te = sprite.matrix.elements
-  quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
-  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy, te[14]!)
+  // Picking broadphase: index at the local translation; the group-folded
+  // world position lands via transformSyncSystem's grid.update the same run.
+  mesh.indexForPicking(sprite)
 
   // Lighting system flags (lit/receiveShadows/castsShadow → instanceSystem.z)
   // and per-instance shadow radius (instanceExtras.x). Written for every

--- a/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
@@ -21,6 +21,7 @@ import type { RegistryData } from '../batchUtils'
 
 import { computeRunKey, getOrCreateRun, findOrCreateBatch, recycleBatchIfEmpty } from '../batchUtils'
 import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
+import { proxyPickToBatch, unproxyPickFromBatch } from '../../react/batchPicking'
 import { ENTITY_ID_MASK } from '../snapshot'
 
 /** Scratch for quadHalfExtents — systems are single-threaded. */
@@ -106,7 +107,11 @@ export function createBatchReassignSystem(): (
 
       // Drop the picking-broadphase entry with the slot — the sprite is
       // re-indexed into its new batch's grid by syncAllBuffers below.
-      if (oldBatchMesh?.mesh) oldBatchMesh.mesh.grid.remove(sprite)
+      // The R3F pick proxy moves with it (re-proxied after insertion).
+      if (oldBatchMesh?.mesh) {
+        oldBatchMesh.mesh.grid.remove(sprite)
+        unproxyPickFromBatch(sprite, oldBatchMesh.mesh)
+      }
 
       entity.remove(InBatch(oldBatchEntity))
 
@@ -165,6 +170,9 @@ export function createBatchReassignSystem(): (
       sprite._batchMesh = newBatchMesh.mesh
       sprite._batchSlot = newSlot
       sprite._batchIdx = newBatchIdx
+
+      // Re-route R3F picking through the new batch.
+      proxyPickToBatch(sprite, newBatchMesh.mesh)
 
       // Full sync to new batch
       syncAllBuffers(entity, newSlot, newBatchMesh.mesh, sprite, effectTraits)

--- a/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
@@ -210,7 +210,7 @@ function syncAllBuffers(
   // position lands via transformSyncSystem — see batchAssignSystem.
   const te = sprite.matrix.elements
   quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
-  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy)
+  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy, te[14]!)
 
   // Lighting system flags (instanceSystem.z) + shadow radius
   // (instanceExtras.x) — re-written on reassign so a slot move carries

--- a/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
@@ -20,7 +20,11 @@ import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 import type { RegistryData } from '../batchUtils'
 
 import { computeRunKey, getOrCreateRun, findOrCreateBatch, recycleBatchIfEmpty } from '../batchUtils'
+import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
 import { ENTITY_ID_MASK } from '../snapshot'
+
+/** Scratch for quadHalfExtents — systems are single-threaded. */
+const _he = { hx: 0, hy: 0 }
 
 /**
  * Create a batch-reassign system bound to its own scratch state.
@@ -99,6 +103,10 @@ export function createBatchReassignSystem(): (
         oldBatchMesh.mesh.freeSlot(oldSlot)
         oldBatchMesh.mesh.syncCount()
       }
+
+      // Drop the picking-broadphase entry with the slot — the sprite is
+      // re-indexed into its new batch's grid by syncAllBuffers below.
+      if (oldBatchMesh?.mesh) oldBatchMesh.mesh.grid.remove(sprite)
 
       entity.remove(InBatch(oldBatchEntity))
 
@@ -189,6 +197,12 @@ function syncAllBuffers(
   // Transform — use Sprite2D's updateMatrix for full 3D support
   sprite.updateMatrix()
   mesh.writeMatrix(slot, sprite.matrix)
+
+  // Picking broadphase: index at the local translation; the world-folded
+  // position lands via transformSyncSystem — see batchAssignSystem.
+  const te = sprite.matrix.elements
+  quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
+  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy)
 
   // Lighting system flags (instanceSystem.z) + shadow radius
   // (instanceExtras.x) — re-written on reassign so a slot move carries

--- a/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchReassignSystem.ts
@@ -20,12 +20,8 @@ import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 import type { RegistryData } from '../batchUtils'
 
 import { computeRunKey, getOrCreateRun, findOrCreateBatch, recycleBatchIfEmpty } from '../batchUtils'
-import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
 import { proxyPickToBatch, unproxyPickFromBatch } from '../../react/batchPicking'
 import { ENTITY_ID_MASK } from '../snapshot'
-
-/** Scratch for quadHalfExtents — systems are single-threaded. */
-const _he = { hx: 0, hy: 0 }
 
 /**
  * Create a batch-reassign system bound to its own scratch state.
@@ -208,9 +204,7 @@ function syncAllBuffers(
 
   // Picking broadphase: index at the local translation; the world-folded
   // position lands via transformSyncSystem — see batchAssignSystem.
-  const te = sprite.matrix.elements
-  quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
-  mesh.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy, te[14]!)
+  mesh.indexForPicking(sprite)
 
   // Lighting system flags (instanceSystem.z) + shadow radius
   // (instanceExtras.x) — re-written on reassign so a slot move carries

--- a/packages/three-flatland/src/ecs/systems/batchRemoveSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchRemoveSystem.ts
@@ -58,6 +58,11 @@ export function createBatchRemoveSystem(): (world: World, pendingDestroy: Entity
       const eid = (entity as unknown as number) & ENTITY_ID_MASK
       const sprite = registry.spriteArr[eid]
       if (sprite) {
+        // Drop the picking-broadphase entry. The common removal path
+        // (Sprite2D._unenrollFromWorld) has already nulled spriteArr AND
+        // removed the grid entry itself; this covers removal triggers
+        // where the sprite is still enrolled.
+        if (batchMesh?.mesh) batchMesh.mesh.grid.remove(sprite)
         sprite._batchMesh = null
         sprite._batchSlot = -1
         sprite._batchIdx = -1

--- a/packages/three-flatland/src/ecs/systems/batchRemoveSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/batchRemoveSystem.ts
@@ -3,6 +3,7 @@ import type { World, Entity } from 'koota'
 import { IsRenderable, InBatch, BatchSlot, BatchMesh, BatchMeta, BatchRegistry } from '../traits'
 import type { RegistryData } from '../batchUtils'
 import { computeRunKey, recycleBatchIfEmpty } from '../batchUtils'
+import { unproxyPickFromBatch } from '../../react/batchPicking'
 import { ENTITY_ID_MASK } from '../snapshot'
 
 /**
@@ -62,7 +63,11 @@ export function createBatchRemoveSystem(): (world: World, pendingDestroy: Entity
         // (Sprite2D._unenrollFromWorld) has already nulled spriteArr AND
         // removed the grid entry itself; this covers removal triggers
         // where the sprite is still enrolled.
-        if (batchMesh?.mesh) batchMesh.mesh.grid.remove(sprite)
+        if (batchMesh?.mesh) {
+          batchMesh.mesh.grid.remove(sprite)
+          // Hand picking back from the batch (R3F batch-root proxy).
+          unproxyPickFromBatch(sprite, batchMesh.mesh)
+        }
         sprite._batchMesh = null
         sprite._batchSlot = -1
         sprite._batchIdx = -1

--- a/packages/three-flatland/src/ecs/systems/sceneGraphSyncSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/sceneGraphSyncSystem.ts
@@ -3,6 +3,7 @@ import type { World } from 'koota'
 import { BatchRegistry, BatchMesh, BatchMeta } from '../traits'
 import type { RegistryData } from '../batchUtils'
 import { rebuildBatchOrder } from '../batchUtils'
+import type { SpriteBatch } from '../../pipeline/SpriteBatch'
 
 /**
  * Create a scene-graph sync system bound to its own scratch state.
@@ -45,10 +46,14 @@ export function createSceneGraphSyncSystem(): (
       if (batchMesh?.mesh) activeMeshes.add(batchMesh.mesh)
     }
 
-    // Remove children not in active batches
+    // Remove stale BATCH MESHES only. The group's children also include
+    // non-batch objects — sprites demoted to standalone via a user
+    // `renderOrder` write (reparented here by `_demoteToStandalone`) and
+    // foreign Object3Ds routed through `SpriteGroup.add`'s super path —
+    // which this system does not manage and must never evict.
     for (let i = parent.children.length - 1; i >= 0; i--) {
       const child = parent.children[i]
-      if (child && !activeMeshes.has(child)) {
+      if (child && (child as Partial<SpriteBatch>).isSpriteBatch === true && !activeMeshes.has(child)) {
         parentRemove.call(parent, child)
       }
     }

--- a/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
@@ -169,7 +169,7 @@ export function transformSyncSystem(world: World): void {
     // (the same tx/ty the GPU draws at). No-op inside the grid when the
     // sprite's cell coverage hasn't changed — the static-sprite frame.
     quadHalfExtents(m00, m01, m10, m11, sprite.hitRadius, _he)
-    mesh.grid.update(sprite, tx, ty, _he.hx, _he.hy)
+    mesh.grid.update(sprite, tx, ty, _he.hx, _he.hy, tz)
 
     // We do NOT write sprite.matrixWorld here. Rendering reads the instance
     // slot above; the only per-frame consumer of a batched sprite's

--- a/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
@@ -161,27 +161,11 @@ export function transformSyncSystem(world: World): void {
 
     mesh.markMatrixDirty(slot)
 
-    // Mirror the composed WORLD affine into the sprite's matrixWorld so
-    // raycasts and any matrixWorld consumer see exactly what renders.
-    // matrixWorld stays a valid Matrix4 (identity z-column, w-row).
-    const me = sprite.matrixWorld.elements
-    me[0] = m00
-    me[1] = m10
-    me[2] = 0
-    me[3] = 0
-    me[4] = m01
-    me[5] = m11
-    me[6] = 0
-    me[7] = 0
-    me[8] = 0
-    me[9] = 0
-    me[10] = 1
-    me[11] = 0
-    me[12] = tx
-    me[13] = ty
-    me[14] = tz
-    me[15] = 1
-    sprite.matrixWorldNeedsUpdate = false
+    // We do NOT write sprite.matrixWorld here. Rendering reads the instance
+    // slot above; the only per-frame consumer of a batched sprite's
+    // matrixWorld is raycast(), which composes it on demand for the one sprite
+    // being cast (Sprite2D._composeBatchedMatrixWorld). Materializing it for
+    // every sprite every frame is wasted work.
 
     // Auto-derived shadow radius tracks animated scale (e.g.
     // AnimatedSprite2D frame source-size swaps) each frame. Explicit

--- a/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
@@ -2,7 +2,11 @@ import { getStore as kootaGetStore, type World, type Trait } from 'koota'
 import { IsRenderable, IsBatched, SortLayer, SpriteZIndex, BatchSlot, BatchRegistry } from '../traits'
 import type { RegistryData } from '../batchUtils'
 import type { SpriteBatch } from '../../pipeline/SpriteBatch'
+import { quadHalfExtents } from '../../pipeline/SpriteSpatialGrid'
 import { ENTITY_ID_MASK } from '../snapshot'
+
+/** Scratch for quadHalfExtents — systems are single-threaded. */
+const _he = { hx: 0, hy: 0 }
 
 /** Resolve SoA store for a numeric trait — one lookup, reused for all entities. */
 function getNumericStore(world: World, trait: Trait): Record<string, number[]> {
@@ -160,6 +164,12 @@ export function transformSyncSystem(world: World): void {
     buf[o + 15] = 1
 
     mesh.markMatrixDirty(slot)
+
+    // Keep the picking broadphase keyed to the composed WORLD position
+    // (the same tx/ty the GPU draws at). No-op inside the grid when the
+    // sprite's cell coverage hasn't changed — the static-sprite frame.
+    quadHalfExtents(m00, m01, m10, m11, sprite.hitRadius, _he)
+    mesh.grid.update(sprite, tx, ty, _he.hx, _he.hy)
 
     // We do NOT write sprite.matrixWorld here. Rendering reads the instance
     // slot above; the only per-frame consumer of a batched sprite's

--- a/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
+++ b/packages/three-flatland/src/ecs/systems/transformSyncSystem.ts
@@ -10,11 +10,22 @@ function getNumericStore(world: World, trait: Trait): Record<string, number[]> {
 }
 
 /**
- * Sync transforms to GPU instance matrices.
+ * Sync transforms to GPU instance matrices AND `sprite.matrixWorld`.
  *
  * Position, rotation, and scale are read directly from the Object3D via
  * spriteArr (flat array indexed by entity SoA index). Same O(1) array
  * access pattern as all other SoA stores — zero hash overhead.
+ *
+ * This pass is the SINGLE WRITER of a batched sprite's world transform:
+ * the owning SpriteGroup's world affine (from `registry.parentGroup`) is
+ * folded into each sprite's local 2D TRS, and the composed WORLD affine
+ * lands in both the batch instanceMatrix slot (what the GPU draws — the
+ * batch mesh itself stays pinned at identity, see SpriteBatch) and
+ * `sprite.matrixWorld` (what raycasts read). Batched sprites have
+ * `matrixWorldAutoUpdate` disabled so three never clobbers the result.
+ * The fold is a 2D-affine ∘ 2D-affine compose — never a full 4x4
+ * multiply — and is skipped entirely when the group sits at identity
+ * (the 99% path).
  *
  * UV writes used to live here too (under the comment "UV sync is folded
  * into transformSyncSystem"). Phase 3 of the perf roadmap moved UV to
@@ -30,6 +41,32 @@ export function transformSyncSystem(world: World): void {
   if (!registry) return
   const meshSlots = registry.batchSlots
   const spriteArr = registry.spriteArr
+
+  // Extract the SpriteGroup's world 2D affine ONCE per call. The group
+  // ancestors' matrixWorld may not be composed yet this frame (the
+  // schedule runs at the TOP of SpriteGroup.updateMatrixWorld, before
+  // three's own compose), so refresh it explicitly. updateWorldMatrix
+  // is not overridden by SpriteGroup — no schedule re-entry.
+  let ga = 1
+  let gb = 0
+  let gc = 0
+  let gd = 1
+  let gtx = 0
+  let gty = 0
+  let gtz = 0
+  const group = registry.parentGroup
+  if (group) {
+    group.updateWorldMatrix(true, false)
+    const ge = group.matrixWorld.elements
+    ga = ge[0]!
+    gb = ge[1]!
+    gc = ge[4]!
+    gd = ge[5]!
+    gtx = ge[12]!
+    gty = ge[13]!
+    gtz = ge[14]!
+  }
+  const groupIsIdentity = ga === 1 && gb === 0 && gc === 0 && gd === 1 && gtx === 0 && gty === 0 && gtz === 0
 
   // Pre-resolve SoA stores once — reused for every entity in the loop.
   const firstEntity = entities[0]
@@ -67,39 +104,84 @@ export function transformSyncSystem(world: World): void {
     const sy = sprite.scale.y * sprite._trimSY
     const rz = sprite.rotation.z
 
-    const buf = mesh.instanceMatrix.array as Float32Array
-    const o = slot * 16
+    // Local 2D linear part (rotation.z × scale, trim-baked).
+    let m00: number
+    let m01: number
+    let m10: number
+    let m11: number
     if (rz !== 0) {
       const c = Math.cos(rz)
       const s = Math.sin(rz)
-      buf[o] = c * sx
-      buf[o + 4] = -s * sy
-      buf[o + 8] = 0
-      buf[o + 12] = px
-      buf[o + 1] = s * sx
-      buf[o + 5] = c * sy
-      buf[o + 9] = 0
-      buf[o + 13] = py
+      m00 = c * sx
+      m01 = -s * sy
+      m10 = s * sx
+      m11 = c * sy
     } else {
-      buf[o] = sx
-      buf[o + 4] = 0
-      buf[o + 8] = 0
-      buf[o + 12] = px
-      buf[o + 1] = 0
-      buf[o + 5] = sy
-      buf[o + 9] = 0
-      buf[o + 13] = py
+      m00 = sx
+      m01 = 0
+      m10 = 0
+      m11 = sy
     }
+    let tx = px
+    let ty = py
+    let tz = pz
+    if (!groupIsIdentity) {
+      // Fold the group's world affine: 2x2 linear multiply + translation.
+      const l00 = m00
+      const l01 = m01
+      const l10 = m10
+      const l11 = m11
+      m00 = ga * l00 + gc * l10
+      m10 = gb * l00 + gd * l10
+      m01 = ga * l01 + gc * l11
+      m11 = gb * l01 + gd * l11
+      tx = ga * px + gc * py + gtx
+      ty = gb * px + gd * py + gty
+      tz = pz + gtz
+    }
+
+    const buf = mesh.instanceMatrix.array as Float32Array
+    const o = slot * 16
+    buf[o] = m00
+    buf[o + 1] = m10
     buf[o + 2] = 0
-    buf[o + 6] = 0
-    buf[o + 10] = 1
-    buf[o + 14] = pz
     buf[o + 3] = 0
+    buf[o + 4] = m01
+    buf[o + 5] = m11
+    buf[o + 6] = 0
     buf[o + 7] = 0
+    buf[o + 8] = 0
+    buf[o + 9] = 0
+    buf[o + 10] = 1
     buf[o + 11] = 0
+    buf[o + 12] = tx
+    buf[o + 13] = ty
+    buf[o + 14] = tz
     buf[o + 15] = 1
 
     mesh.markMatrixDirty(slot)
+
+    // Mirror the composed WORLD affine into the sprite's matrixWorld so
+    // raycasts and any matrixWorld consumer see exactly what renders.
+    // matrixWorld stays a valid Matrix4 (identity z-column, w-row).
+    const me = sprite.matrixWorld.elements
+    me[0] = m00
+    me[1] = m10
+    me[2] = 0
+    me[3] = 0
+    me[4] = m01
+    me[5] = m11
+    me[6] = 0
+    me[7] = 0
+    me[8] = 0
+    me[9] = 0
+    me[10] = 1
+    me[11] = 0
+    me[12] = tx
+    me[13] = ty
+    me[14] = tz
+    me[15] = 1
+    sprite.matrixWorldNeedsUpdate = false
 
     // Auto-derived shadow radius tracks animated scale (e.g.
     // AnimatedSprite2D frame source-size swaps) each frame. Explicit

--- a/packages/three-flatland/src/events/batchBroadphase.test.ts
+++ b/packages/three-flatland/src/events/batchBroadphase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { Raycaster, Vector2, Vector3, Texture } from 'three'
+import { PerspectiveCamera, Raycaster, Vector2, Vector3, Texture } from 'three'
 import { Flatland } from '../Flatland'
 import { Sprite2D } from '../sprites/Sprite2D'
 
@@ -71,6 +71,34 @@ describe('batch-root broadphase picking', () => {
     expect(rc.intersectObjects(flatland.scene.children, true)[0]?.object).toBe(s)
     rc.setFromCamera(new Vector2(0, 0), flatland.camera) // old spot
     expect(rc.intersectObjects(flatland.scene.children, true).length).toBe(0)
+  })
+
+  // Under a PERSPECTIVE camera the ray converges, so its (x,y) at the sprite's
+  // world z differs from its (x,y) at z=0. Localizing the broadphase on a
+  // single z=0 plane would query the wrong grid cell and miss. The batch must
+  // sweep the ray across its members' z-span. (Ortho rays are z-parallel, so
+  // the other tests already cover the collapsed single-cell path.)
+  it('finds a batched sprite at non-zero z off-axis under a perspective camera', () => {
+    const flatland = fl()
+    const cam = new PerspectiveCamera(50, 1, 0.1, 1000)
+    cam.position.set(0, 0, 200)
+    cam.updateMatrixWorld(true)
+    cam.updateProjectionMatrix()
+
+    const s = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+    s.position.set(100, 0, 100) // off-axis AND off the z=0 plane
+    s.scale.set(20, 20, 1)
+    flatland.add(s)
+    flatland.scene.updateMatrixWorld(true)
+
+    const proj = s.position.clone().project(cam) // aim NDC at the sprite centre
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(proj.x, proj.y), cam)
+
+    // Narrow phase alone hits; the broadphase (scene traversal) must too.
+    expect(rc.intersectObject(s).length).toBe(1)
+    const hits = rc.intersectObjects(flatland.scene.children, true)
+    expect(hits.some((h) => h.object === s)).toBe(true)
   })
 
   // A batched R3F sprite carrying its OWN custom raycast is NOT proxied (it

--- a/packages/three-flatland/src/events/batchBroadphase.test.ts
+++ b/packages/three-flatland/src/events/batchBroadphase.test.ts
@@ -101,6 +101,36 @@ describe('batch-root broadphase picking', () => {
     expect(hits.some((h) => h.object === s)).toBe(true)
   })
 
+  // Robustness: when the camera's Z lies INSIDE the batch's member z-span
+  // (a near sprite in front + a sprite behind the camera), a naive
+  // intersect-both-z-planes localizer aborts (the far plane is behind the ray).
+  // The forward-clamped sweep must still find the reachable near sprite.
+  it('finds a forward sprite when the camera sits inside the member z-span', () => {
+    const flatland = fl()
+    const cam = new PerspectiveCamera(50, 1, 0.1, 1000)
+    cam.position.set(0, 0, 50)
+    cam.updateMatrixWorld(true)
+    cam.updateProjectionMatrix()
+
+    // Behind the camera (z=100 > camera z=50) — pushes zMax past the origin.
+    const behind = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+    behind.position.set(0, 0, 100)
+    behind.scale.set(20, 20, 1)
+    flatland.add(behind)
+    // In front, off the z=0... on z=0, reachable.
+    const front = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+    front.position.set(20, 0, 0)
+    front.scale.set(20, 20, 1)
+    flatland.add(front)
+    flatland.scene.updateMatrixWorld(true)
+
+    const proj = front.position.clone().project(cam)
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(proj.x, proj.y), cam)
+    const hits = rc.intersectObjects(flatland.scene.children, true)
+    expect(hits.some((h) => h.object === front)).toBe(true)
+  })
+
   // A batched R3F sprite carrying its OWN custom raycast is NOT proxied (it
   // stays in R3F's per-object interaction list). It is still in the batch
   // grid, so without a guard the batch would ALSO invoke its raycast — twice

--- a/packages/three-flatland/src/events/batchBroadphase.test.ts
+++ b/packages/three-flatland/src/events/batchBroadphase.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { Raycaster, Vector2, Vector3, Texture } from 'three'
+import { Flatland } from '../Flatland'
+import { Sprite2D } from '../sprites/Sprite2D'
+
+/**
+ * Batch-root broadphase picking. Scene traversal hits the SpriteBatch (not each
+ * sprite); the batch does a spatial-grid broadphase and returns the hit Sprite2D
+ * as intersection.object. This is the acceleration on top of #205's per-sprite
+ * correctness. These fail until SpriteBatch.raycast is implemented.
+ */
+function fl() {
+  const flatland = new Flatland({ viewSize: 400 })
+  flatland.resize(800, 800) // frustum half-width 200
+  return flatland
+}
+function add(flatland: Flatland, x: number, y: number, scale = 100): Sprite2D {
+  const s = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+  s.position.set(x, y, 0)
+  s.scale.set(scale, scale, 1)
+  flatland.add(s)
+  return s
+}
+
+describe('batch-root broadphase picking', () => {
+  it('scene traversal (intersectObjects(scene,true)) returns the hit SPRITE', () => {
+    const flatland = fl()
+    const a = add(flatland, 80, 0)
+    add(flatland, -120, 0)
+    flatland.scene.updateMatrixWorld(true)
+
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(80 / 200, 0), flatland.camera)
+    const hits = rc.intersectObjects(flatland.scene.children, true)
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0]!.object).toBe(a) // the sprite, not the batch
+  })
+
+  it('hits only the sprite under the point; empty space misses', () => {
+    const flatland = fl()
+    add(flatland, 80, 0)
+    flatland.scene.updateMatrixWorld(true)
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(80 / 200, 0), flatland.camera)
+    expect(rc.intersectObjects(flatland.scene.children, true).length).toBe(1)
+    rc.setFromCamera(new Vector2(-0.9, 0.9), flatland.camera) // empty
+    expect(rc.intersectObjects(flatland.scene.children, true).length).toBe(0)
+  })
+
+  it('overlapping sprites resolve topmost by zIndex', () => {
+    const flatland = fl()
+    const back = add(flatland, 0, 0)
+    const front = add(flatland, 0, 0)
+    front.zIndex = 10
+    flatland.scene.updateMatrixWorld(true)
+    const rc = new Raycaster()
+    rc.set(new Vector3(0, 0, 100), new Vector3(0, 0, -1))
+    const hits = rc.intersectObjects(flatland.scene.children, true)
+    expect(hits[0]!.object).toBe(front)
+    expect(hits.map((h) => h.object)).toContain(back)
+  })
+
+  it('a moved sprite is found at its new position, not its old one', () => {
+    const flatland = fl()
+    const s = add(flatland, 0, 0)
+    flatland.scene.updateMatrixWorld(true)
+    s.position.set(120, 0, 0)
+    flatland.scene.updateMatrixWorld(true)
+    const rc = new Raycaster()
+    rc.setFromCamera(new Vector2(120 / 200, 0), flatland.camera)
+    expect(rc.intersectObjects(flatland.scene.children, true)[0]?.object).toBe(s)
+    rc.setFromCamera(new Vector2(0, 0), flatland.camera) // old spot
+    expect(rc.intersectObjects(flatland.scene.children, true).length).toBe(0)
+  })
+})

--- a/packages/three-flatland/src/events/batchBroadphase.test.ts
+++ b/packages/three-flatland/src/events/batchBroadphase.test.ts
@@ -72,4 +72,54 @@ describe('batch-root broadphase picking', () => {
     rc.setFromCamera(new Vector2(0, 0), flatland.camera) // old spot
     expect(rc.intersectObjects(flatland.scene.children, true).length).toBe(0)
   })
+
+  // A batched R3F sprite carrying its OWN custom raycast is NOT proxied (it
+  // stays in R3F's per-object interaction list). It is still in the batch
+  // grid, so without a guard the batch would ALSO invoke its raycast — twice
+  // per pointer event. The batch must skip R3F-managed non-proxied candidates.
+  it('does not double-invoke a non-proxied R3F sprite’s custom raycast', () => {
+    const flatland = fl()
+    const tex = new Texture() // shared → proxied + custom sprite land in ONE batch
+
+    // A fake R3F root so proxyPickToBatch can splice/register.
+    const interaction: object[] = []
+    const root = { getState: () => ({ internal: { interaction, initialHits: [] } }) }
+
+    // Proxied member (default raycast) — keeps the batch registered.
+    const proxied = new Sprite2D({ texture: tex, anchor: [0.5, 0.5] })
+    proxied.scale.set(100, 100, 1)
+    ;(proxied as unknown as { __r3f: unknown }).__r3f = { root, eventCount: 1, handlers: { onClick() {} } }
+
+    // Non-proxied member: R3F-managed + OWN custom raycast at the same spot.
+    let customCalls = 0
+    const custom = new Sprite2D({ texture: tex, anchor: [0.5, 0.5] })
+    custom.scale.set(100, 100, 1)
+    ;(custom as unknown as { __r3f: unknown }).__r3f = { root, eventCount: 1, handlers: { onClick() {} } }
+    ;(custom as unknown as { raycast: unknown }).raycast = () => {
+      customCalls++
+    }
+
+    flatland.add(proxied)
+    flatland.add(custom)
+    flatland.scene.updateMatrixWorld(true)
+
+    // Both share one batch; the custom sprite was left in R3F's list, not proxied.
+    const batch = proxied._batchMesh
+    expect(batch).not.toBeNull()
+    expect(proxied._pickProxied).toBe(true)
+    expect(custom._pickProxied).toBe(false)
+    expect(custom._batchMesh).toBe(batch) // same batch (shared texture)
+
+    // Cast straight down through the overlapped centre and drive the batch.
+    const rc = new Raycaster()
+    rc.set(new Vector3(0, 0, 100), new Vector3(0, 0, -1))
+    const intersects: import('three').Intersection[] = []
+    batch!.raycast(rc, intersects)
+
+    // The batch hit-tested the proxied sprite but NOT the custom one — R3F's
+    // own list owns that; invoking it here would be the second call.
+    expect(customCalls).toBe(0)
+    expect(intersects.some((h) => h.object === proxied)).toBe(true)
+    expect(intersects.some((h) => h.object === custom)).toBe(false)
+  })
 })

--- a/packages/three-flatland/src/events/batchedWorldTransform.test.ts
+++ b/packages/three-flatland/src/events/batchedWorldTransform.test.ts
@@ -6,10 +6,12 @@ import { Sprite2D } from '../sprites/Sprite2D'
 /**
  * Batched sprites must render AND hit-test at the same WORLD point.
  *
- * The ECS transform pass is the single writer of a batched sprite's world
- * transform: it folds the SpriteGroup's own world affine into each sprite's
- * local 2D TRS and writes the result to BOTH the batch instanceMatrix slot
- * (what the GPU draws) and `sprite.matrixWorld` (what raycasts read).
+ * The ECS transform pass folds the SpriteGroup's world affine into each
+ * sprite's local 2D TRS and writes the result to the batch instanceMatrix slot
+ * (what the GPU draws). It does NOT write sprite.matrixWorld — that is composed
+ * on demand inside raycast(), only for the sprite actually being cast. So these
+ * tests assert the slot (rendering) and the raycast (hit testing), never a
+ * per-frame matrixWorld.
  */
 
 function makeSprite(scale = 100): Sprite2D {
@@ -39,19 +41,13 @@ describe('batched sprite world transform under a translated SpriteGroup', () => 
     // renderer.render() entry point — runs the ECS schedule.
     scene.updateMatrixWorld(true)
 
-    // (a) matrixWorld carries the group's translation
-    expect(sprite.matrixWorld.elements[12]).toBe(500)
-    expect(sprite.matrixWorld.elements[13]).toBe(0)
-    expect(sprite.matrixWorld.elements[0]).toBe(100)
-    expect(sprite.matrixWorld.elements[5]).toBe(100)
-
-    // (b) the instance slot carries the SAME world transform
+    // (a) the instance slot (what renders) carries the world transform
     const slot = instanceSlot(sprite)
     expect(slot[12]).toBe(500)
     expect(slot[0]).toBe(100)
     expect(slot[5]).toBe(100)
 
-    // (c) a raycast at the sprite's world centre hits; off-sprite misses
+    // (b) a raycast at the sprite's world centre hits; off-sprite misses
     const rc = new Raycaster()
     rc.set(new Vector3(500, 0, 100), new Vector3(0, 0, -1))
     expect(rc.intersectObject(sprite)).toHaveLength(1)
@@ -77,10 +73,7 @@ describe('batched sprite world transform under a translated SpriteGroup', () => 
 
     scene.updateMatrixWorld(true)
 
-    // Group rotates the sprite's position (200, 0) to (0, 200)
-    expect(sprite.matrixWorld.elements[12]).toBeCloseTo(0, 10)
-    expect(sprite.matrixWorld.elements[13]).toBeCloseTo(200, 10)
-
+    // Group rotates the sprite's position (200, 0) to (0, 200) in the slot
     const slot = instanceSlot(sprite)
     expect(slot[12]).toBeCloseTo(0, 10)
     expect(slot[13]).toBeCloseTo(200, 10)
@@ -147,11 +140,13 @@ describe('batched sprite world transform under a translated SpriteGroup', () => 
 
     scene.updateMatrixWorld(true)
 
-    expect(sprite.matrixWorld.elements[12]).toBe(30)
-    expect(sprite.matrixWorld.elements[13]).toBe(-40)
+    // Identity group → slot is the plain local compose, and hit testing agrees.
     const slot = instanceSlot(sprite)
     expect(slot[12]).toBe(30)
     expect(slot[13]).toBe(-40)
+    const rc = new Raycaster()
+    rc.set(new Vector3(30, -40, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(1)
   })
 })
 

--- a/packages/three-flatland/src/events/batchedWorldTransform.test.ts
+++ b/packages/three-flatland/src/events/batchedWorldTransform.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import { Matrix4, Raycaster, Scene, Texture, Vector3 } from 'three'
+import { SpriteGroup } from '../pipeline/SpriteGroup'
+import { Sprite2D } from '../sprites/Sprite2D'
+
+/**
+ * Batched sprites must render AND hit-test at the same WORLD point.
+ *
+ * The ECS transform pass is the single writer of a batched sprite's world
+ * transform: it folds the SpriteGroup's own world affine into each sprite's
+ * local 2D TRS and writes the result to BOTH the batch instanceMatrix slot
+ * (what the GPU draws) and `sprite.matrixWorld` (what raycasts read).
+ */
+
+function makeSprite(scale = 100): Sprite2D {
+  const sprite = new Sprite2D({ texture: new Texture(), anchor: [0.5, 0.5] })
+  sprite.scale.set(scale, scale, 1)
+  return sprite
+}
+
+/** Read the 16-float instance slot for a batched sprite. */
+function instanceSlot(sprite: Sprite2D): Float32Array {
+  const mesh = sprite._batchMesh
+  expect(mesh).not.toBeNull()
+  const o = sprite._batchSlot * 16
+  return (mesh!.instanceMatrix.array as Float32Array).slice(o, o + 16)
+}
+
+describe('batched sprite world transform under a translated SpriteGroup', () => {
+  it('folds the group translation into matrixWorld, the instance slot, and raycasts', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    group.position.x = 500
+    scene.add(group)
+
+    const sprite = makeSprite(100)
+    group.add(sprite)
+
+    // renderer.render() entry point — runs the ECS schedule.
+    scene.updateMatrixWorld(true)
+
+    // (a) matrixWorld carries the group's translation
+    expect(sprite.matrixWorld.elements[12]).toBe(500)
+    expect(sprite.matrixWorld.elements[13]).toBe(0)
+    expect(sprite.matrixWorld.elements[0]).toBe(100)
+    expect(sprite.matrixWorld.elements[5]).toBe(100)
+
+    // (b) the instance slot carries the SAME world transform
+    const slot = instanceSlot(sprite)
+    expect(slot[12]).toBe(500)
+    expect(slot[0]).toBe(100)
+    expect(slot[5]).toBe(100)
+
+    // (c) a raycast at the sprite's world centre hits; off-sprite misses
+    const rc = new Raycaster()
+    rc.set(new Vector3(500, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(1)
+
+    // 20 units outside the 100-unit quad's right edge
+    rc.set(new Vector3(570, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(0)
+
+    // The sprite's OLD local position (origin) no longer hits
+    rc.set(new Vector3(0, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(0)
+  })
+
+  it('folds a rotated group affine (2D compose, not translation-only)', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    group.rotation.z = Math.PI / 2
+    scene.add(group)
+
+    const sprite = makeSprite(50)
+    sprite.position.set(200, 0, 0)
+    group.add(sprite)
+
+    scene.updateMatrixWorld(true)
+
+    // Group rotates the sprite's position (200, 0) to (0, 200)
+    expect(sprite.matrixWorld.elements[12]).toBeCloseTo(0, 10)
+    expect(sprite.matrixWorld.elements[13]).toBeCloseTo(200, 10)
+
+    const slot = instanceSlot(sprite)
+    expect(slot[12]).toBeCloseTo(0, 10)
+    expect(slot[13]).toBeCloseTo(200, 10)
+
+    // Raycast at the rotated world position hits
+    const rc = new Raycaster()
+    rc.set(new Vector3(0, 200, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(1)
+    // The unrotated position misses
+    rc.set(new Vector3(200, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(0)
+  })
+
+  it('raycasts correctly under a translated group even before the schedule runs', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    group.position.x = 500
+    scene.add(group)
+
+    const sprite = makeSprite(100)
+    group.add(sprite)
+
+    // NO scene.updateMatrixWorld — raycast issued pre-first-render must
+    // self-refresh, including the group fold.
+    const rc = new Raycaster()
+    rc.set(new Vector3(500, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(1)
+    rc.set(new Vector3(0, 0, 100), new Vector3(0, 0, -1))
+    expect(rc.intersectObject(sprite)).toHaveLength(0)
+  })
+
+  it('does not double-apply the group transform through the batch mesh', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    group.position.set(500, 250, 0)
+    scene.add(group)
+
+    const sprite = makeSprite(100)
+    group.add(sprite)
+
+    scene.updateMatrixWorld(true)
+
+    // The batch mesh must stay pinned at identity — the instance slots
+    // already carry world transforms, so shader-side modelMatrix ×
+    // instanceMatrix would otherwise apply the group transform twice.
+    const batch = sprite._batchMesh!
+    expect(batch.matrixWorld.equals(new Matrix4())).toBe(true)
+
+    // Composite render transform (modelMatrix × instanceMatrix) equals the
+    // sprite's world transform exactly.
+    const composite = new Matrix4().fromArray(instanceSlot(sprite)).premultiply(batch.matrixWorld)
+    expect(composite.elements[12]).toBe(500)
+    expect(composite.elements[13]).toBe(250)
+  })
+
+  it('identity group keeps the direct local compose (fast path)', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    scene.add(group)
+
+    const sprite = makeSprite(100)
+    sprite.position.set(30, -40, 0)
+    group.add(sprite)
+
+    scene.updateMatrixWorld(true)
+
+    expect(sprite.matrixWorld.elements[12]).toBe(30)
+    expect(sprite.matrixWorld.elements[13]).toBe(-40)
+    const slot = instanceSlot(sprite)
+    expect(slot[12]).toBe(30)
+    expect(slot[13]).toBe(-40)
+  })
+})
+
+describe('renderOrder demotion under sceneGraphSync', () => {
+  it('keeps a demoted standalone sprite in the graph across schedule runs', () => {
+    const scene = new Scene()
+    const group = new SpriteGroup()
+    scene.add(group)
+
+    const sprite = makeSprite(100)
+    group.add(sprite)
+    const sibling = makeSprite(100)
+    group.add(sibling)
+
+    scene.updateMatrixWorld(true)
+    expect(sprite._batchMesh).not.toBeNull()
+
+    // Explicit renderOrder write escapes the sortLayer system — the
+    // sprite demotes to standalone and reparents under the group.
+    sprite.renderOrder = 7
+    expect(group.children.includes(sprite)).toBe(true)
+
+    // The next schedule run's scene-graph prune must NOT evict the
+    // demoted sprite (it only manages batch meshes).
+    scene.updateMatrixWorld(true)
+    expect(group.children.includes(sprite)).toBe(true)
+    expect(sprite.visible).toBe(true)
+
+    // And its world matrix composes through three again (standalone path)
+    group.position.x = 100
+    scene.updateMatrixWorld(true)
+    expect(sprite.matrixWorld.elements[12]).toBe(100)
+  })
+})

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -4,7 +4,6 @@ import {
   InstancedInterleavedBuffer,
   InterleavedBufferAttribute,
   DynamicDrawUsage,
-  Plane,
   Sphere,
   Vector3,
   type Matrix4,
@@ -70,13 +69,10 @@ const INTERLEAVED_FULL_THRESHOLD = 3
 const CUSTOM_FULL_THRESHOLD = 3
 
 /**
- * The batch's picking plane: world z = 0. Instance transforms live near
- * z = 0 (sort-layer offsets + tiny zIndex epsilons), and the batch mesh
- * itself is identity-pinned, so a single plane intersection localizes
- * the ray for the broadphase. Module-level scratch — raycast is
- * single-threaded and synchronous.
+ * Scratch for the two XY endpoints of the ray's sweep across the batch's
+ * member z-span (see `raycast`). Module-level — raycast is single-threaded
+ * and synchronous.
  */
-const _pickPlane = new Plane(new Vector3(0, 0, 1), 0)
 const _pickPoint = new Vector3()
 const _pickPoint2 = new Vector3()
 
@@ -654,22 +650,34 @@ export class SpriteBatch extends InstancedMesh {
    * at which it is sampled: under an orthographic camera the ray is
    * z-parallel (XY constant), but under perspective it converges, so a
    * single z=0 sample would query the wrong cell for a sprite at non-zero
-   * world Z. Sweep the ray across the grid's [zMin, zMax] span instead —
-   * two plane intersections bounding a segment, which collapses back to one
-   * cell (the fast path) whenever the batch is coplanar or the camera is
-   * orthographic.
+   * world Z. Localize by sweeping the ray across the grid's [zMin, zMax]
+   * span — the XY endpoints at where the ray ENTERS and EXITS the span,
+   * clamped to the forward (t ≥ 0) half. That collapses to one cell (the
+   * fast path) when the batch is coplanar or the camera is orthographic,
+   * and — unlike intersecting the two z-planes directly — stays correct
+   * when the ray origin sits inside the span or a stale span reaches behind
+   * the camera (those just clamp; they never abort the whole broadphase).
    */
   override raycast(raycaster: Raycaster, intersects: Intersection[]): void {
     if (this._activeCount === 0) return
     const grid = this.grid
     const zMin = grid.zMin
-    if (zMin > grid.zMax) return // empty grid
-    // Localize the ray at both ends of the member z-span. A ray parallel to
-    // (or receding from) these z-planes yields no point — nothing to pick.
-    _pickPlane.constant = -zMin
-    if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint) === null) return
-    _pickPlane.constant = -grid.zMax
-    if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint2) === null) return
+    const zMax = grid.zMax
+    if (zMin > zMax) return // empty grid
+    const ray = raycaster.ray
+    const oz = ray.origin.z
+    const dz = ray.direction.z
+    if (dz === 0) return // ray edge-on to the 2D plane — XY unbounded, no localize
+    // Ray parameters where z crosses the span bounds, ordered + clamped to the
+    // forward half. Entirely-behind span (tHi < 0) → nothing to pick.
+    const ta = (zMin - oz) / dz
+    const tb = (zMax - oz) / dz
+    let tLo = ta < tb ? ta : tb
+    const tHi = ta < tb ? tb : ta
+    if (tHi < 0) return
+    if (tLo < 0) tLo = 0
+    _pickPoint.copy(ray.direction).multiplyScalar(tLo).add(ray.origin)
+    _pickPoint2.copy(ray.direction).multiplyScalar(tHi).add(ray.origin)
     for (const sprite of grid.querySegment(_pickPoint.x, _pickPoint.y, _pickPoint2.x, _pickPoint2.y)) {
       if (sprite._pickProxied) {
         // R3F batch-root picking nulled the sprite's own `raycast` and made

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -78,6 +78,7 @@ const CUSTOM_FULL_THRESHOLD = 3
  */
 const _pickPlane = new Plane(new Vector3(0, 0, 1), 0)
 const _pickPoint = new Vector3()
+const _pickPoint2 = new Vector3()
 
 /**
  * A batch of sprites rendered with a single draw call.
@@ -641,20 +642,35 @@ export class SpriteBatch extends InstancedMesh {
   /**
    * Batch-root broadphase picking. Scene traversal reaches the batch
    * (member sprites are not graph children), so the batch localizes the
-   * ray — one intersection with the world z=0 plane the instances live
-   * near — and queries its spatial grid for candidate sprites. Each
-   * candidate delegates to `Sprite2D.raycast`, which owns ALL narrow-
-   * phase correctness (on-demand world-matrix compose, hitTestMode
+   * ray and queries its spatial grid for candidate sprites. Each candidate
+   * delegates to `Sprite2D.raycast`, which owns ALL narrow-phase
+   * correctness (on-demand world-matrix compose, hitTestMode
    * bounds/alpha/radius, near/far) and pushes intersections with
    * `object === sprite`. three's Raycaster distance-sorts afterward, so
    * higher-zIndex sprites (closer along +z) surface first — no sorting
    * here.
+   *
+   * The grid is indexed by world XY, but the ray's XY depends on the depth
+   * at which it is sampled: under an orthographic camera the ray is
+   * z-parallel (XY constant), but under perspective it converges, so a
+   * single z=0 sample would query the wrong cell for a sprite at non-zero
+   * world Z. Sweep the ray across the grid's [zMin, zMax] span instead —
+   * two plane intersections bounding a segment, which collapses back to one
+   * cell (the fast path) whenever the batch is coplanar or the camera is
+   * orthographic.
    */
   override raycast(raycaster: Raycaster, intersects: Intersection[]): void {
     if (this._activeCount === 0) return
-    // Parallel or receding ray — no plane point to localize around.
+    const grid = this.grid
+    const zMin = grid.zMin
+    if (zMin > grid.zMax) return // empty grid
+    // Localize the ray at both ends of the member z-span. A ray parallel to
+    // (or receding from) these z-planes yields no point — nothing to pick.
+    _pickPlane.constant = -zMin
     if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint) === null) return
-    for (const sprite of this.grid.queryPoint(_pickPoint.x, _pickPoint.y)) {
+    _pickPlane.constant = -grid.zMax
+    if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint2) === null) return
+    for (const sprite of grid.querySegment(_pickPoint.x, _pickPoint.y, _pickPoint2.x, _pickPoint2.y)) {
       if (sprite._pickProxied) {
         // R3F batch-root picking nulled the sprite's own `raycast` and made
         // THIS batch its raycast path. Bypass the null straight to the

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -12,6 +12,7 @@ import {
   type Intersection,
 } from 'three'
 import { SpriteSpatialGrid } from './SpriteSpatialGrid'
+import { retireBatchPicking } from '../react/batchPicking'
 import { createSynthQuadGeometry } from './synthQuadGeometry'
 import { buildEnvelopeGeometry } from './envelopeGeometry'
 import { getAtlasMesh } from '../loaders/atlasMeshRegistry'
@@ -654,8 +655,12 @@ export class SpriteBatch extends InstancedMesh {
     // Parallel or receding ray — no plane point to localize around.
     if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint) === null) return
     for (const sprite of this.grid.queryPoint(_pickPoint.x, _pickPoint.y)) {
-      // `hitTestMode = 'none'` nulls the instance raycast property.
-      if (typeof sprite.raycast === 'function') sprite.raycast(raycaster, intersects)
+      // A nulled `raycast` is an opt-out (`hitTestMode = 'none'`, user
+      // `raycast={null}`) — respect it, UNLESS the null is R3F batch-root
+      // picking's own doing (`_pickProxied`), in which case this batch IS
+      // the sprite's raycast path. `_hitTestInto` re-checks 'none' itself.
+      if (sprite.raycast === null && !sprite._pickProxied) continue
+      sprite._hitTestInto(raycaster, intersects)
     }
   }
 
@@ -706,6 +711,9 @@ export class SpriteBatch extends InstancedMesh {
    * Dispose of resources.
    */
   override dispose(): this {
+    // Drop any R3F batch-root picking registration — a disposed mesh
+    // must not linger in a live root's interaction list.
+    retireBatchPicking(this)
     this.resetSlots()
     this.geometry.dispose()
     // Don't dispose the material - it may be shared between batches

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -87,6 +87,13 @@ const CUSTOM_FULL_THRESHOLD = 3
  */
 export class SpriteBatch extends InstancedMesh {
   /**
+   * Type marker for graph-management code (sceneGraphSyncSystem's prune)
+   * that must distinguish batch meshes from other SpriteGroup children
+   * without a value import of this class.
+   */
+  readonly isSpriteBatch = true
+
+  /**
    * The material used by all sprites in this batch.
    */
   readonly spriteMaterial: Sprite2DMaterial
@@ -576,6 +583,24 @@ export class SpriteBatch extends InstancedMesh {
     if (this.count > 0) {
       this.computeBoundingSphere()
     }
+  }
+
+  /**
+   * The instance slots carry each sprite's WORLD transform (the ECS
+   * transform pass folds the owning SpriteGroup's world affine in), so
+   * the batch mesh itself must stay pinned at identity — inheriting the
+   * group's transform through the normal parent-chain compose would
+   * double-apply it in the shader's `modelMatrix × instanceMatrix`.
+   */
+  override updateMatrixWorld(_force?: boolean): void {
+    this.matrixWorld.identity()
+    this.matrixWorldNeedsUpdate = false
+  }
+
+  /** See {@link SpriteBatch.updateMatrixWorld} — identity-pinned. */
+  override updateWorldMatrix(_updateParents?: boolean, _updateChildren?: boolean): void {
+    this.matrixWorld.identity()
+    this.matrixWorldNeedsUpdate = false
   }
 
   /**

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -12,7 +12,7 @@ import {
   type Intersection,
 } from 'three'
 import { SpriteSpatialGrid } from './SpriteSpatialGrid'
-import { retireBatchPicking } from '../react/batchPicking'
+import { retireBatchPicking, isR3FManaged } from '../react/batchPicking'
 import { createSynthQuadGeometry } from './synthQuadGeometry'
 import { buildEnvelopeGeometry } from './envelopeGeometry'
 import { getAtlasMesh } from '../loaders/atlasMeshRegistry'
@@ -660,11 +660,17 @@ export class SpriteBatch extends InstancedMesh {
         // THIS batch its raycast path. Bypass the null straight to the
         // narrow phase (`_hitTestInto` re-checks `hitTestMode = 'none'`).
         sprite._hitTestInto(raycaster, intersects)
+      } else if (isR3FManaged(sprite)) {
+        // R3F-managed but NOT proxied (own custom `raycast`, or an opt-out
+        // null): R3F's own per-object interaction list still holds it, so
+        // hit-testing it here too would fire its raycast twice per pointer
+        // event. Leave it to R3F.
+        continue
       } else if (typeof sprite.raycast === 'function') {
-        // Vanilla / non-proxied: honor the sprite's OWN raycast — the
-        // prototype hit test, or a user-supplied custom one. A null raycast
-        // (`hitTestMode = 'none'` or an explicit `raycast={null}` opt-out) is
-        // falsy here and correctly skipped.
+        // Vanilla (three.js) sprite — the batch grid is its ONLY picking
+        // path. Honor its OWN raycast: the prototype hit test or a
+        // user-supplied custom one. A null raycast (`hitTestMode = 'none'`
+        // or an explicit opt-out) is falsy here and correctly skipped.
         sprite.raycast(raycaster, intersects)
       }
     }

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -10,8 +10,9 @@ import {
   type Raycaster,
   type Intersection,
 } from 'three'
-import { SpriteSpatialGrid } from './SpriteSpatialGrid'
+import { SpriteSpatialGrid, quadHalfExtents } from './SpriteSpatialGrid'
 import { retireBatchPicking, isR3FManaged } from '../react/batchPicking'
+import type { Sprite2D } from '../sprites/Sprite2D'
 import { createSynthQuadGeometry } from './synthQuadGeometry'
 import { buildEnvelopeGeometry } from './envelopeGeometry'
 import { getAtlasMesh } from '../loaders/atlasMeshRegistry'
@@ -75,6 +76,8 @@ const CUSTOM_FULL_THRESHOLD = 3
  */
 const _pickPoint = new Vector3()
 const _pickPoint2 = new Vector3()
+/** Scratch for `indexForPicking`'s half-extents — single-threaded, synchronous. */
+const _he = { hx: 0, hy: 0 }
 
 /**
  * A batch of sprites rendered with a single draw call.
@@ -633,6 +636,19 @@ export class SpriteBatch extends InstancedMesh {
     if (this.boundingSphere === null) this.boundingSphere = new Sphere()
     this.boundingSphere.center.set(0, 0, 0)
     this.boundingSphere.radius = Infinity
+  }
+
+  /**
+   * Index `sprite` into the picking broadphase from its local matrix. The
+   * batch systems call this at slot assign/reassign; the group-folded WORLD
+   * position lands later the same schedule run via `transformSyncSystem`'s
+   * `grid.update`. When transform sync is disabled the instance matrix IS
+   * this local affine, so the grid and the rendered position agree either way.
+   */
+  indexForPicking(sprite: Sprite2D): void {
+    const te = sprite.matrix.elements
+    quadHalfExtents(te[0]!, te[4]!, te[1]!, te[5]!, sprite.hitRadius, _he)
+    this.grid.insert(sprite, te[12]!, te[13]!, _he.hx, _he.hy, te[14]!)
   }
 
   /**

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -4,11 +4,14 @@ import {
   InstancedInterleavedBuffer,
   InterleavedBufferAttribute,
   DynamicDrawUsage,
+  Plane,
   Sphere,
+  Vector3,
   type Matrix4,
   type Raycaster,
   type Intersection,
 } from 'three'
+import { SpriteSpatialGrid } from './SpriteSpatialGrid'
 import { createSynthQuadGeometry } from './synthQuadGeometry'
 import { buildEnvelopeGeometry } from './envelopeGeometry'
 import { getAtlasMesh } from '../loaders/atlasMeshRegistry'
@@ -66,6 +69,16 @@ const INTERLEAVED_FULL_THRESHOLD = 3
 const CUSTOM_FULL_THRESHOLD = 3
 
 /**
+ * The batch's picking plane: world z = 0. Instance transforms live near
+ * z = 0 (sort-layer offsets + tiny zIndex epsilons), and the batch mesh
+ * itself is identity-pinned, so a single plane intersection localizes
+ * the ray for the broadphase. Module-level scratch — raycast is
+ * single-threaded and synchronous.
+ */
+const _pickPlane = new Plane(new Vector3(0, 0, 1), 0)
+const _pickPoint = new Vector3()
+
+/**
  * A batch of sprites rendered with a single draw call.
  *
  * Uses InstancedMesh with:
@@ -119,6 +132,14 @@ export class SpriteBatch extends InstancedMesh {
    * longer matches its registration gets rebuilt instead of reused.
    */
   readonly envelopeVersion: number
+
+  /**
+   * Picking broadphase: a uniform hash grid of this batch's member
+   * sprites keyed by world position. Maintained by the batch lifecycle
+   * systems (assign/reassign/remove insert + remove entries) and by
+   * `transformSyncSystem` (moves). Queried by {@link SpriteBatch.raycast}.
+   */
+  readonly grid = new SpriteSpatialGrid()
 
   /**
    * Current number of active slots in the batch.
@@ -549,6 +570,8 @@ export class SpriteBatch extends InstancedMesh {
     this._freeList.length = 0
     this._nextIndex = 0
     this.count = 0
+    // Wholesale membership reset — the broadphase index goes with it.
+    this.grid.clear()
   }
 
   /**
@@ -615,12 +638,26 @@ export class SpriteBatch extends InstancedMesh {
   }
 
   /**
-   * Raycasting a batch is meaningless — the unit-quad geometry knows
-   * nothing about per-instance UV flip/atlas remap or alpha. Pointer
-   * interaction happens per-Sprite2D via its own plane-math raycast;
-   * batched-sprite picking is tracked separately (GPU ID-buffer picking).
+   * Batch-root broadphase picking. Scene traversal reaches the batch
+   * (member sprites are not graph children), so the batch localizes the
+   * ray — one intersection with the world z=0 plane the instances live
+   * near — and queries its spatial grid for candidate sprites. Each
+   * candidate delegates to `Sprite2D.raycast`, which owns ALL narrow-
+   * phase correctness (on-demand world-matrix compose, hitTestMode
+   * bounds/alpha/radius, near/far) and pushes intersections with
+   * `object === sprite`. three's Raycaster distance-sorts afterward, so
+   * higher-zIndex sprites (closer along +z) surface first — no sorting
+   * here.
    */
-  override raycast(_raycaster: Raycaster, _intersects: Intersection[]): void {}
+  override raycast(raycaster: Raycaster, intersects: Intersection[]): void {
+    if (this._activeCount === 0) return
+    // Parallel or receding ray — no plane point to localize around.
+    if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint) === null) return
+    for (const sprite of this.grid.queryPoint(_pickPoint.x, _pickPoint.y)) {
+      // `hitTestMode = 'none'` nulls the instance raycast property.
+      if (typeof sprite.raycast === 'function') sprite.raycast(raycaster, intersects)
+    }
+  }
 
   /**
    * Flush per-buffer dirty state to GPU upload ranges.

--- a/packages/three-flatland/src/pipeline/SpriteBatch.ts
+++ b/packages/three-flatland/src/pipeline/SpriteBatch.ts
@@ -655,12 +655,18 @@ export class SpriteBatch extends InstancedMesh {
     // Parallel or receding ray — no plane point to localize around.
     if (raycaster.ray.intersectPlane(_pickPlane, _pickPoint) === null) return
     for (const sprite of this.grid.queryPoint(_pickPoint.x, _pickPoint.y)) {
-      // A nulled `raycast` is an opt-out (`hitTestMode = 'none'`, user
-      // `raycast={null}`) — respect it, UNLESS the null is R3F batch-root
-      // picking's own doing (`_pickProxied`), in which case this batch IS
-      // the sprite's raycast path. `_hitTestInto` re-checks 'none' itself.
-      if (sprite.raycast === null && !sprite._pickProxied) continue
-      sprite._hitTestInto(raycaster, intersects)
+      if (sprite._pickProxied) {
+        // R3F batch-root picking nulled the sprite's own `raycast` and made
+        // THIS batch its raycast path. Bypass the null straight to the
+        // narrow phase (`_hitTestInto` re-checks `hitTestMode = 'none'`).
+        sprite._hitTestInto(raycaster, intersects)
+      } else if (typeof sprite.raycast === 'function') {
+        // Vanilla / non-proxied: honor the sprite's OWN raycast — the
+        // prototype hit test, or a user-supplied custom one. A null raycast
+        // (`hitTestMode = 'none'` or an explicit `raycast={null}` opt-out) is
+        // falsy here and correctly skipped.
+        sprite.raycast(raycaster, intersects)
+      }
     }
   }
 

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
@@ -70,4 +70,27 @@ describe('SpriteSpatialGrid', () => {
     // Query is far from 'a' — no false hit, and critically it RETURNED.
     expect(hit).toEqual([])
   })
+
+  it('insert terminates for an absurd coordinate (index past 2^53)', () => {
+    const g = new SpriteSpatialGrid(128)
+    const start = performance.now()
+    g.insert(sprite('a'), 2 ** 53 * 128, 0, 4, 4) // index ~2^53 → cx++ would stall
+    expect(performance.now() - start).toBeLessThan(200)
+    expect(g.size).toBe(1)
+  })
+
+  it('insert AND remove stay bounded for a giant AABB (no unbounded allocation)', () => {
+    const g = new SpriteSpatialGrid(128)
+    const a = sprite('a')
+    const t0 = performance.now()
+    g.insert(a, 0, 0, 1e9, 1e9) // half-extent 1e9 → billions of cells if uncapped
+    expect(performance.now() - t0).toBeLessThan(500)
+    // A query at the sprite's centre still finds it (indexed window covers 0,0).
+    expect(ids(g.querySegment(0, 0, 10, 10))).toEqual(['a'])
+    // Remove walks the same capped window — must also terminate promptly.
+    const t1 = performance.now()
+    g.remove(a)
+    expect(performance.now() - t1).toBeLessThan(500)
+    expect(g.size).toBe(0)
+  })
 })

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { SpriteSpatialGrid } from './SpriteSpatialGrid'
+import type { Sprite2D } from '../sprites/Sprite2D'
+
+// The grid keys on Sprite2D identity only; a bare tagged object suffices.
+function sprite(tag: string): Sprite2D {
+  return { tag } as unknown as Sprite2D
+}
+function ids(it: Iterable<Sprite2D>): string[] {
+  return [...it].map((s) => (s as unknown as { tag: string }).tag).sort()
+}
+
+describe('SpriteSpatialGrid', () => {
+  it('tracks the world-Z span (grows, does not shrink on remove)', () => {
+    const g = new SpriteSpatialGrid(128)
+    expect(g.zMin).toBe(Infinity)
+    expect(g.zMax).toBe(-Infinity)
+    const a = sprite('a')
+    g.insert(a, 0, 0, 10, 10, 5)
+    g.insert(sprite('b'), 0, 0, 10, 10, -3)
+    expect(g.zMin).toBe(-3)
+    expect(g.zMax).toBe(5)
+    g.remove(a) // span stays wide — a safe over-approximation
+    expect(g.zMin).toBe(-3)
+    expect(g.zMax).toBe(5)
+    g.clear()
+    expect(g.zMin).toBe(Infinity)
+    expect(g.zMax).toBe(-Infinity)
+  })
+
+  it('querySegment collapses to a single cell when both ends share it', () => {
+    const g = new SpriteSpatialGrid(128)
+    g.insert(sprite('a'), 10, 10, 4, 4)
+    g.insert(sprite('b'), 300, 10, 4, 4)
+    // Both endpoints in cell (0,0).
+    expect(ids(g.querySegment(5, 5, 20, 20))).toEqual(['a'])
+  })
+
+  it('querySegment unions every cell the block spans', () => {
+    const g = new SpriteSpatialGrid(128)
+    g.insert(sprite('a'), 10, 10, 4, 4) // cell 0,0
+    g.insert(sprite('b'), 260, 10, 4, 4) // cell 2,0
+    // Segment from cell 0,0 to cell 2,0 covers both.
+    expect(ids(g.querySegment(10, 10, 260, 10))).toEqual(['a', 'b'])
+  })
+
+  it('does not hang on a grazing ray: an astronomically long segment stays bounded', () => {
+    const g = new SpriteSpatialGrid(128)
+    g.insert(sprite('a'), 10, 10, 4, 4) // cell 0,0, inside the huge block
+    g.insert(sprite('b'), 1e6, 1e6, 4, 4) // far away, also inside the block
+    // A segment spanning ~1e10 cells per axis — the naive block loop would
+    // iterate ~1e20 cells. The occupied-set branch returns the two real
+    // sprites in O(occupied) instead.
+    const start = performance.now()
+    const hit = ids(g.querySegment(0, 0, 1e12, 1e12))
+    expect(performance.now() - start).toBeLessThan(200)
+    expect(hit).toEqual(['a', 'b'])
+  })
+})

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.test.ts
@@ -56,4 +56,18 @@ describe('SpriteSpatialGrid', () => {
     expect(performance.now() - start).toBeLessThan(200)
     expect(hit).toEqual(['a', 'b'])
   })
+
+  it('terminates on a SMALL block at astronomically large cell indices', () => {
+    const g = new SpriteSpatialGrid(128)
+    g.insert(sprite('a'), 10, 10, 4, 4)
+    // A tiny 2-cell block, but at world coords ~2^53·cellSize where integer
+    // ++ would stop advancing. Must fall back to the occupied-cell branch and
+    // return promptly rather than spinning forever.
+    const huge = 2 ** 53 * 128
+    const start = performance.now()
+    const hit = ids(g.querySegment(huge, huge, huge + 128, huge))
+    expect(performance.now() - start).toBeLessThan(200)
+    // Query is far from 'a' — no false hit, and critically it RETURNED.
+    expect(hit).toEqual([])
+  })
 })

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -1,0 +1,168 @@
+import type { Sprite2D } from '../sprites/Sprite2D'
+
+/**
+ * Uniform hash-grid cell size in world units. Tunable — 128 balances
+ * cell occupancy against per-sprite cell coverage for typical sprite
+ * scales (tens to low hundreds of world units).
+ */
+export const SPATIAL_GRID_CELL_SIZE = 128
+
+/** A sprite's current cell coverage — inclusive cell-index bounds. */
+interface CellRange {
+  minCx: number
+  minCy: number
+  maxCx: number
+  maxCy: number
+}
+
+/** Shared empty result for point queries that land in an unoccupied cell. */
+const EMPTY: readonly Sprite2D[] = []
+
+/**
+ * Uniform hash grid of `Sprite2D` keyed by world position, used by
+ * `SpriteBatch.raycast` as the picking broadphase.
+ *
+ * Indexing strategy: **multi-cell insert, single-cell query.** Each
+ * sprite is inserted into every cell its world AABB overlaps (sprites
+ * vary freely in size, so a fixed query neighborhood like a 3×3 block
+ * would miss sprites larger than a cell). A point query then reads
+ * exactly ONE cell — any sprite whose AABB covers the point must occupy
+ * that cell — and since a cell holds each sprite at most once (Set),
+ * single-cell queries need no dedup pass at all.
+ *
+ * The grid is a conservative broadphase: candidates are over-approximate
+ * (AABB of the possibly-rotated quad) and the narrow phase
+ * (`Sprite2D.raycast`) does the exact hit test.
+ *
+ * @internal
+ */
+export class SpriteSpatialGrid {
+  private readonly _cellSize: number
+
+  /** Occupancy: `"cx,cy"` → sprites whose AABB overlaps that cell. */
+  private readonly _cells = new Map<string, Set<Sprite2D>>()
+
+  /** Reverse index: sprite → its current cell coverage, for O(1) remove. */
+  private readonly _ranges = new Map<Sprite2D, CellRange>()
+
+  constructor(cellSize: number = SPATIAL_GRID_CELL_SIZE) {
+    this._cellSize = cellSize
+  }
+
+  /** Number of sprites currently indexed. */
+  get size(): number {
+    return this._ranges.size
+  }
+
+  /**
+   * Insert `sprite` covering the world AABB centered at (x, y) with
+   * half-extents (hx, hy). Re-inserting an already-indexed sprite
+   * behaves like {@link update}.
+   */
+  insert(sprite: Sprite2D, x: number, y: number, hx: number, hy: number): void {
+    this.update(sprite, x, y, hx, hy)
+  }
+
+  /**
+   * Move `sprite` to the world AABB centered at (x, y) with half-extents
+   * (hx, hy). No-op when the covered cell range is unchanged (the
+   * common static-sprite frame); inserts when the sprite isn't indexed yet.
+   */
+  update(sprite: Sprite2D, x: number, y: number, hx: number, hy: number): void {
+    const cs = this._cellSize
+    const minCx = Math.floor((x - hx) / cs)
+    const minCy = Math.floor((y - hy) / cs)
+    const maxCx = Math.floor((x + hx) / cs)
+    const maxCy = Math.floor((y + hy) / cs)
+
+    const range = this._ranges.get(sprite)
+    if (range) {
+      if (range.minCx === minCx && range.minCy === minCy && range.maxCx === maxCx && range.maxCy === maxCy) {
+        return // Same cells — nothing to re-index.
+      }
+      this._removeFromCells(sprite, range)
+      range.minCx = minCx
+      range.minCy = minCy
+      range.maxCx = maxCx
+      range.maxCy = maxCy
+      this._addToCells(sprite, range)
+      return
+    }
+
+    const fresh: CellRange = { minCx, minCy, maxCx, maxCy }
+    this._ranges.set(sprite, fresh)
+    this._addToCells(sprite, fresh)
+  }
+
+  /** Remove `sprite` from the grid. No-op if it isn't indexed. */
+  remove(sprite: Sprite2D): void {
+    const range = this._ranges.get(sprite)
+    if (!range) return
+    this._removeFromCells(sprite, range)
+    this._ranges.delete(sprite)
+  }
+
+  /**
+   * Candidate sprites whose quad could cover the world point (x, y).
+   * Reads a single cell (see class doc) — allocation-free beyond the
+   * cell-key string; the returned iterable is live grid state, consume
+   * immediately without mutating the grid.
+   */
+  queryPoint(x: number, y: number): Iterable<Sprite2D> {
+    const cs = this._cellSize
+    return this._cells.get(`${Math.floor(x / cs)},${Math.floor(y / cs)}`) ?? EMPTY
+  }
+
+  /** Drop all sprites — used when a batch is recycled or disposed. */
+  clear(): void {
+    this._cells.clear()
+    this._ranges.clear()
+  }
+
+  private _addToCells(sprite: Sprite2D, range: CellRange): void {
+    for (let cy = range.minCy; cy <= range.maxCy; cy++) {
+      for (let cx = range.minCx; cx <= range.maxCx; cx++) {
+        const key = `${cx},${cy}`
+        let cell = this._cells.get(key)
+        if (!cell) {
+          cell = new Set()
+          this._cells.set(key, cell)
+        }
+        cell.add(sprite)
+      }
+    }
+  }
+
+  private _removeFromCells(sprite: Sprite2D, range: CellRange): void {
+    for (let cy = range.minCy; cy <= range.maxCy; cy++) {
+      for (let cx = range.minCx; cx <= range.maxCx; cx++) {
+        const key = `${cx},${cy}`
+        const cell = this._cells.get(key)
+        if (!cell) continue
+        cell.delete(sprite)
+        if (cell.size === 0) this._cells.delete(key)
+      }
+    }
+  }
+}
+
+/**
+ * World AABB half-extents of a sprite's centered unit quad under a 2D
+ * affine with linear part [[m00, m01], [m10, m11]] (column-major
+ * columns [m00, m10] and [m01, m11]) — exact for any rotation/shear:
+ * hx = (|m00| + |m01|) / 2, hy = (|m10| + |m11|) / 2. Inflated when
+ * `hitRadius > 0.5` since 'radius' hit-testing can extend beyond the
+ * quad. Writes into `out` to stay allocation-free in per-frame loops.
+ */
+export function quadHalfExtents(
+  m00: number,
+  m01: number,
+  m10: number,
+  m11: number,
+  hitRadius: number,
+  out: { hx: number; hy: number }
+): void {
+  const inflate = hitRadius > 0.5 ? hitRadius * 2 : 1
+  out.hx = ((Math.abs(m00) + Math.abs(m01)) / 2) * inflate
+  out.hy = ((Math.abs(m10) + Math.abs(m11)) / 2) * inflate
+}

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -157,15 +157,32 @@ export class SpriteSpatialGrid {
     if (cx0 === cx1 && cy0 === cy1) {
       return this._cells.get(`${cx0},${cy0}`) ?? EMPTY
     }
-    const out = new Set<Sprite2D>()
     const minCx = cx0 < cx1 ? cx0 : cx1
     const maxCx = cx0 < cx1 ? cx1 : cx0
     const minCy = cy0 < cy1 ? cy0 : cy1
     const maxCy = cy0 < cy1 ? cy1 : cy0
-    for (let cy = minCy; cy <= maxCy; cy++) {
-      for (let cx = minCx; cx <= maxCx; cx++) {
-        const cell = this._cells.get(`${cx},${cy}`)
-        if (cell) for (const s of cell) out.add(s)
+    const out = new Set<Sprite2D>()
+    // A near-grazing ray (tiny dz) can make the swept segment — and thus this
+    // cell bounding block — span astronomically many cells, almost all empty.
+    // Iterate whichever set is smaller: the block, or the OCCUPIED cells
+    // (bounded by the sprite count). The result is identical; only the cost
+    // differs. Guards against an unbounded loop / hang on a grazing ray.
+    const blockCells = (maxCx - minCx + 1) * (maxCy - minCy + 1)
+    if (blockCells <= this._cells.size) {
+      for (let cy = minCy; cy <= maxCy; cy++) {
+        for (let cx = minCx; cx <= maxCx; cx++) {
+          const cell = this._cells.get(`${cx},${cy}`)
+          if (cell) for (const s of cell) out.add(s)
+        }
+      }
+    } else {
+      for (const [key, cell] of this._cells) {
+        const comma = key.indexOf(',')
+        const cx = Number(key.slice(0, comma))
+        const cy = Number(key.slice(comma + 1))
+        if (cx >= minCx && cx <= maxCx && cy >= minCy && cy <= maxCy) {
+          for (const s of cell) out.add(s)
+        }
       }
     }
     return out

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -34,6 +34,11 @@ function clampCell(v: number): number {
   return v < -MAX_SAFE_CELL ? -MAX_SAFE_CELL : v > MAX_SAFE_CELL ? MAX_SAFE_CELL : v
 }
 
+/** Map key for the cell at integer indices (cx, cy). */
+function cellKey(cx: number, cy: number): string {
+  return `${cx},${cy}`
+}
+
 /** A sprite's current cell coverage — inclusive cell-index bounds. */
 interface CellRange {
   minCx: number
@@ -49,13 +54,12 @@ const EMPTY: readonly Sprite2D[] = []
  * Uniform hash grid of `Sprite2D` keyed by world position, used by
  * `SpriteBatch.raycast` as the picking broadphase.
  *
- * Indexing strategy: **multi-cell insert, single-cell query.** Each
- * sprite is inserted into every cell its world AABB overlaps (sprites
- * vary freely in size, so a fixed query neighborhood like a 3×3 block
- * would miss sprites larger than a cell). A point query then reads
- * exactly ONE cell — any sprite whose AABB covers the point must occupy
- * that cell — and since a cell holds each sprite at most once (Set),
- * single-cell queries need no dedup pass at all.
+ * Indexing strategy: **multi-cell insert, cell-block query.** Each sprite
+ * is inserted into every cell its world AABB overlaps (sprites vary freely
+ * in size, so a fixed query neighborhood like a 3×3 block would miss
+ * sprites larger than a cell). {@link querySegment} then reads only the
+ * cells the picking ray sweeps — a single cell for an orthographic camera
+ * or a coplanar batch (the common case), a short segment under perspective.
  *
  * The grid is a conservative broadphase: candidates are over-approximate
  * (AABB of the possibly-rotated quad) and the narrow phase
@@ -172,25 +176,15 @@ export class SpriteSpatialGrid {
   }
 
   /**
-   * Candidate sprites whose quad could cover the world point (x, y).
-   * Reads a single cell (see class doc) — allocation-free beyond the
-   * cell-key string; the returned iterable is live grid state, consume
-   * immediately without mutating the grid.
-   */
-  queryPoint(x: number, y: number): Iterable<Sprite2D> {
-    const cs = this._cellSize
-    return this._cells.get(`${Math.floor(x / cs)},${Math.floor(y / cs)}`) ?? EMPTY
-  }
-
-  /**
    * Candidate sprites under the world-space segment from (x0, y0) to
    * (x1, y1) — the projection of a picking ray swept across the batch's
    * z-span. When both ends fall in the same cell (an orthographic camera,
    * or a coplanar batch, collapses the segment to a point) this reads that
-   * ONE cell allocation-free, exactly like {@link queryPoint}. Otherwise it
-   * unions every cell in the segment's bounding block into a fresh Set —
-   * conservative (a few extra cells) but never a miss; the narrow phase
-   * filters. Cheap because this runs per pointer event, not per frame.
+   * ONE cell allocation-free. Otherwise it unions every cell in the
+   * segment's bounding block into a fresh Set — conservative (a few extra
+   * cells) but never a miss; the narrow phase filters. Cheap because this
+   * runs per pointer event, not per frame; the returned iterable is transient
+   * grid state, consume immediately without mutating the grid.
    */
   querySegment(x0: number, y0: number, x1: number, y1: number): Iterable<Sprite2D> {
     const cs = this._cellSize
@@ -199,41 +193,33 @@ export class SpriteSpatialGrid {
     const cx1 = Math.floor(x1 / cs)
     const cy1 = Math.floor(y1 / cs)
     if (cx0 === cx1 && cy0 === cy1) {
-      return this._cells.get(`${cx0},${cy0}`) ?? EMPTY
+      return this._cells.get(cellKey(cx0, cy0)) ?? EMPTY
     }
     const minCx = cx0 < cx1 ? cx0 : cx1
     const maxCx = cx0 < cx1 ? cx1 : cx0
     const minCy = cy0 < cy1 ? cy0 : cy1
     const maxCy = cy0 < cy1 ? cy1 : cy0
     const out = new Set<Sprite2D>()
-    // A near-grazing ray (tiny dz) can make the swept segment — and thus this
-    // cell bounding block — span astronomically many cells, almost all empty.
-    // Iterate whichever set is smaller: the block, or the OCCUPIED cells
-    // (bounded by the sprite count). The result is identical; only the cost
-    // differs. Guards against an unbounded loop / hang on a grazing ray.
-    //
-    // The block branch also requires float-safe indices: a `cx++` at
-    // Number.MAX_SAFE_INTEGER (world coords near 2^53·cellSize) stops
-    // advancing and loops forever, so beyond a generous magnitude fall back to
-    // the occupied-set branch, whose bound comparisons increment nothing.
+    // Iterate the cheaper of two equivalent passes: the segment's cell block,
+    // or every indexed sprite (tested for AABB overlap with the block). A
+    // near-grazing ray (tiny dz) can make the block span astronomically many
+    // cells, almost all empty; and a `cx++` past 2^53 (world coords near
+    // 2^53·cellSize) stops advancing, looping forever. So take the block loop
+    // only when its indices are float-safe AND it is no larger than the sprite
+    // set; otherwise the per-sprite pass, whose overlap tests increment nothing.
     const indicesSafe =
       minCx > -MAX_SAFE_CELL && maxCx < MAX_SAFE_CELL && minCy > -MAX_SAFE_CELL && maxCy < MAX_SAFE_CELL
     const blockCells = (maxCx - minCx + 1) * (maxCy - minCy + 1)
-    if (indicesSafe && blockCells <= this._cells.size) {
+    if (indicesSafe && blockCells <= this._ranges.size) {
       for (let cy = minCy; cy <= maxCy; cy++) {
         for (let cx = minCx; cx <= maxCx; cx++) {
-          const cell = this._cells.get(`${cx},${cy}`)
+          const cell = this._cells.get(cellKey(cx, cy))
           if (cell) for (const s of cell) out.add(s)
         }
       }
     } else {
-      for (const [key, cell] of this._cells) {
-        const comma = key.indexOf(',')
-        const cx = Number(key.slice(0, comma))
-        const cy = Number(key.slice(comma + 1))
-        if (cx >= minCx && cx <= maxCx && cy >= minCy && cy <= maxCy) {
-          for (const s of cell) out.add(s)
-        }
+      for (const [sprite, r] of this._ranges) {
+        if (r.minCx <= maxCx && r.maxCx >= minCx && r.minCy <= maxCy && r.maxCy >= minCy) out.add(sprite)
       }
     }
     return out
@@ -250,7 +236,7 @@ export class SpriteSpatialGrid {
   private _addToCells(sprite: Sprite2D, range: CellRange): void {
     for (let cy = range.minCy; cy <= range.maxCy; cy++) {
       for (let cx = range.minCx; cx <= range.maxCx; cx++) {
-        const key = `${cx},${cy}`
+        const key = cellKey(cx, cy)
         let cell = this._cells.get(key)
         if (!cell) {
           cell = new Set()
@@ -264,7 +250,7 @@ export class SpriteSpatialGrid {
   private _removeFromCells(sprite: Sprite2D, range: CellRange): void {
     for (let cy = range.minCy; cy <= range.maxCy; cy++) {
       for (let cx = range.minCx; cx <= range.maxCx; cx++) {
-        const key = `${cx},${cy}`
+        const key = cellKey(cx, cy)
         const cell = this._cells.get(key)
         if (!cell) continue
         cell.delete(sprite)

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -167,8 +167,15 @@ export class SpriteSpatialGrid {
     // Iterate whichever set is smaller: the block, or the OCCUPIED cells
     // (bounded by the sprite count). The result is identical; only the cost
     // differs. Guards against an unbounded loop / hang on a grazing ray.
+    //
+    // The block branch also requires float-safe indices: a `cx++` at
+    // Number.MAX_SAFE_INTEGER (world coords near 2^53·cellSize) stops
+    // advancing and loops forever, so beyond a generous magnitude fall back to
+    // the occupied-set branch, whose bound comparisons increment nothing.
+    const SAFE_CELL = 2 ** 40
+    const indicesSafe = minCx > -SAFE_CELL && maxCx < SAFE_CELL && minCy > -SAFE_CELL && maxCy < SAFE_CELL
     const blockCells = (maxCx - minCx + 1) * (maxCy - minCy + 1)
-    if (blockCells <= this._cells.size) {
+    if (indicesSafe && blockCells <= this._cells.size) {
       for (let cy = minCy; cy <= maxCy; cy++) {
         for (let cx = minCx; cx <= maxCx; cx++) {
           const cell = this._cells.get(`${cx},${cy}`)

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -7,6 +7,33 @@ import type { Sprite2D } from '../sprites/Sprite2D'
  */
 export const SPATIAL_GRID_CELL_SIZE = 128
 
+/**
+ * Largest cell-index magnitude the grid indexes into. Two bounds in one:
+ * indices stay float-safe (a `cx++` at 2^53 stops advancing → infinite loop),
+ * and the covered region stays finite. `2^40` cells ≈ 1.4e14 world units at
+ * the default cell size — orders of magnitude beyond any real 2D scene (and
+ * beyond float32 render precision), so only absurd coordinates/scales clamp.
+ */
+const MAX_SAFE_CELL = 2 ** 40
+
+/**
+ * Cap on the per-axis cell span a single sprite may occupy. A sprite whose
+ * AABB is astronomically large would otherwise allocate one cell Set per
+ * covered cell (unbounded memory). 256 cells/axis (32768 world units) far
+ * exceeds any real sprite; a degenerate one is indexed into a bounded window
+ * centred on it (≤ 256² cells — kept small so even a pathological input is
+ * cheap, not just finite).
+ */
+const MAX_CELL_SPAN = 256
+
+/**
+ * Clamp a cell index to the float-safe window. `NaN` (a NaN coordinate)
+ * passes through and simply produces an empty, non-iterating range.
+ */
+function clampCell(v: number): number {
+  return v < -MAX_SAFE_CELL ? -MAX_SAFE_CELL : v > MAX_SAFE_CELL ? MAX_SAFE_CELL : v
+}
+
 /** A sprite's current cell coverage — inclusive cell-index bounds. */
 interface CellRange {
   minCx: number
@@ -95,10 +122,27 @@ export class SpriteSpatialGrid {
     if (z < this._zMin) this._zMin = z
     if (z > this._zMax) this._zMax = z
     const cs = this._cellSize
-    const minCx = Math.floor((x - hx) / cs)
-    const minCy = Math.floor((y - hy) / cs)
-    const maxCx = Math.floor((x + hx) / cs)
-    const maxCy = Math.floor((y + hy) / cs)
+    // Clamp coverage to a bounded, float-safe cell window. Without this a
+    // sprite at absurd world coordinates (index ≥ 2^53) would spin the
+    // add/remove loops forever, and a giant AABB would allocate unbounded
+    // cell Sets. Realistic sprites sit far inside these bounds untouched.
+    let minCx = clampCell(Math.floor((x - hx) / cs))
+    let minCy = clampCell(Math.floor((y - hy) / cs))
+    let maxCx = clampCell(Math.floor((x + hx) / cs))
+    let maxCy = clampCell(Math.floor((y + hy) / cs))
+    // Cap the span AROUND the sprite's centre cell (not from the min corner),
+    // so a giant AABB still indexes the region a centre-ish pointer will query.
+    const half = MAX_CELL_SPAN / 2
+    if (maxCx - minCx > MAX_CELL_SPAN) {
+      const cCx = clampCell(Math.floor(x / cs))
+      minCx = cCx - half
+      maxCx = cCx + half
+    }
+    if (maxCy - minCy > MAX_CELL_SPAN) {
+      const cCy = clampCell(Math.floor(y / cs))
+      minCy = cCy - half
+      maxCy = cCy + half
+    }
 
     const range = this._ranges.get(sprite)
     if (range) {
@@ -172,8 +216,8 @@ export class SpriteSpatialGrid {
     // Number.MAX_SAFE_INTEGER (world coords near 2^53·cellSize) stops
     // advancing and loops forever, so beyond a generous magnitude fall back to
     // the occupied-set branch, whose bound comparisons increment nothing.
-    const SAFE_CELL = 2 ** 40
-    const indicesSafe = minCx > -SAFE_CELL && maxCx < SAFE_CELL && minCy > -SAFE_CELL && maxCy < SAFE_CELL
+    const indicesSafe =
+      minCx > -MAX_SAFE_CELL && maxCx < MAX_SAFE_CELL && minCy > -MAX_SAFE_CELL && maxCy < MAX_SAFE_CELL
     const blockCells = (maxCx - minCx + 1) * (maxCy - minCy + 1)
     if (indicesSafe && blockCells <= this._cells.size) {
       for (let cy = minCy; cy <= maxCy; cy++) {

--- a/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
+++ b/packages/three-flatland/src/pipeline/SpriteSpatialGrid.ts
@@ -45,6 +45,18 @@ export class SpriteSpatialGrid {
   /** Reverse index: sprite → its current cell coverage, for O(1) remove. */
   private readonly _ranges = new Map<Sprite2D, CellRange>()
 
+  /**
+   * World-Z span of the indexed sprites. The grid is a 2D (xy) structure,
+   * but a picking ray localizes at a specific z; under a perspective camera
+   * the ray's xy shifts with z, so `SpriteBatch.raycast` must sweep the ray
+   * across [`zMin`, `zMax`] to find candidates (see `querySegment`). Grows to
+   * include each inserted sprite and is not shrunk on remove — a wider span
+   * only widens the swept cell set (still exact after narrow phase), never
+   * drops a hit. Empty grid: `zMin > zMax`.
+   */
+  private _zMin = Infinity
+  private _zMax = -Infinity
+
   constructor(cellSize: number = SPATIAL_GRID_CELL_SIZE) {
     this._cellSize = cellSize
   }
@@ -54,21 +66,34 @@ export class SpriteSpatialGrid {
     return this._ranges.size
   }
 
+  /** Lowest world-Z of any indexed sprite (`Infinity` when empty). */
+  get zMin(): number {
+    return this._zMin
+  }
+
+  /** Highest world-Z of any indexed sprite (`-Infinity` when empty). */
+  get zMax(): number {
+    return this._zMax
+  }
+
   /**
    * Insert `sprite` covering the world AABB centered at (x, y) with
-   * half-extents (hx, hy). Re-inserting an already-indexed sprite
-   * behaves like {@link update}.
+   * half-extents (hx, hy), at world depth `z`. Re-inserting an
+   * already-indexed sprite behaves like {@link update}.
    */
-  insert(sprite: Sprite2D, x: number, y: number, hx: number, hy: number): void {
-    this.update(sprite, x, y, hx, hy)
+  insert(sprite: Sprite2D, x: number, y: number, hx: number, hy: number, z = 0): void {
+    this.update(sprite, x, y, hx, hy, z)
   }
 
   /**
    * Move `sprite` to the world AABB centered at (x, y) with half-extents
-   * (hx, hy). No-op when the covered cell range is unchanged (the
-   * common static-sprite frame); inserts when the sprite isn't indexed yet.
+   * (hx, hy), at world depth `z`. No-op when the covered cell range is
+   * unchanged (the common static-sprite frame); inserts when the sprite
+   * isn't indexed yet.
    */
-  update(sprite: Sprite2D, x: number, y: number, hx: number, hy: number): void {
+  update(sprite: Sprite2D, x: number, y: number, hx: number, hy: number, z = 0): void {
+    if (z < this._zMin) this._zMin = z
+    if (z > this._zMax) this._zMax = z
     const cs = this._cellSize
     const minCx = Math.floor((x - hx) / cs)
     const minCy = Math.floor((y - hy) / cs)
@@ -113,10 +138,45 @@ export class SpriteSpatialGrid {
     return this._cells.get(`${Math.floor(x / cs)},${Math.floor(y / cs)}`) ?? EMPTY
   }
 
+  /**
+   * Candidate sprites under the world-space segment from (x0, y0) to
+   * (x1, y1) — the projection of a picking ray swept across the batch's
+   * z-span. When both ends fall in the same cell (an orthographic camera,
+   * or a coplanar batch, collapses the segment to a point) this reads that
+   * ONE cell allocation-free, exactly like {@link queryPoint}. Otherwise it
+   * unions every cell in the segment's bounding block into a fresh Set —
+   * conservative (a few extra cells) but never a miss; the narrow phase
+   * filters. Cheap because this runs per pointer event, not per frame.
+   */
+  querySegment(x0: number, y0: number, x1: number, y1: number): Iterable<Sprite2D> {
+    const cs = this._cellSize
+    const cx0 = Math.floor(x0 / cs)
+    const cy0 = Math.floor(y0 / cs)
+    const cx1 = Math.floor(x1 / cs)
+    const cy1 = Math.floor(y1 / cs)
+    if (cx0 === cx1 && cy0 === cy1) {
+      return this._cells.get(`${cx0},${cy0}`) ?? EMPTY
+    }
+    const out = new Set<Sprite2D>()
+    const minCx = cx0 < cx1 ? cx0 : cx1
+    const maxCx = cx0 < cx1 ? cx1 : cx0
+    const minCy = cy0 < cy1 ? cy0 : cy1
+    const maxCy = cy0 < cy1 ? cy1 : cy0
+    for (let cy = minCy; cy <= maxCy; cy++) {
+      for (let cx = minCx; cx <= maxCx; cx++) {
+        const cell = this._cells.get(`${cx},${cy}`)
+        if (cell) for (const s of cell) out.add(s)
+      }
+    }
+    return out
+  }
+
   /** Drop all sprites — used when a batch is recycled or disposed. */
   clear(): void {
     this._cells.clear()
     this._ranges.clear()
+    this._zMin = Infinity
+    this._zMax = -Infinity
   }
 
   private _addToCells(sprite: Sprite2D, range: CellRange): void {

--- a/packages/three-flatland/src/react/batchPicking.test.ts
+++ b/packages/three-flatland/src/react/batchPicking.test.ts
@@ -130,6 +130,54 @@ describe('batchPicking — R3F interaction-list proxy', () => {
     expect(internal.interaction).toContain(batch2)
   })
 
+  it('forwards onDragOverMissed / onDropMissed / onPointerMissed to members', () => {
+    const drag: string[] = []
+    const drop: string[] = []
+    const missed: string[] = []
+    const mk = (id: string) =>
+      makeManagedSprite(store, {
+        onClick() {},
+        onDragOverMissed: () => drag.push(id),
+        onDropMissed: () => drop.push(id),
+        onPointerMissed: () => missed.push(id),
+      })
+    const a = mk('a')
+    const b = mk('b')
+    internal.interaction.push(a, b)
+    proxyPickToBatch(a, batch)
+    proxyPickToBatch(b, batch)
+
+    // The batch stands in for both members in R3F's interaction list; R3F
+    // fires the batch's synthesized "missed" handlers, which fan out.
+    const batchHandlers = (batch as unknown as { __r3f: { handlers: Record<string, (e: unknown) => void> } }).__r3f
+      .handlers
+    batchHandlers.onDragOverMissed({})
+    batchHandlers.onDropMissed({})
+    batchHandlers.onPointerMissed({})
+
+    // Drag/drop missed fire on the whole member set unconditionally.
+    expect(drag.sort()).toEqual(['a', 'b'])
+    expect(drop.sort()).toEqual(['a', 'b'])
+    // Pointer-missed too (no member is in initialHits here).
+    expect(missed.sort()).toEqual(['a', 'b'])
+  })
+
+  it('onPointerMissed skips a member that was an initial hit', () => {
+    const missed: string[] = []
+    const a = makeManagedSprite(store, { onClick() {}, onPointerMissed: () => missed.push('a') })
+    const b = makeManagedSprite(store, { onClick() {}, onPointerMissed: () => missed.push('b') })
+    internal.interaction.push(a, b)
+    proxyPickToBatch(a, batch)
+    proxyPickToBatch(b, batch)
+
+    // `a` was the pointerdown's hit → a click is not "missed" for it.
+    internal.initialHits.push(a)
+    const batchHandlers = (batch as unknown as { __r3f: { handlers: Record<string, (e: unknown) => void> } }).__r3f
+      .handlers
+    batchHandlers.onPointerMissed({})
+    expect(missed).toEqual(['b'])
+  })
+
   it('no-ops for a vanilla (non-R3F) sprite', () => {
     const s = new Sprite2D({ texture: new Texture() })
     // No __r3f — pure three.js usage.

--- a/packages/three-flatland/src/react/batchPicking.test.ts
+++ b/packages/three-flatland/src/react/batchPicking.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Raycaster, Texture } from 'three'
+import { Sprite2D } from '../sprites/Sprite2D'
+import type { SpriteBatch } from '../pipeline/SpriteBatch'
+import { proxyPickToBatch, unproxyPickFromBatch, retireBatchPicking } from './batchPicking'
+
+/**
+ * R3F batch-root picking rewires which object R3F raycasts: a batched sprite
+ * leaves `state.internal.interaction` and its owning batch stands in for it.
+ * These tests drive the list-manipulation directly with a synthetic R3F
+ * store + fake batch (the module is structurally typed against R3F's shapes),
+ * covering the opt-out and teardown transitions that the browser smoke can't.
+ */
+
+interface FakeInternal {
+  interaction: object[]
+  initialHits: object[]
+}
+interface FakeStore {
+  getState(): { internal: FakeInternal }
+}
+
+function makeStore(): { store: FakeStore; internal: FakeInternal } {
+  const internal: FakeInternal = { interaction: [], initialHits: [] }
+  return { store: { getState: () => ({ internal }) }, internal }
+}
+
+/** A Sprite2D wired as an R3F-managed, event-bearing object. */
+function makeManagedSprite(store: FakeStore, handlers: Record<string, unknown> = { onClick() {} }): Sprite2D {
+  const sprite = new Sprite2D({ texture: new Texture() })
+  ;(sprite as unknown as { __r3f: unknown }).__r3f = { root: store, eventCount: 1, handlers }
+  return sprite
+}
+
+/** A minimal object usable as a SpriteBatch key/list-member. */
+function makeFakeBatch(): SpriteBatch {
+  return {} as unknown as SpriteBatch
+}
+
+describe('batchPicking — R3F interaction-list proxy', () => {
+  let store: FakeStore
+  let internal: FakeInternal
+  let batch: SpriteBatch
+
+  beforeEach(() => {
+    ;({ store, internal } = makeStore())
+    batch = makeFakeBatch()
+  })
+
+  it('splices a proxied sprite out and registers the batch once', () => {
+    const a = makeManagedSprite(store)
+    const b = makeManagedSprite(store)
+    internal.interaction.push(a, b)
+
+    proxyPickToBatch(a, batch)
+    proxyPickToBatch(b, batch)
+
+    // Both sprites left the per-object list; one batch stands in for them.
+    expect(internal.interaction).toHaveLength(1)
+    expect(internal.interaction[0]).toBe(batch)
+    expect(a.raycast).toBeNull()
+    expect(b.raycast).toBeNull()
+    expect(a._pickProxied).toBe(true)
+    expect(b._pickProxied).toBe(true)
+  })
+
+  it('leaves a custom raycast untouched (does not proxy or clobber it)', () => {
+    const custom = () => {}
+    const s = makeManagedSprite(store)
+    ;(s as unknown as { raycast: unknown }).raycast = custom
+    internal.interaction.push(s)
+
+    proxyPickToBatch(s, batch)
+
+    // Own raycast → not proxied: the custom fn survives, sprite stays listed,
+    // no batch registered.
+    expect(s.raycast).toBe(custom)
+    expect(s._pickProxied).toBe(false)
+    expect(internal.interaction).toEqual([s])
+  })
+
+  it("leaves a hitTestMode='none' sprite alone (own null is its opt-out)", () => {
+    const s = makeManagedSprite(store)
+    s.hitTestMode = 'none' // installs own raycast = null
+    proxyPickToBatch(s, batch)
+
+    expect(s._pickProxied).toBe(false)
+    // Nothing registered — the sprite was never in the pickable set.
+    expect(internal.interaction).toHaveLength(0)
+  })
+
+  it('re-lists a proxied sprite on unproxy and retires the empty batch', () => {
+    const s = makeManagedSprite(store)
+    internal.interaction.push(s)
+    proxyPickToBatch(s, batch)
+    expect(internal.interaction).toEqual([batch])
+
+    unproxyPickFromBatch(s, batch)
+
+    // Sprite restored to the per-object list; batch gone; prototype raycast back.
+    expect(s._pickProxied).toBe(false)
+    expect(typeof s.raycast).toBe('function')
+    expect(internal.interaction).toEqual([s])
+  })
+
+  it('retire with LIVE members restores them instead of stranding them', () => {
+    const a = makeManagedSprite(store)
+    const b = makeManagedSprite(store)
+    internal.interaction.push(a, b)
+    proxyPickToBatch(a, batch)
+    proxyPickToBatch(b, batch)
+    expect(internal.interaction).toEqual([batch])
+
+    // dispose()/recycle path: retire while members are still proxied.
+    retireBatchPicking(batch)
+
+    // Both members must be pickable again — prototype raycast restored,
+    // back in the per-object list, and re-proxyable (raycast no longer null).
+    for (const s of [a, b]) {
+      expect(s._pickProxied).toBe(false)
+      expect(typeof s.raycast).toBe('function')
+      expect(internal.interaction).toContain(s)
+    }
+    expect(internal.interaction).not.toContain(batch)
+
+    // A restored member can be proxied onto a fresh batch (was stranded before).
+    const batch2 = makeFakeBatch()
+    proxyPickToBatch(a, batch2)
+    expect(a._pickProxied).toBe(true)
+    expect(internal.interaction).toContain(batch2)
+  })
+
+  it('no-ops for a vanilla (non-R3F) sprite', () => {
+    const s = new Sprite2D({ texture: new Texture() })
+    // No __r3f — pure three.js usage.
+    proxyPickToBatch(s, batch)
+    expect(s._pickProxied).toBe(false)
+    expect(typeof s.raycast).toBe('function')
+
+    // And its own raycast still hits when driven directly (sanity).
+    const rc = new Raycaster()
+    expect(() => s.raycast(rc, [])).not.toThrow()
+  })
+})

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -105,10 +105,16 @@ function createBatchPointerMissed(reg: BatchPickRegistration): (event: unknown) 
 export function proxyPickToBatch(sprite: Sprite2D, batch: SpriteBatch): void {
   const inst = (sprite as WithR3F).__r3f
   if (!inst?.root) return
-  // An already-null raycast is an existing opt-out (user `raycast={null}`
-  // or hitTestMode 'none') — leave it alone; SpriteBatch.raycast skips
-  // non-proxied nulls.
-  if (sprite.raycast === null) return
+  // Only proxy sprites using the DEFAULT (prototype) raycast. An OWN
+  // `raycast` property means the sprite has opted out or customized picking,
+  // and we must not clobber it:
+  //   - `hitTestMode = 'none'` / user `raycast={null}` → own null (already
+  //     excluded from R3F's interaction list — nothing to proxy)
+  //   - user `raycast={customFn}` → own function that stays in R3F's
+  //     per-object list and works unchanged
+  // Our own proxy installs an own null too, so this doubles as the
+  // idempotency guard: a re-proxied sprite already has one.
+  if (Object.hasOwn(sprite, 'raycast')) return
   const state = inst.root.getState()
   const interaction = state?.internal?.interaction
   if (!interaction) return
@@ -153,7 +159,16 @@ export function unproxyPickFromBatch(sprite: Sprite2D, batch: SpriteBatch): void
   if (reg && reg.sprites.delete(sprite) && reg.sprites.size === 0) {
     retireBatchPicking(batch)
   }
+  restoreProxiedSprite(sprite)
+}
 
+/**
+ * Undo a single sprite's proxy: restore the prototype `raycast` (unless
+ * `hitTestMode = 'none'` owns the null) and re-list it in R3F's per-object
+ * interaction list if it still has handlers. Idempotent — a no-op for a
+ * sprite that isn't proxied.
+ */
+function restoreProxiedSprite(sprite: Sprite2D): void {
   if (!sprite._pickProxied) return
   sprite._pickProxied = false
   if (sprite.hitTestMode !== 'none') {
@@ -181,6 +196,12 @@ export function retireBatchPicking(batch: SpriteBatch): void {
   if (!reg) return
   registrations.delete(batch)
   delete (batch as WithR3F).__r3f
+  // Restore any members still proxied through this batch — a disposed
+  // batch is about to vanish, so its sprites must not be left pointing at
+  // a dead raycast target (unpickable, and un-re-proxyable while their
+  // `raycast` stays null). Normally the last member's unproxy already
+  // emptied the set; this covers dispose()/recycle with live members.
+  for (const sprite of reg.sprites) restoreProxiedSprite(sprite)
   const interaction = reg.root.getState()?.internal?.interaction
   if (!interaction) return
   const idx = interaction.indexOf(batch)

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -97,20 +97,29 @@ export function isR3FManaged(sprite: Sprite2D): boolean {
 const MARKER = (): void => {}
 
 /**
- * The batch sits in the interaction list but never lands in
- * `initialHits`, so R3F calls its `onPointerMissed` on every qualifying
- * click. Forward it to member sprites the way R3F would have when they
- * were listed individually: every R3F member with handlers that was not
- * among the pointerdown's initial hits.
+ * The batch sits in the interaction list but never lands in `initialHits`,
+ * so R3F fires its "missed" handlers (`onPointerMissed`, `onDragOverMissed`,
+ * `onDropMissed`) by walking the interaction list. Since the batch stands in
+ * for its members there, forward each such event to the members the way R3F
+ * would have when they were listed individually.
+ *
+ * `filterInitialHits` mirrors R3F's own dispatch: a click "misses" an object
+ * only if it wasn't among the pointerdown's initial hits (onPointerMissed);
+ * drag-over / drop "missed" fire on the whole interaction list unconditionally
+ * when the drag/drop hit nothing, so they do NOT filter.
  */
-function createBatchPointerMissed(reg: BatchPickRegistration): (event: unknown) => void {
+function createMissedForwarder(
+  reg: BatchPickRegistration,
+  name: 'onPointerMissed' | 'onDragOverMissed' | 'onDropMissed',
+  filterInitialHits: boolean
+): (event: unknown) => void {
   return (event: unknown): void => {
-    const initialHits = reg.root.getState()?.internal?.initialHits
+    const initialHits = filterInitialHits ? reg.root.getState()?.internal?.initialHits : undefined
     for (const sprite of reg.sprites) {
       const inst = (sprite as WithR3F).__r3f
       if (!inst?.eventCount) continue
       if (initialHits?.includes(sprite)) continue
-      inst.handlers.onPointerMissed?.(event)
+      inst.handlers[name]?.(event)
     }
   }
 }
@@ -159,7 +168,9 @@ export function proxyPickToBatch(sprite: Sprite2D, batch: SpriteBatch): void {
         onPointerMove: MARKER,
         onDragOver: MARKER,
         onDrop: MARKER,
-        onPointerMissed: createBatchPointerMissed(reg),
+        onPointerMissed: createMissedForwarder(reg, 'onPointerMissed', true),
+        onDragOverMissed: createMissedForwarder(reg, 'onDragOverMissed', false),
+        onDropMissed: createMissedForwarder(reg, 'onDropMissed', false),
       },
     }
     if (!interaction.includes(batch)) interaction.push(batch)

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -1,0 +1,188 @@
+// three-flatland/react — R3F batch-root picking proxy
+//
+// R3F registers every interactive object (eventCount > 0, raycast !== null)
+// in `state.internal.interaction` and raycasts EACH of them per pointer
+// event — O(n) in interactive sprite count. For batched sprites that's
+// wasted work: the owning SpriteBatch already broadphases its members
+// through a spatial grid. This module moves R3F's raycast target from the
+// member sprites to the batch:
+//
+//   - each R3F-managed sprite that enters a batch gets `raycast = null`
+//     (R3F's documented opt-out) and is spliced out of the interaction
+//     list; `_pickProxied` marks the null as ours so the batch's
+//     delegation (and later restoration) can tell it apart from a user's
+//     explicit `raycast={null}` / `hitTestMode = 'none'`
+//   - the batch itself is registered once in the same interaction list,
+//     with a minimal synthesized `__r3f` so R3F's `getRootState` can
+//     resolve its store (the batch lives in flatland's internal scene,
+//     outside any R3F-traversable parent chain)
+//
+// `SpriteBatch.raycast` pushes intersections with `object === sprite`, and
+// R3F's dispatch bubbles from `hit.object` through `__r3f.eventCount`
+// owners — so `<sprite2D onClick>` fires exactly as before, with
+// `event.object === sprite`, at broadphase cost instead of O(n).
+//
+// Typed structurally against R3F's shapes (no @react-three/fiber import —
+// the core package must not depend on R3F, only consume its shapes), so
+// the batching systems can call these hooks unconditionally: sprites
+// without `__r3f` (vanilla three.js usage) no-op.
+
+import type { Object3D } from 'three'
+import type { Sprite2D } from '../sprites/Sprite2D'
+import type { SpriteBatch } from '../pipeline/SpriteBatch'
+
+/** Structural slice of R3F's `RootState.internal` that this module touches. */
+interface R3FInternal {
+  interaction: Object3D[]
+  initialHits: Object3D[]
+}
+
+interface R3FRootState {
+  internal: R3FInternal
+}
+
+/** Structural slice of R3F's zustand store. */
+interface R3FStore {
+  getState(): R3FRootState
+}
+
+/** Structural slice of R3F's per-object instance (`object.__r3f`). */
+interface R3FInstanceSlice {
+  root: R3FStore
+  eventCount: number
+  handlers: Record<string, ((event: unknown) => void) | undefined>
+}
+
+interface WithR3F {
+  __r3f?: R3FInstanceSlice
+}
+
+/** Live registration of a batch in an R3F interaction list. */
+interface BatchPickRegistration {
+  root: R3FStore
+  /** R3F-managed member sprites whose picking is proxied through the batch. */
+  sprites: Set<Sprite2D>
+}
+
+const registrations = new WeakMap<SpriteBatch, BatchPickRegistration>()
+
+/**
+ * Inert truthy marker for R3F's `filterPointerEvents`: pointer-move /
+ * drag / drop events only raycast interaction objects whose handlers
+ * claim interest. The batch must pass that filter so hover (and drag)
+ * events still reach member sprites — the member's REAL handlers are
+ * what dispatch invokes (the batch is never an eventObject; it has
+ * `eventCount: 0` and never appears in a hit's bubble chain).
+ */
+const MARKER = (): void => {}
+
+/**
+ * The batch sits in the interaction list but never lands in
+ * `initialHits`, so R3F calls its `onPointerMissed` on every qualifying
+ * click. Forward it to member sprites the way R3F would have when they
+ * were listed individually: every R3F member with handlers that was not
+ * among the pointerdown's initial hits.
+ */
+function createBatchPointerMissed(reg: BatchPickRegistration): (event: unknown) => void {
+  return (event: unknown): void => {
+    const initialHits = reg.root.getState()?.internal?.initialHits
+    for (const sprite of reg.sprites) {
+      const inst = (sprite as WithR3F).__r3f
+      if (!inst?.eventCount) continue
+      if (initialHits?.includes(sprite)) continue
+      inst.handlers.onPointerMissed?.(event)
+    }
+  }
+}
+
+/**
+ * Route an R3F-managed sprite's picking through its batch. Called by the
+ * batching systems whenever a sprite lands in a batch (assign/reassign).
+ * No-op for vanilla sprites (no `__r3f`) and for sprites whose `raycast`
+ * is already nulled by the user or `hitTestMode = 'none'` — that null is
+ * an opt-out this proxy must respect, not replace.
+ */
+export function proxyPickToBatch(sprite: Sprite2D, batch: SpriteBatch): void {
+  const inst = (sprite as WithR3F).__r3f
+  if (!inst?.root) return
+  // An already-null raycast is an existing opt-out (user `raycast={null}`
+  // or hitTestMode 'none') — leave it alone; SpriteBatch.raycast skips
+  // non-proxied nulls.
+  if (sprite.raycast === null) return
+  const state = inst.root.getState()
+  const interaction = state?.internal?.interaction
+  if (!interaction) return
+
+  // Exclude the sprite from R3F's per-object raycast list. Handlers stay
+  // registered (`__r3f.eventCount`), so dispatch still fires them when
+  // the batch pushes an intersection with `object === sprite`.
+  ;(sprite as { raycast: unknown }).raycast = null
+  sprite._pickProxied = true
+  const idx = interaction.indexOf(sprite)
+  if (idx > -1) interaction.splice(idx, 1)
+
+  // Register the batch once per tenancy.
+  let reg = registrations.get(batch)
+  if (!reg) {
+    reg = { root: inst.root, sprites: new Set() }
+    registrations.set(batch, reg)
+    ;(batch as WithR3F).__r3f = {
+      root: inst.root,
+      eventCount: 0,
+      handlers: {
+        onPointerMove: MARKER,
+        onDragOver: MARKER,
+        onDrop: MARKER,
+        onPointerMissed: createBatchPointerMissed(reg),
+      },
+    }
+    if (!interaction.includes(batch)) interaction.push(batch)
+  }
+  reg.sprites.add(sprite)
+}
+
+/**
+ * Undo {@link proxyPickToBatch} when a sprite leaves its batch
+ * (remove/reassign/evict/unenroll). Restores the prototype `raycast`
+ * (unless `hitTestMode = 'none'` owns the null), re-lists the sprite in
+ * R3F's interaction list if it still has handlers, and unregisters the
+ * batch when its last proxied member leaves.
+ */
+export function unproxyPickFromBatch(sprite: Sprite2D, batch: SpriteBatch): void {
+  const reg = registrations.get(batch)
+  if (reg && reg.sprites.delete(sprite) && reg.sprites.size === 0) {
+    retireBatchPicking(batch)
+  }
+
+  if (!sprite._pickProxied) return
+  sprite._pickProxied = false
+  if (sprite.hitTestMode !== 'none') {
+    delete (sprite as { raycast?: unknown }).raycast
+  }
+
+  // Re-list for R3F's per-object raycast — a standalone sprite is no
+  // longer reachable through any batch. Mirrors R3F's own membership
+  // condition (eventCount && raycast !== null). During R3F unmount this
+  // is transient: removeInteractivity filters the sprite right back out.
+  const inst = (sprite as WithR3F).__r3f
+  if (inst?.eventCount && sprite.raycast !== null) {
+    const interaction = inst.root.getState()?.internal?.interaction
+    if (interaction && !interaction.includes(sprite)) interaction.push(sprite)
+  }
+}
+
+/**
+ * Force-unregister a batch from its R3F interaction list. Called when
+ * the last proxied member leaves, and defensively on batch recycle /
+ * dispose so a pooled or torn-down mesh never lingers in a live store.
+ */
+export function retireBatchPicking(batch: SpriteBatch): void {
+  const reg = registrations.get(batch)
+  if (!reg) return
+  registrations.delete(batch)
+  delete (batch as WithR3F).__r3f
+  const interaction = reg.root.getState()?.internal?.interaction
+  if (!interaction) return
+  const idx = interaction.indexOf(batch)
+  if (idx > -1) interaction.splice(idx, 1)
+}

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -107,6 +107,12 @@ const MARKER = (): void => {}
  * only if it wasn't among the pointerdown's initial hits (onPointerMissed);
  * drag-over / drop "missed" fire on the whole interaction list unconditionally
  * when the drag/drop hit nothing, so they do NOT filter.
+ *
+ * The initialHits filter is exact for the dominant click (pointerdown and
+ * pointerup on the same target): empty space → every member fires; on a member
+ * → the others fire. It differs from R3F only in the cancelled click
+ * (pointerdown on member A, pointerup on empty): R3F would fire A's
+ * onPointerMissed, this skips it. Niche and arguably preferable (A was pressed).
  */
 function createMissedForwarder(
   reg: BatchPickRegistration,

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -66,6 +66,11 @@ interface WithR3F {
   __r3f?: R3FInstanceSlice
 }
 
+/** R3F's per-object instance slice, or `undefined` for a vanilla three.js object. */
+function r3f(object: Sprite2D | SpriteBatch): R3FInstanceSlice | undefined {
+  return (object as WithR3F).__r3f
+}
+
 /** Live registration of a batch in an R3F interaction list. */
 interface BatchPickRegistration {
   root: R3FStore
@@ -83,7 +88,7 @@ const registrations = new WeakMap<SpriteBatch, BatchPickRegistration>()
  * (three.js) sprites lack `__r3f` and are picked ONLY via the batch grid.
  */
 export function isR3FManaged(sprite: Sprite2D): boolean {
-  return (sprite as WithR3F).__r3f !== undefined
+  return r3f(sprite) !== undefined
 }
 
 /**
@@ -122,7 +127,7 @@ function createMissedForwarder(
   return (event: unknown): void => {
     const initialHits = filterInitialHits ? reg.root.getState()?.internal?.initialHits : undefined
     for (const sprite of reg.sprites) {
-      const inst = (sprite as WithR3F).__r3f
+      const inst = r3f(sprite)
       if (!inst?.eventCount) continue
       if (initialHits?.includes(sprite)) continue
       inst.handlers[name]?.(event)
@@ -138,7 +143,7 @@ function createMissedForwarder(
  * an opt-out this proxy must respect, not replace.
  */
 export function proxyPickToBatch(sprite: Sprite2D, batch: SpriteBatch): void {
-  const inst = (sprite as WithR3F).__r3f
+  const inst = r3f(sprite)
   if (!inst?.root) return
   // Only proxy sprites using the DEFAULT (prototype) raycast. An OWN
   // `raycast` property means the sprite has opted out or customized picking,
@@ -216,7 +221,7 @@ function restoreProxiedSprite(sprite: Sprite2D): void {
   // longer reachable through any batch. Mirrors R3F's own membership
   // condition (eventCount && raycast !== null). During R3F unmount this
   // is transient: removeInteractivity filters the sprite right back out.
-  const inst = (sprite as WithR3F).__r3f
+  const inst = r3f(sprite)
   if (inst?.eventCount && sprite.raycast !== null) {
     const interaction = inst.root.getState()?.internal?.interaction
     if (interaction && !interaction.includes(sprite)) interaction.push(sprite)

--- a/packages/three-flatland/src/react/batchPicking.ts
+++ b/packages/three-flatland/src/react/batchPicking.ts
@@ -26,6 +26,15 @@
 // the core package must not depend on R3F, only consume its shapes), so
 // the batching systems can call these hooks unconditionally: sprites
 // without `__r3f` (vanilla three.js usage) no-op.
+//
+// The supported way to control a sprite's picking is `hitTestMode`
+// (none/bounds/radius/alpha) — it is honored correctly through batching
+// (the setter is `_pickProxied`-aware and the batch's narrow phase
+// re-reads the mode). Mutating the raw three.js `raycast` property on an
+// ALREADY-batched sprite is a low-level poke this proxy cannot track:
+// only the raycast state at proxy time is captured, so a `raycast`
+// reassigned mid-batch is ignored until the sprite next leaves and
+// re-enters a batch. Set picking via `hitTestMode`, or before enrollment.
 
 import type { Object3D } from 'three'
 import type { Sprite2D } from '../sprites/Sprite2D'
@@ -65,6 +74,17 @@ interface BatchPickRegistration {
 }
 
 const registrations = new WeakMap<SpriteBatch, BatchPickRegistration>()
+
+/**
+ * True when a sprite is R3F-managed (`object.__r3f` present). A NON-proxied
+ * such sprite handles its own picking through R3F's per-object interaction
+ * list — so `SpriteBatch.raycast` must skip it as a grid candidate, or it
+ * would be hit-tested twice (once by R3F, once by the batch). Vanilla
+ * (three.js) sprites lack `__r3f` and are picked ONLY via the batch grid.
+ */
+export function isR3FManaged(sprite: Sprite2D): boolean {
+  return (sprite as WithR3F).__r3f !== undefined
+}
 
 /**
  * Inert truthy marker for R3F's `filterPointerEvents`: pointer-move /

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -39,6 +39,7 @@ import type { HitTestMode } from '../events/HitTestMode'
 import { resolveHitTestMode } from '../events/HitTestMode'
 import type { AlphaMap } from '../events/AlphaMap'
 import { rayPlaneZ0, createIntersection } from '../events/raycastHelpers'
+import { unproxyPickFromBatch } from '../react/batchPicking'
 import { createSynthQuadGeometry } from '../pipeline/synthQuadGeometry'
 import { flatlandPrime, flatlandRegister, flatlandUnregister } from '../orchestration/orchestrator'
 import type { Registry } from '../orchestration/registry'
@@ -174,6 +175,17 @@ export class Sprite2D extends Mesh {
   /** Active hit-test strategy. */
   private _hitTestMode: HitTestMode = 'radius'
 
+  /**
+   * True while R3F batch-root picking has nulled this sprite's `raycast`
+   * to keep it out of R3F's per-object interaction list — the owning
+   * SpriteBatch raycasts on its behalf via {@link Sprite2D._hitTestInto}.
+   * Distinguishes that proxy-owned null from a user opt-out
+   * (`raycast={null}` / `hitTestMode = 'none'`), which the batch must
+   * respect. Managed by `react/batchPicking`.
+   * @internal
+   */
+  _pickProxied = false
+
   /** Hit radius override in local units. Default 0.5 (inscribed half-width of unit quad). */
   get hitRadius(): number {
     return this._hitRadius
@@ -193,6 +205,12 @@ export class Sprite2D extends Mesh {
     this._hitTestMode = resolved
     if (resolved === 'none') {
       // Null the own-property so R3F / three skips this object in raycast traversal
+      ;(this as { raycast: unknown }).raycast = null
+    } else if (this._pickProxied) {
+      // R3F batch-root picking owns the null — restoring the prototype
+      // method would re-expose the sprite to R3F's per-object raycast
+      // list. The batch delegates to _hitTestInto, which reads the mode
+      // set above, so the new mode still takes effect.
       ;(this as { raycast: unknown }).raycast = null
     } else {
       // Delete the own-property to restore the prototype method
@@ -1895,6 +1913,18 @@ export class Sprite2D extends Mesh {
    * method works entirely in centered-quad local space with no anchor math.
    */
   override raycast(raycaster: Raycaster, intersects: Intersection[]): void {
+    this._hitTestInto(raycaster, intersects)
+  }
+
+  /**
+   * Narrow-phase hit test — the body of {@link Sprite2D.raycast},
+   * callable regardless of the public `raycast` property (which
+   * `hitTestMode = 'none'` and R3F batch-root picking null).
+   * `SpriteBatch.raycast` delegates broadphase candidates here; the mode
+   * check lives inside so `'none'` still skips on every path.
+   * @internal
+   */
+  _hitTestInto(raycaster: Raycaster, intersects: Intersection[]): void {
     // `hitTestMode = 'none'` also nulls the instance `raycast` so R3F skips
     // this object at registration (the zero-cost path); this guard is
     // defense-in-depth for direct raycast() calls.
@@ -2360,7 +2390,12 @@ export class Sprite2D extends Mesh {
     // remove it here while the batch is still in hand, or the deferred
     // batchRemoveSystem (which can no longer resolve this sprite) would
     // leave a stale grid entry that keeps raycast-hitting.
-    if (this._batchMesh) this._batchMesh.grid.remove(this)
+    if (this._batchMesh) {
+      this._batchMesh.grid.remove(this)
+      // Hand picking back from the batch (R3F batch-root proxy) — the
+      // deferred batchRemoveSystem can no longer resolve this sprite.
+      unproxyPickFromBatch(this, this._batchMesh)
+    }
     this._batchMesh = null
     this._batchSlot = -1
     this._batchIdx = -1

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -1902,7 +1902,18 @@ export class Sprite2D extends Mesh {
     // Flatland's internal scene disables matrixWorldAutoUpdate — matrices are
     // refreshed once per frame inside render() — so a raycast from user code
     // would otherwise read an identity matrixWorld and test a half-unit disc.
-    this.updateMatrixWorld()
+    //
+    // Batched sprites own their matrixWorld through the ECS transform pass
+    // (matrixWorldAutoUpdate is off), so three's refresh would be a no-op;
+    // compose the world affine directly instead — this covers raycasts
+    // issued outside the frame loop / before the first schedule run.
+    // Standalone sprites are real graph children: refresh ancestors too so
+    // pre-first-render raycasts read a current parent chain.
+    if (this._entity) {
+      this._composeBatchedMatrixWorld()
+    } else {
+      this.updateWorldMatrix(true, false)
+    }
     const hit = rayPlaneZ0(raycaster, this)
     if (!hit) return
 
@@ -1941,6 +1952,56 @@ export class Sprite2D extends Mesh {
     const u = localX + 0.5
     const v = localY + 0.5
     intersects.push(createIntersection(hit, this, u, v))
+  }
+
+  /**
+   * Compose this batched sprite's matrixWorld directly: local 2D TRS
+   * (via the fast `updateMatrix`) with the owning SpriteGroup's world
+   * affine folded in — the same 2D-affine ∘ 2D-affine math as
+   * `transformSyncSystem`, for raycasts issued outside the frame loop.
+   * `updateWorldMatrix` can't do this: with `matrixWorldAutoUpdate`
+   * disabled three skips the compose entirely (verified three r183).
+   * @internal
+   */
+  private _composeBatchedMatrixWorld(): void {
+    // Local affine (anchor/trim/layer-depth baked) into this.matrix.
+    this.updateMatrix()
+    this.matrixWorld.copy(this.matrix)
+
+    const registryEntities = this._flatlandWorld?.query(BatchRegistry)
+    const registry =
+      registryEntities && registryEntities.length > 0
+        ? (registryEntities[0]!.get(BatchRegistry) as RegistryData | undefined)
+        : undefined
+    const group = registry?.parentGroup
+    if (group) {
+      group.updateWorldMatrix(true, false)
+      const ge = group.matrixWorld.elements
+      const ga = ge[0]!
+      const gb = ge[1]!
+      const gc = ge[4]!
+      const gd = ge[5]!
+      const gtx = ge[12]!
+      const gty = ge[13]!
+      const gtz = ge[14]!
+      if (ga !== 1 || gb !== 0 || gc !== 0 || gd !== 1 || gtx !== 0 || gty !== 0 || gtz !== 0) {
+        const me = this.matrixWorld.elements
+        const l00 = me[0]!
+        const l10 = me[1]!
+        const l01 = me[4]!
+        const l11 = me[5]!
+        const px = me[12]!
+        const py = me[13]!
+        me[0] = ga * l00 + gc * l10
+        me[1] = gb * l00 + gd * l10
+        me[4] = ga * l01 + gc * l11
+        me[5] = gb * l01 + gd * l11
+        me[12] = ga * px + gc * py + gtx
+        me[13] = gb * px + gd * py + gty
+        me[14] = me[14]! + gtz
+      }
+    }
+    this.matrixWorldNeedsUpdate = false
   }
 
   /**
@@ -2148,6 +2209,13 @@ export class Sprite2D extends Mesh {
     const eid = (this._entity as unknown as number) & ENTITY_ID_MASK
     this._idx = eid
 
+    // The ECS transform pass is the single writer of a batched sprite's
+    // matrixWorld (group-world affine ∘ local TRS). Disable three's
+    // auto-compose so a scene traversal can't overwrite it with a
+    // parent-chain compose that doesn't match the rendered transform.
+    // Restored on unenroll — standalone sprites keep three semantics.
+    this.matrixWorldAutoUpdate = false
+
     // Swap array refs from local to world SoA stores
     const uvStore = resolveStore(w, SpriteUV)
     this._uvX = uvStore['x']!
@@ -2271,6 +2339,11 @@ export class Sprite2D extends Mesh {
     this._batchMesh = null
     this._batchSlot = -1
     this._batchIdx = -1
+
+    // Hand matrixWorld ownership back to three — a standalone (or
+    // demoted) sprite is a real graph child again and needs the normal
+    // parent-chain compose for rendering and raycasts.
+    this.matrixWorldAutoUpdate = true
   }
 
   /**

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -2356,7 +2356,11 @@ export class Sprite2D extends Mesh {
     // (the spriteArr entry above is already nulled), and a stale
     // _batchMesh would let direct-write setters (color/alpha/flip/UV)
     // clobber a freed — possibly reallocated — slot before the next
-    // system pass.
+    // system pass. Same reasoning for the picking-broadphase entry:
+    // remove it here while the batch is still in hand, or the deferred
+    // batchRemoveSystem (which can no longer resolve this sprite) would
+    // leave a stale grid entry that keeps raycast-hitting.
+    if (this._batchMesh) this._batchMesh.grid.remove(this)
     this._batchMesh = null
     this._batchSlot = -1
     this._batchIdx = -1

--- a/packages/three-flatland/src/sprites/Sprite2D.ts
+++ b/packages/three-flatland/src/sprites/Sprite2D.ts
@@ -1909,11 +1909,10 @@ export class Sprite2D extends Mesh {
     // issued outside the frame loop / before the first schedule run.
     // Standalone sprites are real graph children: refresh ancestors too so
     // pre-first-render raycasts read a current parent chain.
-    if (this._entity) {
-      this._composeBatchedMatrixWorld()
-    } else {
-      this.updateWorldMatrix(true, false)
-    }
+    // The standard three refresh contract — routed to the batched compose for
+    // enrolled sprites (see the updateWorldMatrix override), or three's normal
+    // ancestor walk for standalone ones.
+    this.updateWorldMatrix(true, false)
     const hit = rayPlaneZ0(raycaster, this)
     if (!hit) return
 
@@ -1955,12 +1954,34 @@ export class Sprite2D extends Mesh {
   }
 
   /**
+   * Make `matrixWorld` current on demand. For an enrolled (batched) sprite,
+   * `matrixWorldAutoUpdate` is off and the sprite is not a graph child, so
+   * three's own traversal never composes it — do it here. For a standalone
+   * sprite, defer to three's normal ancestor walk. This is the standard
+   * three refresh contract, so any consumer (raycast, bounds, devtools) can
+   * `sprite.updateWorldMatrix(true, false)` then read `matrixWorld`.
+   */
+  override updateWorldMatrix(updateParents: boolean, updateChildren: boolean): void {
+    if (this._entity) {
+      this._composeBatchedMatrixWorld()
+      return
+    }
+    super.updateWorldMatrix(updateParents, updateChildren)
+  }
+
+  override updateMatrixWorld(force?: boolean): void {
+    if (this._entity) {
+      this._composeBatchedMatrixWorld()
+      return
+    }
+    super.updateMatrixWorld(force)
+  }
+
+  /**
    * Compose this batched sprite's matrixWorld directly: local 2D TRS
    * (via the fast `updateMatrix`) with the owning SpriteGroup's world
    * affine folded in — the same 2D-affine ∘ 2D-affine math as
-   * `transformSyncSystem`, for raycasts issued outside the frame loop.
-   * `updateWorldMatrix` can't do this: with `matrixWorldAutoUpdate`
-   * disabled three skips the compose entirely (verified three r183).
+   * `transformSyncSystem`. Called via the `updateWorldMatrix` override.
    * @internal
    */
   private _composeBatchedMatrixWorld(): void {

--- a/packages/three-flatland/src/tilemap/TileMap2D.ts
+++ b/packages/three-flatland/src/tilemap/TileMap2D.ts
@@ -548,8 +548,9 @@ export class TileMap2D extends Group {
    */
   override raycast(raycaster: Raycaster, intersects: Intersection[]): false {
     // See Sprite2D.raycast — Flatland's internal scene disables
-    // matrixWorldAutoUpdate, so refresh before reading matrixWorld.
-    this.updateMatrixWorld()
+    // matrixWorldAutoUpdate, so refresh (ancestors included, for
+    // raycasts issued outside the frame loop) before reading matrixWorld.
+    this.updateWorldMatrix(true, false)
     const hit = rayPlaneZ0(raycaster, this)
     if (!hit) return false
     const { localX, localY } = hit

--- a/planning/superpowers/plans/2026-07-20-batched-sprite-events.md
+++ b/planning/superpowers/plans/2026-07-20-batched-sprite-events.md
@@ -1,0 +1,248 @@
+# Batched-Sprite Pointer Events (#127) — Implementation Plan
+
+> **For agentic workers:** This plan is written for horde execution — parallel implementation agents under hard gates, with a lead who owns correctness. REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans, task-by-task with checkbox (`- [ ]`) tracking. The lead runs every phase gate personally.
+>
+> **Branch:** `feat/batched-sprite-events` (worktree `.claude/worktrees/issue-127-batched-events`)
+> **Issue:** [#127](https://github.com/thejustinwalsh/three-flatland/issues/127) · **Spec:** `planning/superpowers/specs/2026-06-12-event-system-design.md` (D1, §5, §7, §7.3, §8) · **Design:** `planning/milestones/AUTO-BATCH-DESIGN.md`, `planning/milestones/RENDERING-ARCHITECTURE.md`
+
+---
+
+## 1. Ground truth (verified 2026-07-20, headless probes on this branch)
+
+Every claim below was probed against the live code before this plan was written. Three sprite-management modes exist, and they are in **materially different states**:
+
+| Mode | Graph citizen? | Traversal-raycastable? | `instanceMatrix` source | Verified behavior |
+|---|---|---|---|---|
+| Standalone (`scene.add(sprite)`, unbatched) | ✓ | ✓ | n/a (own Mesh) | works |
+| **Auto-batched** (`scene.add(sprite)` ×2 sharing run key) | ✓ (stays in user tree, `visible=false`) | **✓ — already works.** `intersectObjects(scene.children, true)` hits it; `matrixWorld` correct | local TRS recompose (`transformSyncSystem`) | hit-test right, **render wrong under nested parents** |
+| **Explicit** (`spriteGroup.add` / `flatland.add`) | **✗** (`sprite.parent === null`, ECS-only) | **✗** — traversal returns `[]` | local TRS recompose | direct `intersectObject(sprite)` works only via the interim fix |
+
+Probe results (exact numbers):
+
+1. **Auto path, flat scene:** batched sprite (visible=false, in user tree) is found by `raycaster.intersectObjects(scene.children, true)` with `matrixWorld.elements[0] === 100` (its scale). Three's `Raycaster` ignores `visible` — this is load-bearing and standard three behavior.
+2. **Auto path, nested transformed parent** (`Group` at x=500 containing 2 sprites): `instanceMatrix` tx = **0**, `matrixWorld` tx = **500**. **The rendered position is wrong** — `transformSyncSystem` (`packages/three-flatland/src/ecs/systems/transformSyncSystem.ts:63`) composes from local TRS and never reads parents. This is a live **rendering** bug on the shipped auto path, not just a hit-test gap.
+3. **Flatland path:** `sprite.parent === null` after `flatland.add()`; `intersectObjects(flatland.scene.children, true)` → `[]`.
+4. **Demotion pruning bug (new):** demoting a SpriteGroup-managed sprite via `renderOrder = 999` reparents it under the group (`_demoteToStandalone`, `Sprite2D.ts:2014`), and the **very next schedule run `sceneGraphSyncSystem` removes it from the graph** (`sceneGraphSyncSystem.ts:49-54` prunes every child not in `activeMeshes`). The demoted sprite vanishes. The auto path escapes only because its sprites were never group children.
+
+### Corrections to the briefing diagnosis
+
+- **"#85 never delivered its promise" is half-right.** The Phase-2 orchestration epic DID land: per-(renderer,scene) registry, dual-signal registration, auto-batch with tier ladder/hysteresis, run-key routing (`src/orchestration/*`, all green-tested). Auto-batched sprites ARE graph citizens and ARE traversal-raycastable **today**. What never landed is (a) graph citizenship for the **explicit** SpriteGroup/Flatland path, and (b) the AUTO-BATCH-DESIGN line-29 invariant *"`instanceMatrix` set from `matrixWorld`"* — asserted in the design's promotion-safety proof, implemented nowhere. #127's "interactive for free once #85 lands" was true for the auto path and unspecified for the explicit path.
+- **R3F never needed scene-graph discoverability.** Verified in installed `@react-three/fiber@10.0.0-alpha.2` (`dist/index.mjs:665`): R3F raycasts its flat interaction list per-object — `state.raycaster.intersectObject(obj, true)` — not the scene. Direct raycast + a fresh matrix is all R3F needs, which is why the interim fix unblocked the starter templates. What R3F DOES need the parent chain for is **event bubbling** (`index.mjs:686`: `eventObject = eventObject.parent`) — with `parent === null`, ancestor handlers never fire.
+- The root-cause statement — duplicated transform math between `Sprite2D.updateMatrix()` (`Sprite2D.ts:2047`) and `transformSyncSystem` (`:63`), so render truth and hit truth cannot agree by construction — is **confirmed**, with the sharper corollary that on the auto path it is the *renderer* that is wrong and the hit test that is right.
+
+---
+
+## 2. Goal
+
+Per spec §5: a raycast hit on any flatland primitive yields `intersection.object === <the user-facing primitive>`, whether standalone, auto-batched, or SpriteGroup/Flatland-batched; `raycaster.intersectObjects(scene.children, true)` finds batched sprites; batches never appear in intersections; R3F `onPointer*` (render-to-screen and portal/RTT) works on batched sprites. And the transform that renders must be the transform that hit-tests: **one source of truth.**
+
+---
+
+## 3. Decisions
+
+### D-A — Single source of truth: `matrixWorld` is authoritative; batch slots are derived data
+
+`instanceMatrix[slot] := sprite.matrixWorld`, copied **after** matrix propagation each frame. `transformSyncSystem`'s independent TRS recompose is deleted. `SpriteBatch.matrixWorld` is pinned to identity (override `updateMatrixWorld` to skip composition) so the shader's `modelMatrix × instanceMatrix` = `sprite.matrixWorld` exactly.
+
+**Why this is viable (the checks the briefing asked for):**
+
+- **Per-frame cost:** today `transformSyncSystem` runs an inline 2D compose per sprite per frame (`autoInvalidateTransforms` defaults true). The new shape is three's propagation (which already calls our fast `Sprite2D.updateMatrix()` override — same 2D math) + one 16-float copy per slot. Net delta ≈ one 4×4 parent-multiply + memcpy per sprite; at 16k sprites ≈ 1 MB/frame of copies, same order as today. **Gate: measure, don't assume** (Phase 1 gate, ±10% on the schedule micro-benchmark and knightmark 60fps).
+- **`matrixWorldAutoUpdate = false` rationale survives intact.** Flatland disables it so *internal passes* (occlusion, SDF, shadow) don't re-trigger the schedule via `renderer.render` (`Flatland.ts:298-303, 1243-1256`). The single explicit `scene.updateMatrixWorld(true)` in `Flatland.render()` remains the one propagation per frame; it now also composes the (new) sprite children. Nothing about the guard model changes; `scheduleRuns` re-entrancy guards stay.
+- **Ordering** is the real work — see §4 (two-stage schedule). The invariant: *slot matrices are copied from `matrixWorld` after the last `matrixWorld` write of the frame and before any render that consumes them (shadow/occlusion/main).*
+- **Group transforms don't double-apply:** with sprites as group children (D-B), a transformed SpriteGroup flows into `sprite.matrixWorld`; pinning batch matrixWorld to identity prevents the old `batchWorld × instanceLocal` path from applying it twice. Pin with a transformed-SpriteGroup parity test (this behavior — group transform moves batched sprites — works today via the batch's inherited matrixWorld and must not regress).
+- **Bonus honesty:** users with `matrixAutoUpdate=false` hand-managed matrices are respected now (today's recompose from TRS silently ignores them). `sortLayer*10 + zIndex*0.001` z-bake is unchanged — it lives in `updateMatrix()` and rides through `matrixWorld`.
+- **`autoInvalidateTransforms=false`** (manual invalidation, static UIs): the copy pass is gated by the same flag + `invalidateTransforms()`. Divergence between fresh `matrixWorld` and stale slots is inherent to that opt-in mode; document that hits track logical state.
+
+This makes AUTO-BATCH-DESIGN line 29 true and **fixes probe bug #2** (nested-parent auto rendering) as a side effect. That bug alone justifies D-A even if events didn't exist.
+
+**Rejected alternative:** shared compose function between `updateMatrix` and `transformSyncSystem` (dedupes code, but keeps two call sites, still ignores parents, still no traversal discoverability). Rejected: fixes the symptom, not the two-sources disease.
+
+### D-B — Graph citizenship for the explicit path: a hidden holder group
+
+`SpriteGroup` gains an internal `Group` child (name `__batchedSprites`, `visible = false`). `SpriteGroup.add(sprite)` enrolls in ECS **then** parents the sprite under the holder (`holder.add(sprite)` — enroll-first so the `'added'` listener's `flatlandPrime` guard `sprite._flatlandWorld` short-circuits, `orchestrator.ts:57`). Effects:
+
+- `raycaster.intersectObjects(scene.children, true)` traverses into the holder (three's raycast recursion ignores `visible`) and hits sprites; `projectObject` prunes the whole holder in **O(1)** (one `visible` check), so 100k hidden children cost the renderer nothing per pass — this sidesteps the N-visibility-checks-per-pass tax that per-sprite hiding would pay across Flatland's multiple internal passes.
+- `sprite.visible` keeps meaning what the user thinks it means on the explicit path — no conflation with batch-suppression (the auto path's `visible=false`-when-batched conflation stays as shipped; see D-H).
+- Matrix propagation reaches the sprites through the normal `super.updateMatrixWorld` recursion (visibility does not gate matrix updates).
+- **R3F bubbling** now walks sprite → holder → SpriteGroup → flatland.scene, so ancestor handlers and portal-root semantics work.
+- Demotion reparents holder → SpriteGroup (own-mesh draw resumes); `_demoteToStandalone`'s existing `registry.parentAdd` machinery simplifies.
+
+**`sceneGraphSyncSystem` prune must be type-gated to `SpriteBatch` instances** (it currently removes *any* non-batch child — probe bug #4). This one-line class check fixes the demotion-vanish bug and makes the holder safe. Regression-test both.
+
+**Reconciliation with spec §4/§14 ("reverse-lookup apparatus deleted, not deferred"):** honored. No `SpriteBatch.raycast` implementation (it stays the existing no-op override, `SpriteBatch.ts:598` — already correct, and critical: `InstancedMesh.raycast` would otherwise phantom-test every instance), no instance→sprite mapping, no batch participation in events. Discoverability comes from sprites being *real objects in the graph* — exactly the mechanism §5 assumed #85 would provide.
+
+**Audit obligations:** every consumer of `spriteGroup.children` (`clear()`, `clone()`, devtools batch snapshots, stats) and the R3F removal path (`flatland.remove` → `spriteGroup.remove` must also detach from the holder; R3F StrictMode remount churn) — enumerate and test.
+
+### D-C — The interim fix survives, upgraded and re-documented
+
+`Sprite2D.raycast()`'s `this.updateMatrixWorld()` (and TileMap2D's) becomes `this.updateWorldMatrix(true, false)` — which also refreshes the *ancestor* chain, making it correct for parented sprites (a plain `updateMatrixWorld()` composes against a possibly-stale parent). Post D-A/D-B it is no longer compensating for a detached object — it is a freshness guarantee for raycasts issued outside the frame loop (setup code, tests, pre-first-render), equally valid for standalone sprites. The spec's "no interim code" clause (D1) is satisfied: the call's *reason* changed from workaround to documented contract. Pin with a pre-first-render raycast test. The `batchedRaycast.test.ts` characterization tests stay green throughout.
+
+### D-D — R3F: no API changes; new coverage obligations
+
+- **Render-to-screen** (`set({ camera: flatland.camera })`, the starter-template pattern) and **portal** (`createPortal(children, flatland.scene, { events: { compute: createFlatlandCompute(...), priority } })`) both already route rays through `flatland.camera`; per the R3F source verification, per-object raycast + correct `matrixWorld` is sufficient. `createFlatlandCompute` (`react/flatlandEvents.ts`) is untouched.
+- New obligations: (a) bubbling test — handler on an ancestor fires for a batched-sprite hit; (b) portal-mode batched-sprite test; (c) `events.update()` hover-under-camera-motion unaffected (spec §8.3); (d) the react starter template's interaction keeps working (it exercises a *batched* sprite — Flatland's explicit path batches even a single sprite).
+- **Known, documented limit:** handlers on the `<flatland>` element itself will not receive bubbled sprite hits — `flatland.scene` is not a child of the Flatland group, so the parent walk ends at the scene. Same posture as drei `View`. Document; do not hack the parent chain.
+
+### D-E — TileMap2D: already a graph citizen; in scope for freshness + tests only
+
+`flatland.add(tilemap)` goes to `scene.add` (`Flatland.ts:531`) — it was never in the ECS-only trap. Scope: the D-C `updateWorldMatrix` upgrade, plus traversal tests through `flatland.scene` (its `raycast` correctly `return false`s to suppress TileLayer child recursion — keep pinned).
+
+### D-F — Performance & acceleration posture (spec §7.3 / issue note)
+
+- **Per pointer event (R3F):** O(H) where H = handler-carrying objects; each `Sprite2D.raycast` ≈ one 4×4 invert + plane test (~100–200 ns) + the D-C ancestor refresh. ~1k simultaneously-interactive sprites ≈ 0.1–0.2 ms per pointermove: fine. **Vanilla traversal:** adds O(scene nodes) walk — same order.
+- **Per frame:** the slot-copy pass, O(batched sprites), parity with today's `transformSyncSystem` (measured at the gate).
+- **`SpatialGrid` stays unbuilt** (demoted-optional, spec §7.3). Build triggers, recorded here so profiling has a threshold: sustained >0.5 ms per pointer event, or >~2–5k simultaneously-interactive batched sprites. If ever adopted, the PoC's duplicate-candidate and high-water-rebuild bugs (spec §11) are required fixes. Very high instance counts belong to the #128 GPU ID-buffer path — unaffected by this plan (its `pick()` signature and `instanceExtras.y` reservation stand).
+
+### D-G — Scope cuts (each with a tracked exit)
+
+- **Per-slot user visibility** (`sprite.visible = false` on a batched sprite does not hide the drawn slot — true today on both paths, and after this plan a hidden-by-user batched sprite will still draw and still hit): **file a tracking issue** during Phase 4 with the candidate design (user-intent shadow flag + degenerate/zero slot matrix + raycast early-out) — it rides the same slot-copy code path built here, but it changes shipped observable semantics on the auto path (existing tests assert `visible === false` when batched) and deserves its own decision.
+- **Auto-registry-inside-Flatland-scene edge** (sprites nested in plain Groups handed to `flatland.add` fall through to Signal-B auto-orchestration against `flatland.scene`, creating a second world without Flatland's lighting/material wiring): pre-existing, orthogonal. Characterize in one test if cheap, else document in the tracking issue.
+- **`FlatlandTexture` component** stays #126; **drag helper** stays #129; **alpha sidecar** already shipped per its own plan.
+
+---
+
+## 4. The ordering problem (lead-owned design work)
+
+Today the whole `SystemSchedule` runs at the *top* of `SpriteGroup.updateMatrixWorld`, **before** `super.updateMatrixWorld` propagates matrices (`SpriteGroup.ts:444-477`). A matrixWorld-slaved copy cannot live there. Restructure into two stages:
+
+```
+SpriteGroup.updateMatrixWorld(force):
+  stage A (ECS mutation): deferredDestroy → materialVersions → effectTraits →
+      batchAssign → batchReassign → batchSort → sceneGraphSync → batchRemove → lateAssign
+      (+ prepended lighting CPU-prep systems)
+  super.updateMatrixWorld(force)        // three composes group, holder, sprites, batches(identity-pinned)
+  stage B (derived data + render): slotMatrixCopy (matrixWorld → instanceMatrix, markMatrixDirty,
+      shadowRadius from matrix column lengths) → flushDirtyRanges → shadowPipeline/offscreen render systems
+```
+
+**Stage rule:** systems that only mutate ECS/CPU state → stage A; systems that read slot matrices or trigger renders (`flushDirtyRangesSystem`, `shadowPipelineSystem`, any offscreen pass) → stage B. Audit every system currently registered (including `Flatland.setLighting`'s prepends and appends around `Flatland.ts:1056`) against this rule — a shadow pass reading pre-copy slots would render one frame stale and break parity.
+
+**Trigger points:**
+
+- **Explicit path (SpriteGroup standalone or under Flatland):** both stages inside `SpriteGroup.updateMatrixWorld` as above. Sprites are holder children, so their `matrixWorld` is fresh when stage B runs. Flatland's `scene.updateMatrixWorld(true)` remains the sole per-frame trigger; re-entrancy (`_inSystems`, `scheduleRuns`) must guard both stages — shadow passes nest `renderer.render` which recurses into this override.
+- **Auto path:** sprites live in the *user's* tree, possibly ordered after the hidden orchestrator group in traversal — a stage-B copy inside `group.updateMatrixWorld` can read stale matrices. Run the copy in `flatlandSceneSweep` (`orchestrator.ts:147`), which fires at `scene.onBeforeRender` — **after** the renderer's `updateMatrixWorld` and **before** `projectObject`. The sweep becomes an unconditional tail when the registry has batched entities (cost: the same O(N) copy the schedule pays today). **Verify the renderer ordering claim against the installed `three/webgpu` `Renderer.js`** (the orchestrator's comment cites updateMatrixWorld @1508 → onBeforeRender @1559 → projectObject @1575 — re-confirm before relying on it, and pin with a comment citing the verified lines).
+- Guard double-copies with a per-registry frame stamp; on auto registries, the sweep copy is authoritative.
+
+Contingency if the three-propagation cost regresses the benchmark: keep the 2D-specialized compose but perform it *in the copy pass* as `parentWorld × fastLocal` (single site, still matrixWorld-truth); this preserves D-A's invariant while restoring the specialized math.
+
+---
+
+## 5. Invariants to PROVE (not merely test)
+
+These get explicit before/after evidence at gates; a failure blocks the phase.
+
+| # | Invariant | Proof artifact |
+|---|---|---|
+| P1 | **Pixel parity** — batch-demo, knightmark, lighting, tilemap examples render byte-stable (or visually identical) before vs after | screenshot pairs (e2e or vitexec capture), attached to the PR per repo norm |
+| P2 | **Draw-call parity** — hidden sprite children add zero draw calls (`renderer.info` delta / `flatland.stats`) | stats assertion in test + example probe |
+| P3 | **Slot⇔world agreement** — for every mode (auto flat, auto nested, group, flatland, transformed group): `instanceMatrix[slot] === sprite.matrixWorld` after a frame | new parity suite (the test class that would have caught this bug — see §7) |
+| P4 | **Promotion parity** — same pixels standalone vs batched for the same sprite state (AUTO-BATCH-DESIGN's table, now actually true) | nested-parent render test: promote, compare matrices; demote, compare again |
+| P5 | **Perf floor** — knightmark 60fps; schedule micro-bench (16k sprites) within ±10%; 1→100k tier-ladder stress unchanged | recorded numbers in PR description, before/after |
+| P6 | **No batch in intersections, no duplicate hits** — traversal over scenes with batches present yields only Sprite2D/TileMap2D objects, one record per sprite | traversal suite |
+| P7 | **Sorting/lighting unaffected** — batchSort, sortLayer routing, shadow/lighting suites stay green with stage-B reordering | existing suites + shadow-pass freshness test |
+
+---
+
+## 6. Phases & tasks
+
+Phase gates: `pnpm --filter=three-flatland typecheck && cd packages/three-flatland && pnpm vitest run` + lint, plus the phase's listed proofs. Lead runs gates; no phase overlaps its successor's files without lead sign-off. Commit per completed task, conventional commits, exact-path staging.
+
+### Phase 0 — Characterize & baseline (lead, serial, small)
+
+- [ ] Commit characterization tests for the probe findings: auto-nested `instanceMatrix ≠ matrixWorld` (as `.fails` / todo pinned to flip in Phase 1), explicit-path traversal-miss (flips in Phase 2), demotion-prune vanish (flips in Phase 2). Keep `batchedRaycast.test.ts` green — it pins the interim behavior we must not regress mid-flight.
+- [ ] Record perf baselines: knightmark manual check, a 16k-sprite schedule micro-bench (vitest bench or timed loop), draw-call counts from batch-demo.
+- [ ] Verify the `three/webgpu` renderer ordering (§4) against installed source; write findings into the orchestrator comment or plan notes.
+
+### Phase 1 — Single source of truth (D-A, §4) — the risky core; smallest competent unit, tight lead review
+
+- [ ] `SpriteBatch`: pin `matrixWorld` to identity (override `updateMatrixWorld`; keep `frustumCulled=false`); test that a transformed parent no longer flows into batch matrixWorld.
+- [ ] Two-stage schedule split per §4 (`SystemSchedule` gains stages or a second schedule instance); audit + reassign every registered system per the stage rule, including Flatland lighting prepends/appends. Re-entrancy guards cover both stages.
+- [ ] `slotMatrixCopySystem`: matrixWorld → slot copy + `markMatrixDirty` + shadowRadius from matrix column lengths (parity with `transformSyncSystem.ts:108-110`); `autoInvalidateTransforms` gating preserved.
+- [ ] Auto-path sweep tail copy + frame-stamp guard (`orchestrator.ts`).
+- [ ] Delete the TRS recompose from `transformSyncSystem` (the file likely dissolves into the copy system); update its tests and `conditionalTransformSyncSystem` wiring.
+- [ ] Flip the Phase-0 nested-parent test to green.
+- [ ] **Gate:** full suite + P3/P4/P5/P7 + P1/P2 spot-check on batch-demo. Transformed-SpriteGroup parity test green.
+
+### Phase 2 — Graph citizenship (D-B) — parallelizable after Phase 1 lands
+
+- [ ] Holder group in `SpriteGroup`; `add`/`addSprites` enroll-then-parent (order matters, §D-B); `remove`/`removeSprites`/R3F removal detach from holder; demotion reparents holder → group.
+- [ ] `sceneGraphSyncSystem`: prune only `SpriteBatch` instances; demotion-prune regression test (Phase-0 test flips green).
+- [ ] Audit `clear()`, `clone()`, `dispose()`, stats, devtools snapshots for the enlarged `children`; StrictMode remount test for the R3F path.
+- [ ] Traversal suite: `intersectObjects(scene.children, true)` finds explicit-path batched sprites (flatland + bare SpriteGroup); P6 assertions; explicit-path traversal-miss test flips green.
+- [ ] R3F bubbling test (ancestor handler fires); portal-mode batched-sprite compute test.
+- [ ] **Gate:** full suite + P2 (no double-draw: sprite children render zero draws) + P1 screenshots + auto-path suites untouched.
+
+### Phase 3 — Events surface & docs — wide parallel
+
+- [ ] D-C freshness upgrade: `updateWorldMatrix(true, false)` in `Sprite2D.raycast` + `TileMap2D.raycast`; re-document from "interim" to freshness contract; pre-first-render raycast test; keep `batchedRaycast.test.ts` semantics.
+- [ ] `examples/three/hit-test` + `examples/react/hit-test`: add a batched-sprites section (multiple sprites sharing a material, hover/click each independently) — the pair rule, both or neither.
+- [ ] Docs: remove the D1 batched-caveat from the hit-test docs page; document the contract (§5 quote), the `<flatland>`-element bubbling limit (D-D), `visible` semantics note (D-G), perf guidance + acceleration thresholds (D-F).
+- [ ] Starter-template check: react + three templates' interactions still work (they are the shipped consumers of the interim fix); update `templates/react/AGENTS.md` if guidance changed.
+- [ ] Spec bookkeeping: addendum note in the event-system spec marking §7.3/D1 resolved by this plan (do not rewrite locked decisions; append a dated resolution note).
+
+### Phase 4 — Verification & close-out (lead-heavy)
+
+- [ ] e2e: pointer interaction on `examples/react/hit-test` with batched sprites (extend `e2e/smoke-examples.spec.ts` or a sibling spec) — click → observable state change, both render-to-screen and portal if the example supports both.
+- [ ] P1 screenshot pairs for batch-demo/knightmark/lighting/tilemap; P5 numbers recorded in the PR description.
+- [ ] 1→100k stress + hysteresis + tier suites green (unchanged).
+- [ ] File the D-G tracking issues (slot visibility semantics; auto-registry-inside-Flatland edge if not characterized); cross-reference #128 (unaffected); update #127 with the diagnosis correction (auto path already worked; explicit path + transform truth were the real gap).
+- [ ] Changeset: CI generates from conventional commits; verify the bump is minor-alpha and the release-visible packages are right.
+
+---
+
+## 7. Test strategy — the suite that would have caught this
+
+The existing suites test bare sprites (`Sprite2D.raycast.test.ts`), raycast helpers, and Flatland separately; `batchedRaycast.test.ts` tests direct `intersectObject` only. The missing class is **combination + agreement** tests. Add `events/batchedPicking.test.ts` (or sibling) built on one parameterized harness:
+
+> For each management mode — standalone / auto-flat / auto-nested-transformed-parent / SpriteGroup / SpriteGroup-transformed / Flatland / Flatland-with-TileMap — after one simulated frame: (1) direct `intersectObject(sprite)` hits at an off-center point; (2) `intersectObjects(scene.children, true)` returns the same hit with `object === sprite` and nothing batch-shaped; (3) `instanceMatrix[slot]` equals `matrixWorld` (P3); (4) hit `point`/`uv` match between direct and traversal paths.
+
+Plus targeted regressions: demotion-prune (P0), shadow-pass slot freshness (P7), enroll-before-parent ordering (a sprite added to a SpriteGroup must not leak into auto-orchestration), R3F bubbling, pre-first-render raycast, transformed-group parity, spec §11's ledger items stay pinned (already shipped — do not disturb).
+
+---
+
+## 8. Risks & flags (lead attention)
+
+1. **The stage split is the dangerous change.** It reorders systems relative to offscreen renders in the hot path. Mis-staging one lighting system = subtle one-frame shadow lag that screenshots may miss. Mitigation: the stage rule audit is a named task, and P7 includes a shadow-freshness test (mutate a sprite transform, render, assert the shadow pass consumed this frame's slots).
+2. **Renderer-order assumption** for the auto sweep copy is verified-by-comment, not by us — Phase 0 re-verifies against installed three before Phase 1 builds on it.
+3. **Traversal is now user-observable:** `scene.traverse` / `getObjectBy*` will find batched sprites (and the holder) where they found nothing before. This is the feature, but it is also a behavior change — release notes must say so.
+4. **Auto-path `visible` conflation** remains (batched-but-drawn sprites report `visible === false`). Explicit path avoids it via the holder; the divergence between paths is documented, not resolved (D-G issue).
+5. **Perf regression risk** concentrates in three's generic 4×4 parent-multiply replacing the specialized 2D compose. The §4 contingency (specialized compose in the copy pass) is pre-approved if P5 fails — do not invent a third option under time pressure.
+6. If any Phase-1 evidence contradicts D-A viability (e.g. an ECS-ordering constraint not visible from this reading), **stop and escalate to the stakeholder** rather than adapting the architecture mid-horde — D-A is the load-bearing decision of this plan.
+
+---
+
+## 9. Required reading for implementers
+
+`planning/superpowers/specs/2026-06-12-event-system-design.md` (§4-§8, §11) · `planning/milestones/AUTO-BATCH-DESIGN.md` (promotion table, event-driven model) · `planning/milestones/RENDERING-ARCHITECTURE.md` · source: `Sprite2D.ts` (`updateMatrix` :2047, `raycast` :1897, `_demoteToStandalone` :2014, added/removed handlers :1865), `pipeline/SpriteGroup.ts` (schedule :192-305, `updateMatrixWorld` :444), `pipeline/SpriteBatch.ts` (:88, :598), `Flatland.ts` (:292-362, :490, :1200-1307), `ecs/systems/transformSyncSystem.ts`, `ecs/systems/sceneGraphSyncSystem.ts`, `orchestration/orchestrator.ts`, `events/raycastHelpers.ts`, `react/flatlandEvents.ts` · tests: `orchestration/autoBatch.test.ts` (the auto-path contract), `events/batchedRaycast.test.ts`, `tilemap/TileMap2D.raycast.test.ts`.
+
+---
+
+## Stakeholder direction (2026-07-20) — resolve before dispatch
+
+**1. Confirmed architecture: batch origin is identity; only instances carry world transforms.** This matches D-A and every major engine (Unity BRG, Unreal ISM/HISM, Godot MultiMesh, GPU-driven). It is settled — the implementation must not reintroduce any batch-level transform.
+
+**2. Perf reconciliation — D-A copy pass vs single-writer ECS (must decide, with numbers).**
+D-A as written computes `sprite.matrixWorld` via three's propagation, then copies 16 floats into the slot — adding a 4×4 parent-multiply + copy per sprite per frame, including the flat (identity-parent) common case we skip today. Stakeholder requirement: **keep the ECS direct-access fast path and do not regress.**
+Reconcile one of two ways, and prove it:
+- **(a) Prove the copy pass is within ±10%** on knightmark + the 16k bench, and keep D-A as written; or
+- **(b) Single-writer ECS**: `matrixWorldAutoUpdate = false` on batched sprites; the schedule computes world directly (existing fast 2D compose direct-to-slot for identity-parent sprites, fold ancestor matrix only when a parent transform exists) and writes it to **both** the slot and `sprite.matrixWorld`. One compute feeds render + raycast; avoids the two-stage schedule split.
+This interacts with D-B (graph children get propagated by three regardless) — the two must be reconciled explicitly. Phase 0 characterization must measure the copy-pass cost so the choice is evidence-based, not assumed.
+
+**3. Culling — design so it is not foreclosed; do NOT build it now.**
+Confirmed: nothing culls today (`SpriteBatch.frustumCulled = false`, `boundingSphere.radius = Infinity`). World-space instance matrices are the correct substrate for adding it later (whole-batch AABB → spatial clusters → GPU cull). Two constraints to honor now so a future culling pass is not blocked:
+- Instance slot data stays **world-space** (falls out of decision 1).
+- Any future cull-with-compaction must be **sort-stable** — batches are sorted by sortLayer/zIndex, so the slot layout and compaction design must preserve draw order. Do not adopt a slot-packing scheme that would make stable compaction impossible.
+No culling code in this PR; this is a reserved-design note only.
+
+## Correction (2026-07-20) — one hit-test contract, no new picking API
+
+Earlier revisions of this plan invented `flatland.pick()` and promoted a hash-grid to "core broadphase." Both violate the event-system design and are dropped.
+
+**There is exactly one hit-test in the repo:** `raycaster.intersectObject(sprite)` → `Sprite2D.raycast()`. Design D4 and §9 lock this — vanilla is plain `Raycaster`, "zero additional machinery"; R3F's `onPointer*` derive from the same contract. No `flatland.pick()`, no event library, no second path.
+
+**#127 = Part A only.** Make `sprite.matrixWorld` the correct world transform for batched sprites so `Sprite2D.raycast()` works. That is the entire fix: R3F events work (R3F raycasts its interaction list per object, calling `raycast()`), vanilla works (`intersectObject(sprite)` per §9).
+
+**No scene traversal problem to solve.** `SpriteGroup.add()` already keeps batched sprites out of the scene graph, so nothing does `intersectObjects(scene, true)` over them. Consumers hold refs to the sprites they care about (vanilla) or register handlers (R3F) — both per-object, both the one contract.
+
+**`SpatialGrid` stays as the spec's §7.3 optional acceleration** — built only if profiling shows thousands of simultaneously-interactive sprites, and even then it feeds candidates into the same `raycast()` narrowphase with no public API change. Not in #127.
+


### PR DESCRIPTION
### **User description**
Closes #127. This is the whole of #127 — world transform **and** pointer picking for batched sprites — on one branch. (Supersedes #205, which was the world-transform half alone.)

Sprites added via `flatland.add()` compose into a `SpriteBatch` instance matrix and are **not** scene-graph children. Two things were broken; this PR fixes both under the existing `Raycaster` / `onPointer*` idiom — no new API.

## Part 1 — world transform (was #205)

**Broken:** the instance slot was composed from the sprite's **local** transform and `matrixWorld` was never maintained. So a batched sprite under a transformed `SpriteGroup` drew at the wrong place, and the one hit-test contract (`raycaster.intersectObject(sprite)` → `Sprite2D.raycast()`) read an identity `matrixWorld` — testing a 0.5-unit disc against a full-size sprite.

**Fix:** `transformSyncSystem` composes each sprite's **world** transform into both the instance slot and `sprite.matrixWorld`. The `SpriteGroup`'s 2D affine is extracted once per frame and folded per sprite only when non-identity (the identity case — Flatland's group — keeps the direct-to-slot compose). No per-sprite 4×4: the `Sprite2D` transform is a 2D affine (rotation.z, scale.x/y, position.z as depth). `SpriteBatch.matrixWorld` is pinned to identity; `matrixWorldAutoUpdate` is gated off while enrolled.

## Part 2 — broadphase pointer picking

Naively re-listing every batched sprite for raycasting is O(n) — what batching exists to avoid. Instead each `SpriteBatch` owns a uniform spatial hash grid (`SpriteSpatialGrid`) of its members, and `SpriteBatch.raycast` localizes the ray and queries only the cells it sweeps:

```
raycaster.intersectObjects(scene, true)
  └─ hits SpriteBatch (a scene child)
       └─ ray localized across the member z-span → grid query   // O(candidates), not O(n)
            └─ sprite._hitTestInto(...)                          // exact per-sprite test
```

**React** gets the same win: a batched R3F sprite is proxied **out** of `state.internal.interaction` (handlers preserved via `__r3f`) and the batch registered **once** in its place. `<sprite2D onClick>` fires unchanged, `event.object === sprite`, at broadphase cost. `hitTestMode` opt-outs and custom `raycast` are respected; non-proxied R3F sprites are skipped so their raycast can't fire twice.

## Verification

Real WebGPU (`vitexec --gpu`), 3000 shared-texture sprites in one batch: interaction list holds **1** object (down from 3000), click dispatches to the correct sprite — **O(n) → O(1)**.

The picking code went through an [eight-round Codex adversarial review](https://github.com/thejustinwalsh/three-flatland/pull/206#issuecomment-5034355262) — perspective-camera localization, drag/drop-missed forwarding, camera-inside-span, and three grazing-ray / integer-precision DoS hazards, each fixed with a regression test — then a DRY/quality pass (Codex-verified behaviour-preserving). Automated agents: `c0der3view` ticket-compliance ✅; `coderabbit` skipped for the (former) base branch; `Fro Bot`/`tjw-bot` hit provider quota (billing, not code).

**Gate:** 827 tests, no type errors, real-WebGPU smoke green. Known limitation (documented in `batchPicking.ts`): mutating the raw `raycast` property on an already-batched sprite isn't tracked — use `hitTestMode`.


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fix batched sprite world transform: compose SpriteGroup affine into instance slot and `sprite.matrixWorld`
  - Batched sprites now render and hit-test at the correct world position
  - `SpriteBatch.matrixWorld` pinned to identity to avoid double‑applying the group transform

- Implement batch‑root broadphase picking via `SpriteSpatialGrid` for efficient scene traversal
  - `SpriteBatch.raycast` localizes the ray and queries only overlapping grid cells
  - Candidate sprites delegate to their existing narrow‑phase `raycast`

- Proxy batched R3F sprites through the owning `SpriteBatch` to reduce per‑object raycast overhead
  - Sprites are removed from R3F's interaction list; the batch is registered once
  - Missed‑handler forwarding (`onPointerMissed` etc.) preserves user event handlers

- Restrict `sceneGraphSyncSystem` child eviction to only batch meshes, fixing a regression where demoted standalone sprites vanished

- Add comprehensive tests for world transform correctness, broadphase picking, spatial grid, and R3F proxy behaviour


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local TRS (position, rotation, scale)"] --> B["transformSyncSystem: compose with SpriteGroup world affine"]
  B --> C["Instance slot (GPU matrix)"]
  B --> D["sprite.matrixWorld (raycast)"]
  C --> E["SpriteBatch (identity matrixWorld)"]
  D --> F["Sprite2D.raycast / TileMap2D.raycast"]
  G["SpriteSpatialGrid"] -->|"index by world pos"| H["SpriteBatch.raycast broadphase"]
  H -->|"delegate"| F
  I["R3F proxy"] -->|"splice sprites, register batch"| J["SpriteBatch.__r3f"]
  J -->|"forward onPointerMissed etc."| K["Member sprites' handlers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>batchUtils.ts</strong><dd><code>Clean up picking grid and proxy on batch eviction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-de0e3900f7ba910974a169db8c48b600f9e2955f7c51b481bf3fb033b104cc1f">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batchAssignSystem.ts</strong><dd><code>Route R3F picking through batch and index sprite in grid on assignment</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-62b9b24e71af6ffb880988a04e764cb9f119f0102a81674057b1746acaa3ff20">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batchReassignSystem.ts</strong><dd><code>Move picking proxy and grid entry on batch reassignment</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-5f6297f66dff879893cebe37e787e37737ee9806d4a5e236f7be607b645138e7">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batchRemoveSystem.ts</strong><dd><code>Clean up picking grid and proxy when sprites leave a batch</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-4f3bd44521ff6c8e52887383b712100cd35da8c81b9d65712dc1a7cfa492c5dc">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transformSyncSystem.ts</strong><dd><code>Compose world transform and maintain both instance slot and </code><br><code>sprite.matrixWorld</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-3a623578bc74584ff7aa9e4d576ef96b24ce236bc713ac578f64ad07437b970d">+98/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SpriteBatch.ts</strong><dd><code>Add spatial grid, identity matrix-pinning, broadcast raycast, and </code><br><code>picking index</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-73b0847791b976a131015eadd51064b3d32a6023c4ef3c529fa3dbfe3c607eba">+127/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SpriteSpatialGrid.ts</strong><dd><code>Implement uniform hash grid for picking broadphase with safe bounds</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-1a4d1ddb9ddfff28399b98fee2ff03d496ef3a3067bcda6e5c3d8e239527608d">+282/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>batchPicking.ts</strong><dd><code>R3F batch‑root picking proxy: splice sprites, register batch, forward </code><br><code>missed handlers</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-86671bb08de99ff5e182d3697649f46cf8ed166b58dfe7ef4a80816f7a43a16e">+251/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Sprite2D.ts</strong><dd><code>Add world‑matrix composition, _hitTestInto, grid cleanup, and </code><br><code>auto‑update gating</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-0282b70dd27b9d92567fc9b64f76c8f669c5c20de23490458b6a364d6abaf58f">+135/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>sceneGraphSyncSystem.ts</strong><dd><code>Prune only SpriteBatch children to preserve demoted standalone sprites</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-329c2bbad0903ab7f08168df85318ca1705e9025dc71955e363613a8079e8683">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TileMap2D.ts</strong><dd><code>Refresh ancestors in raycast for pre‑frame accuracy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-526835f105660a04a1bcff9b23f81cb27c1cc15e21120405fb0ec123544d4f1d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>batchBroadphase.test.ts</strong><dd><code>Test broadphase picking accuracy, z‑span handling, and </code><br><code>double‑invocation guard</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-8feef18a0236b4b3338237022b5b9183c39e5dad0202848beeb349571d647b48">+183/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>batchedWorldTransform.test.ts</strong><dd><code>Verify rendered slot, raycast, and no double‑apply under transformed </code><br><code>groups</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-1eea8268638971d6e3aa109542cc7e8698ac510edabf6b496a4cbf1d89eaab45">+183/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SpriteSpatialGrid.test.ts</strong><dd><code>Validate grid insert, query, z‑span, and float‑safe bounds</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-4de363f82539f52d4b0df86203c68b70d16e481b9ed0378f8efd8425b3663047">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batchPicking.test.ts</strong><dd><code>Test R3F interaction‑list proxy, custom raycast handling, and </code><br><code>missed‑handler forwarding</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-3241265ef52e7d869dd2d4757a51fb02f552ab2e6e4dba78319582d1f88c9923">+192/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>batch-broadphase-picking.md</strong><dd><code>Document batch‑root broadphase picking changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-dc0dba9d2be155be42a0a3d07b7ccad766d307b1d1851d0b9eaf9b9284c7fce2">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batched-sprite-world-transform.md</strong><dd><code>Document batched sprite world transform and hit‑testing fix</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-22bb8cc03d2c7c2019cfe1f74c5b1552612bfb5d78b0f7c868af77cf9a82a13c">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>2026-07-20-batched-sprite-events.md</strong><dd><code>Add detailed implementation plan for batched sprite events</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/206/files#diff-e2a52ea0100442c9fac19410ee741e6504eb9d47eec65422a8acc6d6e686ec63">+248/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

