### PR TITLE
docs(image, create-three-flatland): add README + LICENSE for the two new packages

### DIFF
--- a/.changeset/create-three-flatland-readme.md
+++ b/.changeset/create-three-flatland-readme.md
@@ -1,0 +1,5 @@
+---
+'create-three-flatland': patch
+---
+
+docs: add package README (banner, usage, template matrix, create-vite-compatible flags) and LICENSE

--- a/.changeset/image-readme.md
+++ b/.changeset/image-readme.md
@@ -1,0 +1,5 @@
+---
+'@three-flatland/image': patch
+---
+
+docs: add package README (banner, KTX2 rationale, encode/decode + Ktx2Loader usage, CLI) and LICENSE

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -42,6 +42,7 @@
     "@three-flatland/alphamap": "0.1.0-alpha.0",
     "@three-flatland/atlas": "0.1.0-alpha.0",
     "@three-flatland/image": "0.0.0",
+    "create-three-flatland": "0.0.0",
     "@three-flatland/schemas": "1.0.0",
     "@three-flatland/audio-play": "0.0.0",
     "@three-flatland/bridge": "0.0.0",

--- a/packages/create-three-flatland/LICENSE
+++ b/packages/create-three-flatland/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Justin Walsh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-three-flatland/README.md
+++ b/packages/create-three-flatland/README.md
@@ -1,0 +1,65 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/thejustinwalsh/three-flatland/main/assets/repo-banner.png" alt="three-flatland" width="100%" />
+</p>
+
+# create-three-flatland
+
+Scaffold a [three-flatland](https://www.npmjs.com/package/three-flatland) project — a minimal, Vite-powered WebGPU 2D starter in either plain [Three.js](https://threejs.org/) or [React Three Fiber](https://r3f.docs.pmnd.rs/). An interactive sprite scene, a Suspense loading overlay, oxlint/oxfmt, and ready-to-run unit + Playwright tests, with `AGENTS.md`/`CLAUDE.md` so coding agents know the ropes.
+
+> **Alpha Release** — this package is in active development. The API will evolve and breaking changes are expected between releases. Pin your version and check the [changelog](https://github.com/thejustinwalsh/three-flatland/releases) before upgrading.
+
+[![npm](https://img.shields.io/npm/v/create-three-flatland)](https://www.npmjs.com/package/create-three-flatland)
+[![license](https://img.shields.io/npm/l/create-three-flatland)](https://github.com/thejustinwalsh/three-flatland/blob/main/LICENSE)
+
+## Usage
+
+```bash
+# npm
+npm create three-flatland@latest
+
+# pnpm
+pnpm create three-flatland
+
+# yarn
+yarn create three-flatland
+```
+
+You'll be prompted for a project directory and a template. Then:
+
+```bash
+cd my-app
+npm install
+npm run dev
+```
+
+### Non-interactive
+
+Pass the target directory and template as arguments (create-vite-compatible flags):
+
+```bash
+npm create three-flatland@latest my-app -- --template three
+npm create three-flatland@latest my-app -- --template react
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `-t, --template <name>` | Template to scaffold: `three` \| `react` |
+| `--overwrite` | Scaffold into a non-empty target directory |
+| `--help` | Show usage |
+
+## Templates
+
+| Template | Stack |
+| --- | --- |
+| `three` | Plain Three.js + WebGPU (`three/webgpu` + TSL) on Vite |
+| `react` | React Three Fiber (`@react-three/fiber/webgpu`) on Vite |
+
+Both render an interactive sprite scene, share the same loading overlay, and ship with linting, formatting, unit tests, and Playwright end-to-end tests wired up.
+
+## Documentation
+
+Full docs, guides, and interactive examples at **[tjw.dev/three-flatland](https://tjw.dev/three-flatland/)**.
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/image/LICENSE
+++ b/packages/image/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Justin Walsh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -1,0 +1,79 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/thejustinwalsh/three-flatland/main/assets/repo-banner.png" alt="three-flatland" width="100%" />
+</p>
+
+# @three-flatland/image
+
+WASM image codec for [three-flatland](https://www.npmjs.com/package/three-flatland) and [Three.js](https://threejs.org/). Encode and decode **PNG, WebP, AVIF, and KTX2** across the browser, Node, and a [`flatland-bake`](https://www.npmjs.com/package/@three-flatland/bake) CLI subcommand — plus a `Ktx2Loader` that keeps textures GPU-compressed to cut VRAM pressure.
+
+> **Alpha Release** — this package is in active development. The API will evolve and breaking changes are expected between releases. Pin your version and check the [changelog](https://github.com/thejustinwalsh/three-flatland/releases) before upgrading.
+
+[![npm](https://img.shields.io/npm/v/@three-flatland/image)](https://www.npmjs.com/package/@three-flatland/image)
+[![license](https://img.shields.io/npm/l/@three-flatland/image)](https://github.com/thejustinwalsh/three-flatland/blob/main/LICENSE)
+
+## Why KTX2
+
+PNG/WebP/AVIF all decode to raw RGBA on the GPU — a 2048×2048 texture costs ~16 MB of VRAM no matter how small the file was on disk. KTX2 (Basis Universal) stays **compressed on the GPU**, transcoded to the platform's native format (BC7, ASTC, ETC2, …) at load. Reach for it when textures are under GPU-memory pressure; reach for PNG/WebP/AVIF when disk size or fidelity is what matters.
+
+## Install
+
+```bash
+npm install @three-flatland/image
+```
+
+`three` is a peer dependency.
+
+## Encode / decode
+
+`encodeImage` takes an `ImageData` (`{ width, height, data }`) and returns the compressed bytes; `decodeImage` goes the other way.
+
+```ts
+import { encodeImage, decodeImage } from '@three-flatland/image'
+
+// ImageData → compressed bytes
+const png = await encodeImage(pixels, { format: 'png' })
+const avif = await encodeImage(pixels, { format: 'avif', quality: 60 })
+const ktx2 = await encodeImage(pixels, {
+  format: 'ktx2',
+  basis: { mode: 'uastc', mipmaps: true }, // supercompression defaults to zstd
+})
+
+// compressed bytes → ImageData
+const decoded = await decodeImage(bytes, 'png')
+```
+
+`estimateGpuMemory` reports the VRAM a source will cost per candidate format, so you can decide when KTX2 is worth it before committing a texture.
+
+In Node, the `/node` subpath adds file and batch helpers:
+
+```ts
+import { encodeImageFile, encodeImageBatch } from '@three-flatland/image/node'
+```
+
+## KTX2 loader
+
+`Ktx2Loader` extends `three.Loader`. Detect the renderer's supported transcode targets once, then load — the texture stays GPU-compressed.
+
+```ts
+import { Ktx2Loader } from '@three-flatland/image/loaders/ktx2'
+
+const loader = new Ktx2Loader()
+await loader.detectSupport(renderer) // required before load(): picks BC7/ASTC/ETC2/…
+const texture = await loader.loadAsync('/sprite.ktx2')
+```
+
+## CLI
+
+The package contributes an `encode` subcommand to the [`flatland-bake`](https://www.npmjs.com/package/@three-flatland/bake) CLI:
+
+```bash
+flatland-bake encode ./sprite.png sprite.ktx2
+```
+
+## Documentation
+
+Full docs and guides at **[tjw.dev/three-flatland](https://tjw.dev/three-flatland/)**.
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -52,14 +52,14 @@ import { encodeImageFile, encodeImageBatch } from '@three-flatland/image/node'
 
 ## KTX2 loader
 
-`Ktx2Loader` extends `three.Loader`. Detect the renderer's supported transcode targets once, then load — the texture stays GPU-compressed.
+`Ktx2Loader` extends `three.Loader`. Detect the renderer's supported transcode targets once (synchronous, chainable), then load — the texture stays GPU-compressed.
 
 ```ts
 import { Ktx2Loader } from '@three-flatland/image/loaders/ktx2'
 
-const loader = new Ktx2Loader()
-await loader.detectSupport(renderer) // required before load(): picks BC7/ASTC/ETC2/…
-const texture = await loader.loadAsync('/sprite.ktx2')
+const texture = await new Ktx2Loader()
+  .detectSupport(renderer) // required before load(); picks BC7/ASTC/ETC2/…
+  .loadAsync('/sprite.ktx2')
 ```
 
 ## CLI


### PR DESCRIPTION
### **User description**
The two packages published in this round — **`@three-flatland/image`** and **`create-three-flatland`** — went out without a `README` or `LICENSE`. This adds both, following the repo's standard package README pattern (centered `repo-banner.png`, one-line description with links, the **Alpha Release** notice, npm + license badges), matching `nodes`/`slug`/`devtools`/`skia`/etc.

### `@three-flatland/image`
KTX2-vs-PNG/WebP/AVIF rationale, `encodeImage`/`decodeImage` + `/node` file helpers, `Ktx2Loader.detectSupport → loadAsync`, and the `flatland-bake encode` subcommand. Signatures verified against source (`encodeImage(ImageData, opts)`, `decodeImage(bytes, format)`, `Ktx2Loader extends three.Loader`).

### `create-three-flatland`
`npm`/`pnpm`/`yarn create` usage, the `three` | `react` template matrix, and the create-vite-compatible `--template`/`--overwrite` flags (pulled from the CLI's own help).

### Also
- **`LICENSE` (MIT)** added to both — siblings ship one, and it makes the `./LICENSE` link resolve + npm show the license. (npm always ships `README`/`LICENSE` regardless of the `files` array, so no manifest change needed.)
- **Patch changesets** for both, per the repo convention. Drop them if you'd rather the READMEs ride the next bump without their own patch entry.

Docs-only; no code paths touched.


___

### **PR Type**
Documentation


___

### **Description**
- Add README files for `create-three-flatland` and `@three-flatland/image` packages

- Add MIT LICENSE files for both packages

- Include patch changesets for documentation version bumps


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-three-flatland-readme.md</strong><dd><code>Patch changeset for create-three-flatland README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/create-three-flatland-readme.md

<ul><li>Add patch changeset for <code>create-three-flatland</code> documenting addition of <br>README and LICENSE</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-72e6eee97c4f48bac2589a535500fe2e6c1c8a4fda36dd8d809353696807bbe0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>image-readme.md</strong><dd><code>Patch changeset for @three-flatland/image README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/image-readme.md

<ul><li>Add patch changeset for <code>@three-flatland/image</code> documenting addition of <br>README and LICENSE</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-81e222a3677df80fadd1d129615899670bf0a5c3fe10c009632677c317b7dfc3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LICENSE</strong><dd><code>Add MIT License for create-three-flatland</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/create-three-flatland/LICENSE

- Add MIT License file for `create-three-flatland` package


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-2d6fecaac4899b333a43c07c79518ac9b5175adf9db71734a80fed471b859059">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>README for create-three-flatland</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/create-three-flatland/README.md

<ul><li>Add comprehensive README with usage instructions, template matrix, and <br>create-vite-compatible flags</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-4627ef2e64ad0a0501b50f6fceb2849d1bef7287ee681dc129009ef2d6a81d43">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LICENSE</strong><dd><code>Add MIT License for @three-flatland/image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/image/LICENSE

- Add MIT License file for `@three-flatland/image`


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-2c39225eab20fd12087c582c93f102580cd878fe04d7859b9e047d6bd6d9b71c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>README for @three-flatland/image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/image/README.md

<ul><li>Add README with KTX2 rationale, API usage for encode/decode, <br>Ktx2Loader instructions, and CLI subcommand reference</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/207/files#diff-bf8c2295c62dac1310710d0a9ebd1b019de4469950e1667a83bf8e7fa515191a">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

