### PR TITLE
fix: eliminate workspace lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "NODE_OPTIONS=--max-old-space-size=8192 nx run-many -t build",
     "dev": "echo '\\n  \u279c  Dev server: http://localhost:4321\\n' && nx run-many -t dev -p docs examples",
     "typecheck": "nx run-many -t typecheck",
-    "lint": "oxlint --type-aware --ignore-pattern '**/create-three-flatland/templates/**' packages minis tools examples '!**/node_modules/**' '!**/dist/**' '!**/third_party/**' '!**/vendor/**' '!**/fixtures/**' '!**/*.gen.ts' '!**/*.generated.ts'",
+    "lint": "oxlint --type-aware --deny-warnings --ignore-pattern '**/create-three-flatland/templates/**' packages minis tools examples '!**/node_modules/**' '!**/dist/**' '!**/third_party/**' '!**/vendor/**' '!**/fixtures/**' '!**/*.gen.ts' '!**/*.generated.ts'",
     "lint:fix": "oxlint --type-aware --fix --ignore-pattern '**/create-three-flatland/templates/**' packages minis tools examples '!**/node_modules/**' '!**/dist/**' '!**/third_party/**' '!**/vendor/**' '!**/fixtures/**' '!**/*.gen.ts' '!**/*.generated.ts'",
     "format": "oxfmt '**/*.ts' '**/*.tsx'",
     "format:check": "oxfmt --check '**/*.ts' '**/*.tsx'",

--- a/packages/devtools/src/dashboard/panels/batches.tsx
+++ b/packages/devtools/src/dashboard/panels/batches.tsx
@@ -21,7 +21,7 @@
  */
 import { useMemo, useState } from 'preact/hooks'
 import { useDevtoolsState } from '../hooks.js'
-import type { BatchPassSnapshot } from '../../devtools-client.js'
+import type { BatchPassSnapshot, BatchSnapshot } from '../../devtools-client.js'
 
 interface GroupedRun {
   runKey: number
@@ -37,6 +37,76 @@ interface PassNode {
   pass: BatchPassSnapshot
   index: number
   children: PassNode[]
+}
+
+interface DerivedBatches {
+  frame: number
+  passCount: number
+  batchCount: number
+  passTotals: { calls: number; tris: number; cpuMs: number }
+  runs: GroupedRun[]
+  totalSprites: number
+  passRoots: PassNode[]
+}
+
+function deriveBatches(
+  frame: number,
+  passes: BatchSnapshot['passes'],
+  activeBatches: BatchSnapshot['batches']
+): DerivedBatches {
+  let calls = 0
+  let tris = 0
+  let cpuMs = 0
+  for (const pass of passes) {
+    if (pass.parent === -1) {
+      calls += pass.calls
+      tris += pass.triangles
+      cpuMs += pass.cpuMs
+    }
+  }
+
+  const groupedRuns = new Map<string, GroupedRun>()
+  let totalSprites = 0
+  for (const batch of activeBatches) {
+    const groupKey = `${batch.kind}:${batch.runKey}`
+    let run = groupedRuns.get(groupKey)
+    if (run === undefined) {
+      run = {
+        runKey: batch.runKey,
+        layer: batch.layer,
+        materialId: batch.materialId,
+        materialName: batch.materialName,
+        kind: batch.kind,
+        totalSprites: 0,
+        batches: [],
+      }
+      groupedRuns.set(groupKey, run)
+    }
+    run.totalSprites += batch.spriteCount
+    totalSprites += batch.spriteCount
+    run.batches.push({ batchIdx: batch.batchIdx, spriteCount: batch.spriteCount, label: batch.label })
+  }
+  const runs = Array.from(groupedRuns.values())
+  runs.sort((a, b) => a.kind.localeCompare(b.kind) || a.layer - b.layer || a.materialId - b.materialId)
+
+  const nodes: PassNode[] = passes.map((pass, index) => ({ pass, index, children: [] }))
+  const passRoots: PassNode[] = []
+  // Parents precede children in producer emission order, so the original
+  // array index remains a stable parent lookup while deriving this tree.
+  for (const node of nodes) {
+    if (node.pass.parent === -1) passRoots.push(node)
+    else nodes[node.pass.parent]?.children.push(node)
+  }
+
+  return {
+    frame,
+    passCount: passes.length,
+    batchCount: activeBatches.length,
+    passTotals: { calls, tris, cpuMs },
+    runs,
+    totalSprites,
+    passRoots,
+  }
 }
 
 export function BatchesPanel() {
@@ -60,77 +130,24 @@ export function BatchesPanel() {
     })
   }
 
-  const passTotals = useMemo(() => {
-    let calls = 0
-    let tris = 0
-    let cpuMs = 0
-    for (const p of batches.passes) {
-      if (p.parent === -1) {
-        calls += p.calls
-        tris += p.triangles
-        cpuMs += p.cpuMs
-      }
-    }
-    return { calls, tris, cpuMs }
-  }, [batches.frame])
-
-  const runs = useMemo(() => {
-    const m = new Map<string, GroupedRun>()
-    for (const b of batches.batches) {
-      const groupKey = `${b.kind}:${b.runKey}`
-      let run = m.get(groupKey)
-      if (run === undefined) {
-        run = {
-          runKey: b.runKey,
-          layer: b.layer,
-          materialId: b.materialId,
-          materialName: b.materialName,
-          kind: b.kind,
-          totalSprites: 0,
-          batches: [],
-        }
-        m.set(groupKey, run)
-      }
-      run.totalSprites += b.spriteCount
-      run.batches.push({ batchIdx: b.batchIdx, spriteCount: b.spriteCount, label: b.label })
-    }
-    const arr = Array.from(m.values())
-    arr.sort((a, b) => a.kind.localeCompare(b.kind) || a.layer - b.layer || a.materialId - b.materialId)
-    return arr
-  }, [batches.frame])
-
-  const totalSprites = useMemo(() => {
-    let n = 0
-    for (const r of runs) n += r.totalSprites
-    return n
-  }, [runs])
-
-  /**
-   * Rebuild the pass tree from the flat array. Parents come before
-   * children in the producer's emission order (frame first, then its
-   * children, etc.) so one linear pass + index lookup suffices.
-   */
-  const passRoots = useMemo(() => {
-    const nodes: PassNode[] = batches.passes.map((p, i) => ({
-      pass: p,
-      index: i,
-      children: [],
-    }))
-    const roots: PassNode[] = []
-    for (const n of nodes) {
-      if (n.pass.parent === -1) roots.push(n)
-      else nodes[n.pass.parent]?.children.push(n)
-    }
-    return roots
-  }, [batches.frame])
+  const { frame, passes, batches: activeBatches } = batches
+  const {
+    frame: derivedFrame,
+    passCount,
+    batchCount,
+    passTotals,
+    runs,
+    totalSprites,
+    passRoots,
+  } = useMemo(() => deriveBatches(frame, passes, activeBatches), [frame, passes, activeBatches])
 
   return (
     <section class="panel batches-panel">
       <header class="panel-header batches-header">
         <span>Batches</span>
         <span class="batches-header-meta">
-          frame {batches.frame} · {passTotals.calls} draws · {runs.length} runs · {batches.batches.length} batches ·{' '}
-          {totalSprites} sprites
+          frame {derivedFrame} · {passTotals.calls} draws · {runs.length} runs · {batchCount} batches · {totalSprites}{' '}
+          sprites
         </span>
       </header>
 
@@ -138,7 +155,7 @@ export function BatchesPanel() {
         <div class="batches-section">
           <div class="batches-section-title">
             <span>Active batches</span>
-            <span class="batches-section-count">{batches.batches.length}</span>
+            <span class="batches-section-count">{batchCount}</span>
           </div>
           <div class="batches-table-head batches-table-head--runs">
             <span class="batches-col-label">run / batch</span>
@@ -182,7 +199,7 @@ export function BatchesPanel() {
         <div class="batches-section">
           <div class="batches-section-title">
             <span>Passes</span>
-            <span class="batches-section-count">{batches.passes.length}</span>
+            <span class="batches-section-count">{passCount}</span>
           </div>
           <div class="batches-table-head batches-table-head--passes">
             <span class="batches-col-label">pass</span>

--- a/packages/devtools/src/dashboard/panels/buffers.tsx
+++ b/packages/devtools/src/dashboard/panels/buffers.tsx
@@ -15,7 +15,7 @@
  * Multiple dashboard consumers (or the tweakpane modal) subscribing to
  * different entries is fine — the producer unions selections server-side.
  */
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import type { BufferChunkPayload } from '../../devtools-client.js'
 import { getClient } from '../client.js'
 import { getFrameCursor } from '../frame-cursor.js'
@@ -56,12 +56,10 @@ export function BuffersPanel() {
     panY: 0,
   })
 
-  // Stable sorted buffer list.
-  const entries = useMemo(() => {
-    const arr = Array.from(state.buffers.values())
-    arr.sort((a, b) => a.name.localeCompare(b.name))
-    return arr
-  }, [state.buffers, state.buffers.size])
+  // The client mutates this map in place; derive the live list on each
+  // subscribed frame so same-size delete/add replacements cannot go stale.
+  const entries = Array.from(state.buffers.values())
+  entries.sort((a, b) => a.name.localeCompare(b.name))
 
   const needle = filter.trim().toLowerCase()
   const visible =

--- a/packages/devtools/src/dashboard/panels/registry.tsx
+++ b/packages/devtools/src/dashboard/panels/registry.tsx
@@ -49,11 +49,8 @@ export function RegistryPanel() {
     }
   }, [client])
 
-  const entries = useMemo(() => {
-    const arr = Array.from(state.registry.values())
-    arr.sort((a, b) => a.name.localeCompare(b.name))
-    return arr
-  }, [state.registry, state.registry.size])
+  const entries = Array.from(state.registry.values())
+  entries.sort((a, b) => a.name.localeCompare(b.name))
 
   const needle = filter.trim().toLowerCase()
   const visible =
@@ -119,6 +116,16 @@ export function RegistryPanel() {
   )
 }
 
+/**
+ * Freeze the client's mutable in-place entry at its explicit revision.
+ * This keeps effects and derived values coherent while preserving the
+ * client's allocation-free steady-state updates.
+ */
+function useRegistryEntrySnapshot(entry: RegistryEntrySnapshot): RegistryEntrySnapshot {
+  const { name, kind, version, count, sample, label } = entry
+  return useMemo(() => ({ name, kind, version, count, sample, label }), [name, kind, version, count, sample, label])
+}
+
 function RegistrySparkline({
   entry,
   width,
@@ -128,6 +135,7 @@ function RegistrySparkline({
   width: number
   height: number
 }): preact.JSX.Element {
+  const snapshot = useRegistryEntrySnapshot(entry)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   // Gate redraw on version bumps — the shared rAF fires on every frame
   // but most entries don't change every frame. Redrawing a 10k-sample
@@ -144,21 +152,22 @@ function RegistrySparkline({
     }
     const ctx = canvas.getContext('2d')
     if (ctx === null) return
-    drawVisualizer(ctx, w, h, entry)
-  }, [entry.version, entry.name, width, height])
+    drawVisualizer(ctx, w, h, snapshot)
+  }, [snapshot, width, height])
   return <canvas class="registry-sparkline" ref={canvasRef} style={{ width: `${width}px`, height: `${height}px` }} />
 }
 
 function RegistryDetail({ entry }: { entry: RegistryEntrySnapshot }): preact.JSX.Element {
-  const { name, kind, count, sample, label, version } = entry
+  const snapshot = useRegistryEntrySnapshot(entry)
+  const { name, kind, count, sample, label, version } = snapshot
   const isFloat = sample instanceof Float32Array
-  const stats = useMemo(() => computeStats(entry), [entry, entry.version])
+  const stats = useMemo(() => computeStats(snapshot), [snapshot])
 
   // Element count on the visualizer axis — for vectors this is the
   // number of vectors, for bits it's total bit count, for scalars it's
   // sample.length. The graph cursor and data-viewer highlight both
   // index into this space.
-  const axisLen = axisLength(entry)
+  const axisLen = axisLength(snapshot)
 
   // Cursor is purely a mirror of the data-view's scroll position —
   // initialised to 0 so the graph always shows an anchor line on
@@ -172,8 +181,8 @@ function RegistryDetail({ entry }: { entry: RegistryEntrySnapshot }): preact.JSX
   const scrollGridToAxisIdx = (idx: number): void => {
     const el = gridScrollerRef.current
     if (el === null) return
-    const perAxisIdx = entry.kind === 'float2' ? 2 : entry.kind === 'float3' ? 3 : entry.kind === 'float4' ? 4 : 1
-    const scalarIdx = entry.kind === 'bits' ? idx : idx * perAxisIdx
+    const perAxisIdx = kind === 'float2' ? 2 : kind === 'float3' ? 3 : kind === 'float4' ? 4 : 1
+    const scalarIdx = kind === 'bits' ? idx : idx * perAxisIdx
     const rowIdx = Math.floor(scalarIdx / ROW_STRIDE)
     const top = rowIdx * SAMPLE_ROW_HEIGHT
     const target = Math.max(0, top - el.clientHeight / 2 + SAMPLE_ROW_HEIGHT / 2)
@@ -202,8 +211,8 @@ function RegistryDetail({ entry }: { entry: RegistryEntrySnapshot }): preact.JSX
     }
     const ctx = canvas.getContext('2d')
     if (ctx === null) return
-    drawVisualizer(ctx, w, h, entry, null)
-  }, [entry.version, entry.name, resizeTick])
+    drawVisualizer(ctx, w, h, snapshot, null)
+  }, [snapshot, resizeTick])
 
   // Imperative hover-tracking: mousemove updates a `style.left` on the
   // cursor <div> directly without going through React. State only
@@ -288,7 +297,7 @@ function RegistryDetail({ entry }: { entry: RegistryEntrySnapshot }): preact.JSX
           <div class="panel-empty">No sample yet.</div>
         ) : (
           <SampleGrid
-            entry={entry}
+            entry={snapshot}
             stride={ROW_STRIDE}
             float={isFloat}
             pinnedIdx={pinnedIdx}

--- a/tools/vscode/webview/atlas/App.tsx
+++ b/tools/vscode/webview/atlas/App.tsx
@@ -833,7 +833,7 @@ export function App() {
     didAutoExpandRef.current = true
     if (!prefs.animDrawerExpanded) prefsStore.set({ animDrawerExpanded: true })
     if (activeAnimation == null) setActiveAnimation(Object.keys(animations)[0] ?? null)
-  }, [animations, prefs.animDrawerExpanded, activeAnimation])
+  }, [animations, prefs.animDrawerExpanded, activeAnimation, setActiveAnimation])
 
   // Clear the manual animation-frame highlight on any context shift
   // the user wouldn't expect to carry over: switching the active
@@ -1002,19 +1002,25 @@ export function App() {
     void handleSave()
   }, [outputFormat, detectedFormat, formatSwitchArmed, handleSave])
 
-  const handleRectCreate = useCallback((r: Rect) => {
-    setRects((prev) => [...prev, r])
-    setSelectedIds(new Set([r.id]))
-  }, [])
+  const handleRectCreate = useCallback(
+    (r: Rect) => {
+      setRects((prev) => [...prev, r])
+      setSelectedIds(new Set([r.id]))
+    },
+    [setRects, setSelectedIds]
+  )
 
-  const handleRectChange = useCallback((id: string, next: { x: number; y: number; w: number; h: number }) => {
-    setRects((prev) => prev.map((r) => (r.id === id ? { ...r, ...next } : r)))
-    // The rect's frame geometry just changed — any loaded rotation/trim/
-    // pivot/polygon-mesh passthrough for it no longer describes the new
-    // rect, and there's no editing UI to keep it consistent. See
-    // RectPassthrough's doc comment in atlasStore.ts.
-    atlasActions.clearPassthrough(id)
-  }, [])
+  const handleRectChange = useCallback(
+    (id: string, next: { x: number; y: number; w: number; h: number }) => {
+      setRects((prev) => prev.map((r) => (r.id === id ? { ...r, ...next } : r)))
+      // The rect's frame geometry just changed — any loaded rotation/trim/
+      // pivot/polygon-mesh passthrough for it no longer describes the new
+      // rect, and there's no editing UI to keep it consistent. See
+      // RectPassthrough's doc comment in atlasStore.ts.
+      atlasActions.clearPassthrough(id)
+    },
+    [setRects]
+  )
 
   // ── Animation handlers ──────────────────────────────────────────────────
   const animationNames = useMemo(() => Object.keys(animations).sort(), [animations])
@@ -1075,7 +1081,7 @@ export function App() {
       if (!prefs.animDrawerExpanded) prefsStore.set({ animDrawerExpanded: true })
       return name
     },
-    [animations, deduceAnimationName, prefs.animDrawerExpanded]
+    [animations, deduceAnimationName, prefs.animDrawerExpanded, setActiveAnimation, setAnimations]
   )
 
   const handleCreateAnimation = useCallback(() => {
@@ -1108,20 +1114,23 @@ export function App() {
         return remaining[0] ?? null
       })
     },
-    [animations]
+    [animations, setActiveAnimation, setAnimations]
   )
 
-  const handleRenameAnimation = useCallback((oldName: string, newName: string) => {
-    setAnimations((prev) => {
-      if (!prev[oldName] || prev[newName]) return prev
-      const next: Record<string, Animation> = {}
-      for (const [k, v] of Object.entries(prev)) {
-        next[k === oldName ? newName : k] = v
-      }
-      return next
-    })
-    setActiveAnimation((cur) => (cur === oldName ? newName : cur))
-  }, [])
+  const handleRenameAnimation = useCallback(
+    (oldName: string, newName: string) => {
+      setAnimations((prev) => {
+        if (!prev[oldName] || prev[newName]) return prev
+        const next: Record<string, Animation> = {}
+        for (const [k, v] of Object.entries(prev)) {
+          next[k === oldName ? newName : k] = v
+        }
+        return next
+      })
+      setActiveAnimation((cur) => (cur === oldName ? newName : cur))
+    },
+    [setActiveAnimation, setAnimations]
+  )
 
   const updateActiveAnimation = useCallback(
     (patch: Partial<Animation>) => {
@@ -1130,7 +1139,7 @@ export function App() {
         return { ...prev, [activeAnimation]: { ...prev[activeAnimation]!, ...patch } }
       })
     },
-    [activeAnimation]
+    [activeAnimation, setAnimations]
   )
 
   // ── Animation playback ──────────────────────────────────────────────────
@@ -1207,7 +1216,7 @@ export function App() {
       }))
       if (newPlayhead !== oldPlayhead) animationStore.seek(newPlayhead)
     },
-    [activeAnimation, animations, animationStore]
+    [activeAnimation, animations, animationStore, setAnimations]
   )
 
   // Remove a group from the active animation (cell-level delete via
@@ -1227,7 +1236,7 @@ export function App() {
         return { ...prev, [activeAnimation]: { ...anim, frames: nextFrames } }
       })
     },
-    [activeAnimation]
+    [activeAnimation, setAnimations]
   )
 
   // Wraps the store's togglePlay with two ergonomic side effects:
@@ -1272,7 +1281,7 @@ export function App() {
         return { ...prev, [activeAnimation]: { ...anim, frames: next } }
       })
     },
-    [activeAnimation]
+    [activeAnimation, setAnimations]
   )
 
   // Set or clear an event tag at a specific post-duplication frame
@@ -1292,7 +1301,7 @@ export function App() {
         return { ...prev, [activeAnimation]: { ...anim, events: cleaned } }
       })
     },
-    [activeAnimation]
+    [activeAnimation, setAnimations]
   )
 
   // Reorder a group within the active animation: remove the group
@@ -1317,7 +1326,7 @@ export function App() {
         return { ...prev, [activeAnimation]: { ...anim, frames: nextFrames } }
       })
     },
-    [activeAnimation]
+    [activeAnimation, setAnimations]
   )
 
   // Convenience: append (Add-to-anim button). Equivalent to
@@ -1376,10 +1385,10 @@ export function App() {
         }
       }
     },
-    [tool]
+    [tool, setTool]
   )
 
-  const clearSelection = useCallback(() => setSelectedIds(new Set()), [])
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), [setSelectedIds])
 
   const deleteSelected = useCallback(() => {
     if (selectedIds.size === 0) return
@@ -1404,11 +1413,11 @@ export function App() {
           }
     )
     setSelectedIds(new Set())
-  }, [rects, selectedIds])
+  }, [rects, selectedIds, setSelectedIds])
 
   const selectAll = useCallback(() => {
     setSelectedIds(new Set(rects.map((r) => r.id)))
-  }, [rects])
+  }, [rects, setSelectedIds])
 
   const renameRect = useCallback(
     (id: string, name: string) => {
@@ -1521,7 +1530,7 @@ export function App() {
     setMode({ kind: 'slicing', state: initial })
     setSelectedIds(new Set())
     setRenameMode({ kind: 'none' })
-  }, [imageSize, regenerateGrid])
+  }, [imageSize, regenerateGrid, setSelectedIds])
 
   const exitSlice = useCallback(() => {
     setMode({ kind: 'normal' })
@@ -1586,7 +1595,7 @@ export function App() {
         return { ...prev, picked: next }
       })
     },
-    [updateSlice, mode, selectedIds]
+    [updateSlice, mode, selectedIds, setSelectedIds]
   )
 
   const setSliceGrid = useCallback(
@@ -1625,7 +1634,7 @@ export function App() {
     setRects((prev) => [...prev, ...newRects])
     setSelectedIds(new Set(newRects.map((r) => r.id)))
     updateSlice((prev) => ({ ...prev, picked: new Set() }))
-  }, [mode, updateSlice])
+  }, [mode, updateSlice, setRects, setSelectedIds])
 
   const slicing = mode.kind === 'slicing'
   const sliceCanCommit = mode.kind === 'slicing' && mode.state.picked.size > 0 && mode.state.prefix.trim() !== ''
@@ -1651,7 +1660,7 @@ export function App() {
     })
     setSelectedIds(new Set())
     setRenameMode({ kind: 'none' })
-  }, [imageSize])
+  }, [imageSize, setSelectedIds])
 
   const exitAutoDetect = useCallback(() => {
     setMode({ kind: 'normal' })
@@ -1706,7 +1715,7 @@ export function App() {
     setRects((prev) => [...prev, ...newRects])
     setSelectedIds(new Set(newRects.map((r) => r.id)))
     updateAutoDetect((prev) => ({ ...prev, picked: new Set() }))
-  }, [mode, updateAutoDetect])
+  }, [mode, updateAutoDetect, setRects, setSelectedIds])
 
   const autoDetectCanCommit =
     mode.kind === 'autodetect' && mode.state.picked.size > 0 && mode.state.prefix.trim() !== ''
@@ -1897,6 +1906,8 @@ export function App() {
     folderSelectionPrefix,
     manualAnimHighlight,
     imageSize,
+    setRects,
+    setTool,
   ])
 
   return (

--- a/tools/vscode/webview/encode/ComparePreview.tsx
+++ b/tools/vscode/webview/encode/ComparePreview.tsx
@@ -78,10 +78,7 @@ function useEncodedTexture(
 
   useEffect(() => {
     if (!encodedBytes || !encodedFormat) {
-      setTex((prev) => {
-        prev?.dispose()
-        return null
-      })
+      setTex(null)
       return
     }
     const reqId = ++reqIdRef.current
@@ -106,10 +103,7 @@ function useEncodedTexture(
           return
         }
         setGpuStats(extractGpuStats(next, sourceWidth, sourceHeight))
-        setTex((prev) => {
-          prev?.dispose()
-          return next
-        })
+        setTex(next)
       } catch (err) {
         console.error('encoded texture decode failed', err)
       }
@@ -120,12 +114,11 @@ function useEncodedTexture(
     }
   }, [encodedBytes, encodedFormat, setGpuStats, sourceWidth, sourceHeight])
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(
     () => () => {
       tex?.dispose()
     },
-    []
+    [tex]
   )
 
   return tex


### PR DESCRIPTION
### **User description**
## Stack

- Base PR: #224
- This PR is the second layer and should merge after #224.

## What changed

- resolves all 38 reported React hook dependency warnings without adding suppressions
- derives coherent snapshots from the devtools client state that is intentionally mutated in place
- keeps atlas callbacks aligned with their stable store actions
- fixes encoded-preview texture disposal on replacement and unmount
- makes the root lint command fail on any future warning

Autofix was run first as requested; it produced no edits, so the remaining warnings were resolved manually.

## Validation

- pnpm lint (zero warnings, deny-warnings enabled)
- pnpm format:check (1,203 files)
- pnpm typecheck (51 projects)
- production builds for @three-flatland/devtools and @three-flatland/vscode
- pnpm test (25 projects; complete workspace gate)
- @three-flatland/devtools: 40 tests
- @three-flatland/vscode: 356 tests
- three-flatland core: 1,036 tests
- @three-flatland/skia: 320 tests

## Commits

1. fix(devtools): derive coherent dashboard snapshots
2. fix(vscode): correct webview hook lifecycles
3. chore(lint): enforce warning-free checks


___

### **PR Type**
Bug fix


___

### **Description**
- Resolve all React hook dependency warnings

- Derive stable snapshots for mutable client state

- Fix encoded-preview texture disposal lifecycle

- Enforce warning-free lint via `--deny-warnings`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workspace lint"] -- "adds --deny-warnings" --> B["warning-free gate"]
  C["devtools panels"] -- "derive stable snapshots" --> D["mutable client state"]
  E["vscode webview"] -- "complete hook dependencies" --> F["stable callbacks"]
  G["encoded texture"] -- "fix disposal lifecycle" --> H["no texture leaks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batches.tsx</strong><dd><code>Derive batch snapshots in one memo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/devtools/src/dashboard/panels/batches.tsx

<ul><li>Extract batch/pass derivation into <code>deriveBatches</code> pure function<br> <li> Replace fragmented <code>useMemo</code> hooks with one snapshot from <code>frame</code>, <code>passes</code>, <br><code>activeBatches</code><br> <li> Fix dependency arrays to avoid stale closure warnings from in-place <br>state mutations</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-d3b2b2c1192b5a1032894516710fdbb312b754629aa48606c8e6213d0f5a0e4d">+85/-68</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>buffers.tsx</strong><dd><code>Derive live buffer entries without memo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/devtools/src/dashboard/panels/buffers.tsx

<ul><li>Drop <code>useMemo</code> for buffer list to avoid stale size-keyed cache<br> <li> Derive sorted entries from live mutable map each subscribed frame</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-20117c370bbc9052daf6cbcf1c4dd374d7fdffcf4fd4f8083ecbdeb344bd955b">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>registry.tsx</strong><dd><code>Freeze registry entry snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/devtools/src/dashboard/panels/registry.tsx

<ul><li>Derive registry entries from mutable map each render<br> <li> Add <code>useRegistryEntrySnapshot</code> to freeze entry fields for stable effect <br>deps<br> <li> Update sparkline/detail calculations to use snapshot</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-0671b8649f3b83ddc1c365d9d5567709e8d5769785e42ebddb492bb2bd7c0446">+24/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Complete VSCode hook dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/webview/atlas/App.tsx

<ul><li>Add missing setter dependencies to <code>useCallback</code> and <code>useEffect</code> hooks<br> <li> Stabilize animation, rect, slice, autodetect and keyboard handlers <br>with complete deps<br> <li> Update pointer-move memo dependency list to include <code>setRects</code> and <br><code>setTool</code></ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-f43c4bf4275c657c2fa62cd2a62aac510c5d6c3c3f6cfda57fb37536dc282e26">+52/-41</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComparePreview.tsx</strong><dd><code>Fix encoded texture disposal lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vscode/webview/encode/ComparePreview.tsx

<ul><li>Remove manual <code>.dispose()</code> calls from state updater to avoid disposal <br>conflicts<br> <li> Set texture state directly; cleanup effect with <code>[tex]</code> disposes <br>replaced/unmounted texture<br> <li> Delete obsolete <code>eslint-disable-next-line</code></ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-e8da393594c86f6db9deba87cf5c0fbae67a2f56b1fe75d63a9dec202d514ec9">+3/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Enforce warning-free lint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Add <code>--deny-warnings</code> to root <code>lint</code> script<br> <li> Enforce warning-free workspace checks</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/225/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevTools batch, buffer, and registry panel updates so displayed counts, sorting, snapshots, and visualizations stay synchronized with current data.
  * Improved texture preview replacement and cleanup to prevent stale or improperly disposed textures.
  * Improved Atlas editor interactions by ensuring callbacks respond correctly when related tools or selections change.

* **Chores**
  * Lint warnings now fail validation, helping catch issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->