### PR TITLE
fix(image, atlas): repository field for image, standard README + LICENSE for atlas

### DIFF
--- a/.changeset/atlas-readme.md
+++ b/.changeset/atlas-readme.md
@@ -1,0 +1,7 @@
+---
+'@three-flatland/atlas': patch
+---
+
+docs: adopt the standard package README (repo banner, description with links,
+Alpha Release notice, npm/license badges) and add the MIT LICENSE file, matching
+the other published packages ahead of atlas's first publish.

--- a/.changeset/image-repository.md
+++ b/.changeset/image-repository.md
@@ -1,0 +1,8 @@
+---
+'@three-flatland/image': patch
+---
+
+fix: add the `repository` and `license` fields to package.json. The empty
+`repository.url` made npm reject the publish with E422 (sigstore provenance
+could not verify the source repo). With provenance enabled, the field must
+match the GitHub repo URL.

--- a/packages/atlas/LICENSE
+++ b/packages/atlas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Justin Walsh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/atlas/README.md
+++ b/packages/atlas/README.md
@@ -1,8 +1,15 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/thejustinwalsh/three-flatland/main/assets/repo-banner.png" alt="three-flatland" width="100%" />
+</p>
+
 # @three-flatland/atlas
 
-First-party atlas baker: packs a directory of PNGs into a sprite atlas
-and generates **tight polygon meshes** from each frame's alpha
-silhouette — the data the tight-mesh overdraw-reduction path consumes.
+First-party atlas baker for [three-flatland](https://www.npmjs.com/package/three-flatland) and [Three.js](https://threejs.org/): packs a directory of PNGs into a sprite atlas and generates **tight polygon meshes** from each frame's alpha silhouette — the data the tight-mesh overdraw-reduction path consumes.
+
+> **Alpha Release** — this package is in active development. The API will evolve and breaking changes are expected between releases. Pin your version and check the [changelog](https://github.com/thejustinwalsh/three-flatland/releases) before upgrading.
+
+[![npm](https://img.shields.io/npm/v/@three-flatland/atlas)](https://www.npmjs.com/package/@three-flatland/atlas)
+[![license](https://img.shields.io/npm/l/@three-flatland/atlas)](https://github.com/thejustinwalsh/three-flatland/blob/main/LICENSE)
 
 ## CLI
 
@@ -42,3 +49,7 @@ fully-transparent frames are skipped.
 Build-tool integration (Vite plugin) is sketched as a follow-up: the
 programmatic API is the integration point — a plugin wraps `bakeAtlas`
 over a glob and emits the pair as assets.
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -2,6 +2,12 @@
   "name": "@three-flatland/image",
   "version": "0.1.0-alpha.1",
   "description": "WASM image encoder package — PNG/WebP/AVIF/KTX2 with browser+Node+CLI surfaces",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thejustinwalsh/three-flatland.git",
+    "directory": "packages/image"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
### **User description**
Two publish-readiness gaps the release run surfaced.

### `@three-flatland/image` — provenance E422
The automated publish failed with `E422 … Error verifying sigstore provenance bundle: "repository.url" is "", expected to match https://github.com/thejustinwalsh/three-flatland`. Its `package.json` had **no `repository` field**, and with `NPM_CONFIG_PROVENANCE: true` that field must match the repo. Added `repository` (`directory: packages/image`) and `license: "MIT"` (the sibling convention; it already ships a LICENSE file). It'll clear provenance on the next run.

### `@three-flatland/atlas` — first-publish readiness
Atlas is a not-yet-published package (its E404 in the run is the new-package + trusted-publisher bootstrap, which is a manual step). Its `repository` field was already correct, but its README was the **plain format** while every other published package uses the standard header. Adopted it — repo banner, description with links, **Alpha Release** notice, npm/license badges — and added the MIT `LICENSE` file (it was missing).

Patch changesets for both. Docs/manifest only; no code paths touched.

> Atlas still needs its one-time manual first-publish + trusted-publisher setup (same as `image`/`create-three-flatland`) before the automated release can pick it up.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix `@three-flatland/image` publish failure by adding missing `repository` and `license` fields to `package.json`

- Standardize `@three-flatland/atlas` README with repo banner, badges, alpha notice, and license section

- Add MIT LICENSE file for atlas

- Include changesets for both packages (`patch`)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["image: missing repository & license"] -- "add fields in package.json" --> B["E422 provenance error resolved"]
  C["atlas: plain README, no LICENSE"] -- "adopt standard header, add LICENSE" --> D["publish-ready"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atlas-readme.md</strong><dd><code>Add atlas patch changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/atlas-readme.md

<ul><li>Add patch changeset for atlas that documents the README and LICENSE <br>updates</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/209/files#diff-f32da3429dbbbb16e285c3f94e1983be65cab883ace1212ae929ae79dd0ac0ad">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>image-repository.md</strong><dd><code>Add image patch changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/image-repository.md

<ul><li>Add patch changeset for image describing the fix for missing <br>repository/license fields</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/209/files#diff-f6d390a2414be5164e60800b5d7c2ad270e43ebd538a8b9ee99b0638c064dd56">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LICENSE</strong><dd><code>Add MIT license for atlas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atlas/LICENSE

- Add MIT license file for atlas, matching other published packages


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/209/files#diff-4cddf8717de4831eb10f16f168c73f5dd7ebdd0bfe6609eab1f1ad5b470a0a73">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Standardize atlas README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atlas/README.md

<ul><li>Replace plain README with standard header featuring repo banner<br> <li> Add npm and license badges, Alpha Release notice, and links to <br>changelog<br> <li> Include License section at the bottom</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/209/files#diff-8c63395478c3321ff33d023a5bf0480681f18209082f5fd5e055e130679054e0">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add missing package metadata for image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/image/package.json

<ul><li>Add <code>"license": "MIT"</code> field<br> <li> Add <code>"repository"</code> object with GitHub URL and directory, fixing <br>provenance verification error</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/209/files#diff-bd9fab76eb73ad8b524550f29db971a210c94151508a207b52add32c980d3c0c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Atlas README with a standard format, branding, badges, alpha-release notice, and license information.
  - Added an MIT license for Atlas.

- **Bug Fixes**
  - Added repository and license metadata to the Image package to support successful npm publishing and provenance verification.

- **Release Notes**
  - Documented patch-level updates for both Atlas and Image packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->