### PR TITLE
fix(core): preserve RenderPipeline clear alpha

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,7 +31,7 @@
       "cache": true
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build", "build"],
       "inputs": ["default", "^production"],
       "outputs": [],
       "cache": true

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -1676,10 +1676,13 @@ export class Flatland extends Group implements WorldProvider {
           renderer.autoClear = prevAutoClear
         }
       } finally {
-        if (renderTargetChanged && currentRenderTarget !== undefined) {
-          renderer.setRenderTarget(currentRenderTarget)
+        try {
+          if (renderTargetChanged && currentRenderTarget !== undefined) {
+            renderer.setRenderTarget(currentRenderTarget)
+          }
+        } finally {
+          restorePixelViewport?.()
         }
-        restorePixelViewport?.()
       }
     } finally {
       try {

--- a/packages/three-flatland/src/Flatland.ts
+++ b/packages/three-flatland/src/Flatland.ts
@@ -129,11 +129,24 @@ export interface FlatlandOptions {
    * Omit it to reveal additional world space and fill the available output.
    */
   viewWidth?: number
-  /** Clear before render (default: true) */
+  /**
+   * Clear before direct rendering (default: true). Three's post-processing
+   * scene pass always clears its private target so effects never sample stale
+   * frame data.
+   */
   autoClear?: boolean
-  /** Background color */
+  /**
+   * Background color used for Flatland-managed clears. A post-processing
+   * pipeline preserves an explicit {@link Scene.background}; direct rendering
+   * retains Flatland's historical managed-background behavior.
+   */
   clearColor?: ColorRepresentation
-  /** Background alpha (default: 1) */
+  /**
+   * Background alpha (default: 1). Direct rendering and post-processing both
+   * preserve it, including offscreen targets. Fractional alpha uses
+   * {@link clearColor}; alpha 0 clears to transparent black to prevent RGB
+   * bleed when the result is filtered.
+   */
   clearAlpha?: number
   /** Enable post-processing pipeline (default: false) */
   postProcessing?: boolean
@@ -314,6 +327,9 @@ export class Flatland extends Group implements WorldProvider {
   /** Clear alpha */
   clearAlpha: number
 
+  /** Last background value managed from Flatland's clear settings. */
+  private _managedSceneBackground: Color | null
+
   /** Cached renderer reference */
   private _renderer: WeakRef<WebGPURenderer> | null = null
 
@@ -333,6 +349,9 @@ export class Flatland extends Group implements WorldProvider {
 
   /** Reusable physical drawing-buffer size for surface-dependent GPU resources. */
   private _drawingBufferSize = new Vector2()
+
+  /** Shared-renderer clear color restored after Flatland's internal passes. */
+  private _savedClearColor = new Color()
 
   /** Reusable physical canvas viewport inherited from the active renderer owner. */
   private _activeCanvasViewport = new Vector4()
@@ -445,6 +464,7 @@ export class Flatland extends Group implements WorldProvider {
 
     // Background — set in render() based on clearAlpha (R3F sets props after construction)
     this.scene.background = this.clearColor
+    this._managedSceneBackground = this.clearColor
 
     // Render pipeline
     this._renderPipelineEnabled = options.postProcessing ?? false
@@ -1527,6 +1547,14 @@ export class Flatland extends Group implements WorldProvider {
     // safe activation here. `start()` is idempotent — no-op every
     // subsequent frame.
     this._devtools?.start()
+
+    // Flatland can share a renderer with a host scene. Capture clear state
+    // before the ECS schedule because lighting pre-passes may change it before
+    // the main draw starts. The reusable Color keeps this per-frame guard
+    // allocation-free.
+    renderer.getClearColor(this._savedClearColor)
+    const savedClearAlpha = renderer.getClearAlpha()
+
     // Mark frame start before ANY renderer.render() calls this frame.
     // Flatland runs multiple internal render passes (SDF pass, occlusion
     // pass, main render, post-processing) — `beginFrame` + `endFrame`
@@ -1535,114 +1563,134 @@ export class Flatland extends Group implements WorldProvider {
     // multiplied by pass count.
     this._devtools?.beginFrame(performance.now(), renderer)
 
-    // Auto-sync global uniforms from renderer
-    this._syncGlobals(renderer)
-
-    // Keep render-surface dimensions current for the camera and lighting.
-    // A fixed aspect only pins the camera; an explicit resize() selects full
-    // manual surface control for both the camera and effects.
-    this._syncSurfaceSize(renderer)
-
-    // Update LightingContext runtime fields before systems run
-    const lctx = this._getLightingContext()
-    if (lctx) {
-      lctx.renderer = renderer
-      lctx.camera = this._camera
-      lctx.scene = this.scene
-      // worldSize/worldOffset are always live Vector2s (trait default +
-      // preserved across setLighting); lightEffectSystem mutates them in
-      // place each frame. No lazy allocation needed here.
-    }
-
-    // Sync the Flatland-owned world uniform nodes from the current camera
-    // bounds so shader-side shadow / radiance math has live values. Mutation
-    // on `.value` is free — no shader rebuild. The uniform references were
-    // captured by effect shaders at setLighting time.
-    const cam = this._camera
-    this._worldSizeUniform.value.set(cam.right - cam.left, cam.top - cam.bottom)
-    this._worldOffsetUniform.value.set(cam.left, cam.bottom)
-
-    // ONE canonical trigger for the ECS schedule + matrix update per
-    // frame. `scene.updateMatrixWorld(true)` walks into
-    // `SpriteGroup.updateMatrixWorld`, which runs the schedule (all
-    // lighting + sprite systems) exactly once, then recurses into
-    // three.js matrix propagation. `scene.matrixWorldAutoUpdate` is
-    // disabled at construction so internal passes (OcclusionPass, SDF)
-    // don't trigger extra schedule runs.
-    //
-    // The `scheduleRuns` counter on the registry is kept as a defensive
-    // guard — if any future path (user code, new internal pass) calls
-    // `scene.updateMatrixWorld` or `spriteGroup.update` again in the
-    // same frame, `SpriteGroup` observes the advanced counter and
-    // short-circuits.
-    this.scene.updateMatrixWorld(true)
-
-    // Store renderer reference
-    if (!this._renderer || this._renderer.deref() !== renderer) {
-      this._renderer = new WeakRef(renderer)
-    }
-
-    // Auto-initialize or rebuild render pipeline if needed
-    this._ensureRenderPipeline(renderer)
-
-    // Bind the centered integer viewport before any direct or post-processed
-    // draw. Canvas viewports are expressed in logical pixels; render-target
-    // viewports already use physical texels. Restore user renderer state after
-    // this Flatland render completes.
-    const restorePixelViewport = this._applyPixelViewport(renderer)
-    let currentRenderTarget: RenderTarget | null | undefined
-    let renderTargetChanged = false
-
     try {
-      // Bind Flatland's destination for both direct and post-processed
-      // rendering. Keep target lookup/binding inside the restoration boundary:
-      // a backend error here must not leak Flatland's pixel viewport.
-      currentRenderTarget = renderer.getRenderTarget()
-      renderTargetChanged = currentRenderTarget !== this._renderTarget
-      if (renderTargetChanged) renderer.setRenderTarget(this._renderTarget)
+      // Auto-sync global uniforms from renderer
+      this._syncGlobals(renderer)
 
-      if (this._renderPipeline && this._renderPipelineEnabled) {
-        beginDebugPass('main.post', renderer)
-        try {
-          this._renderPipeline.render()
-        } finally {
-          endDebugPass(renderer)
+      // Keep render-surface dimensions current for the camera and lighting.
+      // A fixed aspect only pins the camera; an explicit resize() selects full
+      // manual surface control for both the camera and effects.
+      this._syncSurfaceSize(renderer)
+
+      // Update LightingContext runtime fields before systems run
+      const lctx = this._getLightingContext()
+      if (lctx) {
+        lctx.renderer = renderer
+        lctx.camera = this._camera
+        lctx.scene = this.scene
+        // worldSize/worldOffset are always live Vector2s (trait default +
+        // preserved across setLighting); lightEffectSystem mutates them in
+        // place each frame. No lazy allocation needed here.
+      }
+
+      // Sync the Flatland-owned world uniform nodes from the current camera
+      // bounds so shader-side shadow / radiance math has live values. Mutation
+      // on `.value` is free — no shader rebuild. The uniform references were
+      // captured by effect shaders at setLighting time.
+      const cam = this._camera
+      this._worldSizeUniform.value.set(cam.right - cam.left, cam.top - cam.bottom)
+      this._worldOffsetUniform.value.set(cam.left, cam.bottom)
+
+      // ONE canonical trigger for the ECS schedule + matrix update per
+      // frame. `scene.updateMatrixWorld(true)` walks into
+      // `SpriteGroup.updateMatrixWorld`, which runs the schedule (all
+      // lighting + sprite systems) exactly once, then recurses into
+      // three.js matrix propagation. `scene.matrixWorldAutoUpdate` is
+      // disabled at construction so internal passes (OcclusionPass, SDF)
+      // don't trigger extra schedule runs.
+      //
+      // The `scheduleRuns` counter on the registry is kept as a defensive
+      // guard — if any future path (user code, new internal pass) calls
+      // `scene.updateMatrixWorld` or `spriteGroup.update` again in the
+      // same frame, `SpriteGroup` observes the advanced counter and
+      // short-circuits.
+      this.scene.updateMatrixWorld(true)
+
+      // Store renderer reference
+      if (!this._renderer || this._renderer.deref() !== renderer) {
+        this._renderer = new WeakRef(renderer)
+      }
+
+      // Auto-initialize or rebuild render pipeline if needed
+      this._ensureRenderPipeline(renderer)
+
+      // Bind the centered integer viewport before any direct or post-processed
+      // draw. Canvas viewports are expressed in logical pixels; render-target
+      // viewports already use physical texels. Restore user renderer state after
+      // this Flatland render completes.
+      const restorePixelViewport = this._applyPixelViewport(renderer)
+      let currentRenderTarget: RenderTarget | null | undefined
+      let renderTargetChanged = false
+
+      try {
+        // Bind Flatland's destination for both direct and post-processed
+        // rendering. Keep target lookup/binding inside the restoration boundary:
+        // a backend error here must not leak Flatland's pixel viewport.
+        currentRenderTarget = renderer.getRenderTarget()
+        renderTargetChanged = currentRenderTarget !== this._renderTarget
+        if (renderTargetChanged) renderer.setRenderTarget(this._renderTarget)
+
+        // R3F can assign clear props after construction, so synchronize them at
+        // the last possible point. A PassNode forces autoClear while drawing its
+        // private scene target, so an active pipeline always needs Flatland's
+        // clear color/alpha even when the public autoClear option is false.
+        const renderPipeline = this._renderPipeline
+        const pipelineActive = renderPipeline !== null && this._renderPipelineEnabled
+        const clearRequested = this.autoClear || pipelineActive
+        // A Color background forces a Three clear even when autoClear is false,
+        // so direct accumulation must leave the scene background unset. A
+        // pipeline preserves a user-authored background (for example a
+        // texture); Flatland only synchronizes the default background it owns.
+        if (!pipelineActive || this.scene.background === this._managedSceneBackground) {
+          this._managedSceneBackground = clearRequested && this.clearAlpha >= 1 ? this.clearColor : null
+          this.scene.background = this._managedSceneBackground
         }
-      } else {
-        // Sync scene.background based on clearAlpha (R3F sets props after construction)
-        this.scene.background = this.clearAlpha < 1 ? null : this.clearColor
-
-        // Configure renderer clear state and let render() handle clearing
         const prevAutoClear = renderer.autoClear
-        renderer.autoClear = this.autoClear
+        // Preserve the host's compositing choice for the pipeline's final
+        // fullscreen output. PassNode independently forces autoClear while it
+        // renders the scene into its private input target.
+        renderer.autoClear = pipelineActive ? prevAutoClear : this.autoClear
         try {
-          if (this.autoClear) {
-            renderer.setClearColor(this.clearAlpha < 1 ? 0x000000 : this.clearColor, this.clearAlpha)
+          if (clearRequested) {
+            // Fully transparent pixels use black to avoid RGB bleed during
+            // filtering. Fractional alpha preserves the authored clear color.
+            renderer.setClearColor(this.clearAlpha === 0 ? 0x000000 : this.clearColor, this.clearAlpha)
           }
-          beginDebugPass('main', renderer)
-          try {
-            renderer.render(this.scene, this._camera)
-          } finally {
-            endDebugPass(renderer)
+
+          if (pipelineActive) {
+            beginDebugPass('main.post', renderer)
+            try {
+              renderPipeline.render()
+            } finally {
+              endDebugPass(renderer)
+            }
+          } else {
+            beginDebugPass('main', renderer)
+            try {
+              renderer.render(this.scene, this._camera)
+            } finally {
+              endDebugPass(renderer)
+            }
           }
         } finally {
           renderer.autoClear = prevAutoClear
         }
+      } finally {
+        if (renderTargetChanged && currentRenderTarget !== undefined) {
+          renderer.setRenderTarget(currentRenderTarget)
+        }
+        restorePixelViewport?.()
       }
     } finally {
-      if (renderTargetChanged && currentRenderTarget !== undefined) {
-        renderer.setRenderTarget(currentRenderTarget)
+      try {
+        renderer.setClearColor(this._savedClearColor, savedClearAlpha)
+      } finally {
+        // Mark frame end after ALL renderer.render() calls have completed.
+        // This aggregates internal passes into one logical devtools frame and
+        // still balances beginFrame if renderer-state restoration throws.
+        this._devtools?.endFrame(renderer)
       }
-      restorePixelViewport?.()
     }
-
-    // Devtools: mark frame end after ALL renderer.render() calls have
-    // completed this frame. Aggregates draw calls / triangles across
-    // internal passes, computes real cpuMs and FPS at the logical
-    // frame boundary, emits the data packet (or idle ping). The batch
-    // registry snapshot is pulled via the sink source Flatland
-    // registered in its constructor — no explicit capture call needed.
-    this._devtools?.endFrame(renderer)
   }
 
   /**

--- a/packages/three-flatland/src/flatland-resize.test.ts
+++ b/packages/three-flatland/src/flatland-resize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { OrthographicCamera, Vector2, Vector4 } from 'three'
+import { Color, OrthographicCamera, Vector2, Vector4 } from 'three'
 import { pass, vec4 } from 'three/tsl'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'
@@ -30,6 +30,8 @@ function mockRenderer(width: number, height: number, pixelRatio = 1) {
       return target.set(Math.floor(state.width * pixelRatio), Math.floor(state.height * pixelRatio))
     },
     getPixelRatio: () => pixelRatio,
+    getClearAlpha: () => 1,
+    getClearColor: (target: Color) => target.set(0x000000),
     getViewport: (target: Vector4) => target.copy(viewport),
     setViewport: (x: number | Vector4, y?: number, viewportWidth?: number, viewportHeight?: number) => {
       if (x instanceof Vector4) viewport.copy(x)

--- a/packages/three-flatland/src/flatland-resize.test.ts
+++ b/packages/three-flatland/src/flatland-resize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { Color, OrthographicCamera, Vector2, Vector4 } from 'three'
+import { OrthographicCamera, Vector2, Vector4, type Color } from 'three'
 import { pass, vec4 } from 'three/tsl'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'

--- a/packages/three-flatland/src/lights/OcclusionPass.ts
+++ b/packages/three-flatland/src/lights/OcclusionPass.ts
@@ -211,10 +211,10 @@ export class OcclusionPass {
     this._hiddenMeshes.length = 0
     scene.traverse(this._collectAndSwap)
 
-    // Clear color/alpha are deliberately NOT restored — Flatland.render
-    // sets them per-frame immediately after the pre-pass, so round-tripping
-    // the Color4 (which isn't part of the public three type export) would
-    // add complexity without changing observable behaviour.
+    // Clear color/alpha are deliberately NOT restored here. Flatland.render
+    // captures the caller's clear state before the ECS schedule and restores
+    // it once the frame's passes are done. Clear-sensitive consumers within
+    // the same frame must still establish the state they require.
     try {
       scene.background = null
       renderer.setRenderTarget(this._rt)

--- a/packages/three-flatland/src/react/flatland-aspect.test.tsx
+++ b/packages/three-flatland/src/react/flatland-aspect.test.tsx
@@ -14,6 +14,7 @@ afterEach(() => {
   universe.reset()
 })
 
+/** Creates a headless R3F root with mutable renderer surface dimensions. */
 async function createTestRoot(width: number, height: number) {
   vi.stubGlobal('requestAnimationFrame', () => 0)
   vi.stubGlobal('cancelAnimationFrame', () => {})
@@ -53,6 +54,7 @@ async function createTestRoot(width: number, height: number) {
   return { renderer, root, surface }
 }
 
+/** Unmounts a test root inside React's asynchronous act boundary. */
 async function unmountTestRoot(root: ReturnType<typeof createRoot>): Promise<void> {
   await act(async () => {
     root.unmount()

--- a/packages/three-flatland/src/react/flatland-aspect.test.tsx
+++ b/packages/three-flatland/src/react/flatland-aspect.test.tsx
@@ -1,6 +1,6 @@
 import { act, createRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Color, OrthographicCamera, Vector2, Vector4 } from 'three'
+import { OrthographicCamera, Vector2, Vector4, type Color } from 'three'
 import { createRoot, extend } from '@react-three/fiber/webgpu'
 import { universe } from 'koota'
 import type { WebGPURenderer } from 'three/webgpu'

--- a/packages/three-flatland/src/react/flatland-aspect.test.tsx
+++ b/packages/three-flatland/src/react/flatland-aspect.test.tsx
@@ -1,6 +1,6 @@
 import { act, createRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { OrthographicCamera, Vector2, Vector4 } from 'three'
+import { Color, OrthographicCamera, Vector2, Vector4 } from 'three'
 import { createRoot, extend } from '@react-three/fiber/webgpu'
 import { universe } from 'koota'
 import type { WebGPURenderer } from 'three/webgpu'
@@ -35,6 +35,8 @@ async function createTestRoot(width: number, height: number) {
     },
     setPixelRatio() {},
     getPixelRatio: () => 1,
+    getClearAlpha: () => 1,
+    getClearColor: (target: Color) => target.set(0x000000),
     getRenderTarget: () => null,
     setRenderTarget() {},
     setClearColor() {},

--- a/packages/three-flatland/src/render-target-alpha.test.ts
+++ b/packages/three-flatland/src/render-target-alpha.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Flatland } from './Flatland'
 import { createPassEffect } from './pipeline/PassEffect'
 
+/** Creates a minimal manual RenderPipeline whose render hook is observable. */
 function createPipeline(render = vi.fn()): RenderPipeline {
   return {
     outputNode: vec4(0, 0, 0, 0),
@@ -23,6 +24,7 @@ function createPipeline(render = vi.fn()): RenderPipeline {
   } as unknown as RenderPipeline
 }
 
+/** Creates the sizing surface Flatland requires for a manual scene pass. */
 function createPassNode(): PassNode {
   return {
     setSize: vi.fn(),
@@ -30,6 +32,7 @@ function createPassNode(): PassNode {
   } as unknown as PassNode
 }
 
+/** Creates a stateful renderer double that models clear and target restoration. */
 function createRenderer(
   initialTarget: RenderTarget | null = null,
   initialClearColor: ColorRepresentation = '#123456',
@@ -69,11 +72,13 @@ function createRenderer(
   return renderer
 }
 
+/** Asserts the renderer's live clear state without exposing the test double. */
 function expectClearState(renderer: WebGPURenderer, color: string, alpha: number): void {
   expect(renderer.getClearColor(new Color()).getHexString()).toBe(color)
   expect(renderer.getClearAlpha()).toBe(alpha)
 }
 
+/** Installs a caller-owned pipeline and its paired scene pass. */
 function installManualPipeline(flatland: Flatland, render = vi.fn()): RenderPipeline {
   const pipeline = createPipeline(render)
   flatland.setRenderPipeline(pipeline, createPassNode())
@@ -86,6 +91,7 @@ const IdentityPass = createPassEffect({
   pass: () => (input) => input,
 })
 
+/** Materializes Flatland's automatic pipeline from one identity effect. */
 function installAutomaticPipeline(flatland: Flatland, renderer: WebGPURenderer): RenderPipeline {
   const effect = new IdentityPass()
   flatland.addPass(effect)

--- a/packages/three-flatland/src/render-target-alpha.test.ts
+++ b/packages/three-flatland/src/render-target-alpha.test.ts
@@ -8,8 +8,7 @@ import {
   type ColorRepresentation,
   type Scene,
 } from 'three'
-import type { RenderPipeline, WebGPURenderer } from 'three/webgpu'
-import type PassNode from 'three/src/nodes/display/PassNode.js'
+import type { PassNode, RenderPipeline, WebGPURenderer } from 'three/webgpu'
 import { pass as scenePass, vec4 } from 'three/tsl'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Flatland } from './Flatland'

--- a/packages/three-flatland/src/render-target-alpha.test.ts
+++ b/packages/three-flatland/src/render-target-alpha.test.ts
@@ -1,0 +1,299 @@
+import {
+  Color,
+  RenderTarget,
+  Texture,
+  Vector2,
+  Vector4,
+  type Camera,
+  type ColorRepresentation,
+  type Scene,
+} from 'three'
+import type { RenderPipeline, WebGPURenderer } from 'three/webgpu'
+import type PassNode from 'three/src/nodes/display/PassNode.js'
+import { pass as scenePass, vec4 } from 'three/tsl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Flatland } from './Flatland'
+import { createPassEffect } from './pipeline/PassEffect'
+
+function createPipeline(render = vi.fn()): RenderPipeline {
+  return {
+    outputNode: vec4(0, 0, 0, 0),
+    outputColorTransform: true,
+    needsUpdate: false,
+    render,
+  } as unknown as RenderPipeline
+}
+
+function createPassNode(): PassNode {
+  return {
+    setSize: vi.fn(),
+    setViewport: vi.fn(),
+  } as unknown as PassNode
+}
+
+function createRenderer(
+  initialTarget: RenderTarget | null = null,
+  initialClearColor: ColorRepresentation = '#123456',
+  initialClearAlpha = 0.75
+) {
+  let currentTarget = initialTarget
+  const clearColor = new Color(initialClearColor)
+  let clearAlpha = initialClearAlpha
+  const viewport = Object.assign(new Vector4(0, 0, 64, 64), { minDepth: 0, maxDepth: 1 })
+  const renderer = {
+    _canvasTarget: { _viewport: viewport },
+    autoClear: true,
+    contextNode: null,
+    opaque: true,
+    transparent: true,
+    getClearAlpha: () => clearAlpha,
+    getClearColor: (target: Color) => target.copy(clearColor),
+    getPixelRatio: () => 1,
+    getMRT: () => null,
+    getOutputRenderTarget: () => null,
+    getRenderTarget: () => currentTarget,
+    getViewport: (target: Vector4) => target.copy(viewport),
+    getSize: (target: Vector2) => target.set(64, 64),
+    getDrawingBufferSize: (target: Vector2) => target.set(64, 64),
+    render: vi.fn((_scene: Scene, _camera: Camera) => undefined),
+    setClearColor: vi.fn((value: ColorRepresentation, alpha = 1) => {
+      clearColor.set(value)
+      clearAlpha = alpha
+    }),
+    setMRT: vi.fn(),
+    setRenderTarget: vi.fn((target: RenderTarget | null) => {
+      currentTarget = target
+    }),
+    setViewport: vi.fn(),
+  } as unknown as WebGPURenderer
+
+  return renderer
+}
+
+function expectClearState(renderer: WebGPURenderer, color: string, alpha: number): void {
+  expect(renderer.getClearColor(new Color()).getHexString()).toBe(color)
+  expect(renderer.getClearAlpha()).toBe(alpha)
+}
+
+function installManualPipeline(flatland: Flatland, render = vi.fn()): RenderPipeline {
+  const pipeline = createPipeline(render)
+  flatland.setRenderPipeline(pipeline, createPassNode())
+  return pipeline
+}
+
+const IdentityPass = createPassEffect({
+  name: 'renderTargetAlphaIdentity',
+  schema: {},
+  pass: () => (input) => input,
+})
+
+function installAutomaticPipeline(flatland: Flatland, renderer: WebGPURenderer): RenderPipeline {
+  const effect = new IdentityPass()
+  flatland.addPass(effect)
+
+  const ensurePipeline = Reflect.get(flatland, '_ensureRenderPipeline') as (renderer: WebGPURenderer) => void
+  ensurePipeline.call(flatland, renderer)
+
+  const pipeline = flatland.renderPipeline!
+  pipeline.render = vi.fn()
+  return pipeline
+}
+
+describe('Flatland render-target alpha', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the same transparent clear state for direct rendering', () => {
+    const target = new RenderTarget(64, 64)
+    const flatland = new Flatland({ renderTarget: target, clearColor: '#050812', clearAlpha: 0 })
+    const renderer = createRenderer()
+    renderer.autoClear = false
+
+    flatland.render(renderer)
+
+    expect(flatland.scene.background).toBeNull()
+    expect(renderer.setClearColor).toHaveBeenCalledWith(0x000000, 0)
+    expect(renderer.autoClear).toBe(false)
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('uses the same transparent clear state for a manual pipeline', () => {
+    const target = new RenderTarget(64, 64)
+    const flatland = new Flatland({ renderTarget: target, clearColor: '#050812', clearAlpha: 0 })
+    const renderer = createRenderer()
+    renderer.autoClear = false
+    const render = vi.fn(() => {
+      expect(flatland.scene.background).toBeNull()
+      expect(renderer.autoClear).toBe(false)
+      expect(renderer.setClearColor).toHaveBeenCalledWith(0x000000, 0)
+    })
+    installManualPipeline(flatland, render)
+
+    flatland.render(renderer)
+
+    expect(render).toHaveBeenCalledOnce()
+    expect(renderer.autoClear).toBe(false)
+  })
+
+  it('preserves transparent clear state for an automatic pipeline', () => {
+    const target = new RenderTarget(64, 64)
+    const flatland = new Flatland({ renderTarget: target, clearColor: '#050812', clearAlpha: 0 })
+    const renderer = createRenderer()
+    const pipeline = installAutomaticPipeline(flatland, renderer)
+    pipeline.render = vi.fn(() => {
+      expect(flatland.scene.background).toBeNull()
+      expect(renderer.autoClear).toBe(true)
+      expectClearState(renderer, '000000', 0)
+    })
+
+    flatland.render(renderer)
+
+    expect(flatland.scene.background).toBeNull()
+    expect(renderer.setClearColor).toHaveBeenCalledWith(0x000000, 0)
+    expect(pipeline.render).toHaveBeenCalledOnce()
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('uses direct rendering after an automatic pipeline is disabled', () => {
+    const flatland = new Flatland({ clearColor: '#050812', clearAlpha: 0 })
+    const renderer = createRenderer()
+    const pipeline = installAutomaticPipeline(flatland, renderer)
+    flatland.clearPasses()
+
+    flatland.render(renderer)
+
+    expect(pipeline.render).not.toHaveBeenCalled()
+    expect(renderer.render).toHaveBeenCalledOnce()
+    expect(flatland.scene.background).toBeNull()
+    expect(renderer.setClearColor).toHaveBeenCalledWith(0x000000, 0)
+  })
+
+  it('preserves fractional clear alpha through the pipeline setup', () => {
+    const flatland = new Flatland({ clearColor: '#050812', clearAlpha: 0.5 })
+    const renderer = createRenderer()
+    installManualPipeline(flatland)
+
+    flatland.render(renderer)
+
+    expect(flatland.scene.background).toBeNull()
+    expect(renderer.setClearColor).toHaveBeenCalledWith(flatland.clearColor, 0.5)
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('uses the authored color for an opaque pipeline background', () => {
+    const flatland = new Flatland({ clearColor: '#050812', clearAlpha: 1 })
+    const renderer = createRenderer()
+    installManualPipeline(flatland)
+
+    flatland.render(renderer)
+
+    expect(flatland.scene.background).toBe(flatland.clearColor)
+    const [clearColor, clearAlpha] = vi.mocked(renderer.setClearColor).mock.calls[0]!
+    expect(clearColor).toBeInstanceOf(Color)
+    expect((clearColor as Color).getHexString()).toBe('050812')
+    expect(clearAlpha).toBe(1)
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('uses an opaque authored clear for a pipeline when autoClear is disabled', () => {
+    const flatland = new Flatland({ autoClear: false, clearColor: '#050812', clearAlpha: 1 })
+    const renderer = createRenderer()
+    renderer.autoClear = false
+    const render = vi.fn(() => {
+      expect(renderer.autoClear).toBe(false)
+      expect(flatland.scene.background).toBe(flatland.clearColor)
+      expectClearState(renderer, '050812', 1)
+    })
+    installManualPipeline(flatland, render)
+
+    flatland.render(renderer)
+
+    expect(render).toHaveBeenCalledOnce()
+    expect(renderer.autoClear).toBe(false)
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('preserves a user-authored pipeline background', () => {
+    const flatland = new Flatland({ clearAlpha: 0 })
+    const renderer = createRenderer()
+    const background = new Texture()
+    flatland.scene.background = background
+    installManualPipeline(flatland, () => {
+      expect(flatland.scene.background).toBe(background)
+    })
+
+    flatland.render(renderer)
+
+    expect(flatland.scene.background).toBe(background)
+  })
+
+  it.each([0, 1])('does not clear direct rendering when autoClear is disabled (clearAlpha=%s)', (clearAlpha) => {
+    const flatland = new Flatland({ autoClear: false, clearColor: '#050812', clearAlpha })
+    const renderer = createRenderer()
+    vi.mocked(renderer.render).mockImplementation(() => {
+      expect(renderer.autoClear).toBe(false)
+      expect(renderer.setClearColor).not.toHaveBeenCalled()
+      expectClearState(renderer, '123456', 0.75)
+      expect(flatland.scene.background).toBeNull()
+    })
+
+    flatland.render(renderer)
+
+    expect(renderer.setClearColor).toHaveBeenCalledOnce()
+    expect(renderer.autoClear).toBe(true)
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('seeds a real PassNode clear when autoClear is disabled', () => {
+    const target = new RenderTarget(64, 64)
+    const flatland = new Flatland({ renderTarget: target, autoClear: false, clearAlpha: 0 })
+    const renderer = createRenderer(null, '#ff0000', 1)
+    const inputPass = scenePass(flatland.scene, flatland.camera)
+    vi.mocked(renderer.render).mockImplementation(() => {
+      expect(renderer.autoClear).toBe(true)
+      expectClearState(renderer, '000000', 0)
+    })
+    installManualPipeline(flatland, () => {
+      const frame = { renderer } as unknown as Parameters<PassNode['updateBefore']>[0]
+      inputPass.updateBefore(frame)
+    })
+
+    flatland.render(renderer)
+
+    expect(renderer.render).toHaveBeenCalledOnce()
+    expect(renderer.autoClear).toBe(true)
+    expectClearState(renderer, 'ff0000', 1)
+  })
+
+  it('captures caller clear state before internal pre-passes run', () => {
+    const flatland = new Flatland({ autoClear: false })
+    const renderer = createRenderer(null, '#123456', 0.75)
+    vi.spyOn(flatland.scene, 'updateMatrixWorld').mockImplementation(() => {
+      renderer.setClearColor('#abcdef', 1)
+    })
+    vi.mocked(renderer.render).mockImplementation(() => {
+      expectClearState(renderer, 'abcdef', 1)
+    })
+
+    flatland.render(renderer)
+
+    expectClearState(renderer, '123456', 0.75)
+  })
+
+  it('restores renderer state when the pipeline throws', () => {
+    const previousTarget = new RenderTarget(8, 8)
+    const target = new RenderTarget(64, 64)
+    const flatland = new Flatland({ renderTarget: target, clearAlpha: 0 })
+    const renderer = createRenderer(previousTarget)
+    renderer.autoClear = false
+    installManualPipeline(flatland, () => {
+      throw new Error('pipeline failed')
+    })
+
+    expect(() => flatland.render(renderer)).toThrow('pipeline failed')
+    expect(renderer.autoClear).toBe(false)
+    expect(renderer.getRenderTarget()).toBe(previousTarget)
+    expectClearState(renderer, '123456', 0.75)
+  })
+})

--- a/packages/three-flatland/src/render-target-color.test.ts
+++ b/packages/three-flatland/src/render-target-color.test.ts
@@ -1,4 +1,5 @@
 import {
+  Color,
   HalfFloatType,
   LinearSRGBColorSpace,
   RenderTarget,
@@ -7,6 +8,7 @@ import {
   Vector4,
   type Scene,
   type Camera,
+  type ColorRepresentation,
 } from 'three'
 import type { RenderPipeline, WebGPURenderer } from 'three/webgpu'
 import type PassNode from 'three/src/nodes/display/PassNode.js'
@@ -42,6 +44,8 @@ function createPassNode() {
 
 function createRenderer(initialTarget: RenderTarget | null = null, width = 640, height = 360) {
   let currentTarget = initialTarget
+  const clearColor = new Color('#123456')
+  let clearAlpha = 0.75
   const viewport = Object.assign(new Vector4(0, 0, width, height), { minDepth: 0.2, maxDepth: 0.8 })
   const setRenderTarget = vi.fn((target: RenderTarget | null) => {
     currentTarget = target
@@ -50,13 +54,18 @@ function createRenderer(initialTarget: RenderTarget | null = null, width = 640, 
   const renderer = {
     _canvasTarget: { _viewport: viewport },
     autoClear: true,
+    getClearAlpha: () => clearAlpha,
+    getClearColor: (target: Color) => target.copy(clearColor),
     getPixelRatio: () => 1,
     getRenderTarget: () => currentTarget,
     getViewport: (target: Vector4) => target.copy(viewport),
     getSize: (target: Vector2) => target.set(width, height),
     getDrawingBufferSize: (target: Vector2) => target.set(width, height),
     render: vi.fn((_scene: Scene, _camera: Camera) => undefined),
-    setClearColor: vi.fn(),
+    setClearColor: vi.fn((value: ColorRepresentation, alpha = 1) => {
+      clearColor.set(value)
+      clearAlpha = alpha
+    }),
     setRenderTarget,
     setViewport: (x: number | Vector4, y?: number, width?: number, height?: number, minDepth = 0, maxDepth = 1) => {
       if (x instanceof Vector4) viewport.copy(x)

--- a/packages/three-flatland/src/render-target-color.test.ts
+++ b/packages/three-flatland/src/render-target-color.test.ts
@@ -42,6 +42,7 @@ function createPassNode() {
   } as unknown as PassNode
 }
 
+/** Creates a stateful renderer double for color-space and viewport tests. */
 function createRenderer(initialTarget: RenderTarget | null = null, width = 640, height = 360) {
   let currentTarget = initialTarget
   const clearColor = new Color('#123456')

--- a/packages/three-flatland/src/shadow-pipeline.test.ts
+++ b/packages/three-flatland/src/shadow-pipeline.test.ts
@@ -27,6 +27,7 @@ function getPipeline(flatland: Flatland) {
   return entities.length > 0 ? entities[0]!.get(ShadowPipeline) : null
 }
 
+/** Creates the minimal renderer surface needed to advance shadow systems. */
 function mockRenderer(width: number, height: number) {
   return {
     getSize: (target: Vector2) => target.set(width, height),

--- a/packages/three-flatland/src/shadow-pipeline.test.ts
+++ b/packages/three-flatland/src/shadow-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { RenderTarget, Vector2 } from 'three'
+import { Color, RenderTarget, Vector2 } from 'three'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'
 import { createLightEffect } from './lights/LightEffect'
@@ -32,6 +32,8 @@ function mockRenderer(width: number, height: number) {
     getSize: (target: Vector2) => target.set(width, height),
     getDrawingBufferSize: (target: Vector2) => target.set(width, height),
     getPixelRatio: () => 1,
+    getClearAlpha: () => 1,
+    getClearColor: (target: Color) => target.set(0x000000),
     getRenderTarget: () => null,
     setRenderTarget: () => {},
     setClearColor: () => {},

--- a/packages/three-flatland/src/shadow-pipeline.test.ts
+++ b/packages/three-flatland/src/shadow-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { Color, RenderTarget, Vector2 } from 'three'
+import { RenderTarget, Vector2, type Color } from 'three'
 import type { WebGPURenderer } from 'three/webgpu'
 import { Flatland } from './Flatland'
 import { createLightEffect } from './lights/LightEffect'


### PR DESCRIPTION
Closes #223

## Stack status

The prerequisite PRs #224, #225, and #226 are merged. This PR is rebased directly on current `main`, so GitHub activates `Closes #223`. `git range-diff` verified that rebasing changed no patch content across the four render-pipeline commits.

## What changed

- apply `clearColor` / `clearAlpha` consistently to direct, automatic, and manually supplied render pipelines, including transparent and fractional-alpha offscreen targets
- seed Three's real `PassNode` private target even when `Flatland.autoClear` is disabled, while preserving the host renderer's final-output compositing choice
- restore renderer clear state, render target, viewport, `autoClear`, and devtools frame balance on success and exceptions
- preserve explicit pipeline `Scene.background` values and retain direct rendering's existing managed-background contract
- add regression coverage for transparent, fractional, opaque, disabled-pipeline, pre-pass mutation, host-background, and exception paths
- make Nx build workspace dependencies before their consumers' tests, fixing the reproduced `three-flatland/react` build/test race

## Proof

- real WebGPU readback: transparent pipeline alpha `0`, fractional pipeline alpha `128`, opaque `autoClear: false` target content retained
- `pnpm test` — 45 tasks across 25 projects, zero-cache pass; core: 88 files / 1,049 tests / no type errors
- `pnpm typecheck` — 51 projects passed
- `pnpm build` — 49 projects plus docs passed
- `pnpm lint`
- `pnpm format:check`
- Claude Opus high-effort adversarial review, including Three r185 `PassNode`, background force-clear, state restoration, and Nx task-graph tracing; every finding and informational note addressed
- CodeRabbit's restoration and public-import findings were fixed, its follow-up produced no further comments, and all review threads are resolved
- c0der3view's requested real WebGPU verification was completed and recorded on the PR

Changesets are generated from the Conventional Commit history by CI; no hand-written changeset is included.
