### PR TITLE
docs: 2026-08-27 audit report and hit-test tab-sync fixes

### DIFF
--- a/docs/src/content/docs/examples/hit-test.mdx
+++ b/docs/src/content/docs/examples/hit-test.mdx
@@ -154,13 +154,13 @@ The sidecar is **optional at runtime**. If the loader cannot find it — or the 
 Pass `alpha: true` to the loader. The loader probes for the `sprites.alpha.png` sibling, loads it if the hash matches, and attaches the result to `sheet.alphaMap`.
 
 <Tabs syncKey="framework">
-<TabItem label="Three.js">
+<TabItem label="Three.js" icon="simple-icons:threedotjs">
 ```typescript
 const sheet = await SpriteSheetLoader.load('/sprites/sprites.json', { alpha: true })
 // sheet.alphaMap is now populated (AlphaMap instance)
 ```
 </TabItem>
-<TabItem label="React">
+<TabItem label="React" icon="simple-icons:react">
 ```tsx
 const sheet = useLoader(SpriteSheetLoader, '/sprites/sprites.json', (loader) => {
   loader.alpha = true
@@ -175,7 +175,7 @@ const sheet = useLoader(SpriteSheetLoader, '/sprites/sprites.json', (loader) => 
 For a `Sprite2D`, assign the map and switch the mode. For `AnimatedSprite2D`, the constructor and the `spriteSheet` setter both adopt `sheet.alphaMap` automatically — you only need to set `hitTestMode`.
 
 <Tabs syncKey="framework">
-<TabItem label="Three.js">
+<TabItem label="Three.js" icon="simple-icons:threedotjs">
 ```typescript
 // Sprite2D — assign the map, then switch the mode
 const sprite = new Sprite2D({ texture: sheet.texture, frame: sheet.getFrame('knight_idle') })
@@ -189,7 +189,7 @@ knight.hitTestMode = 'alpha'
 // knight.alphaThreshold defaults to 0.5
 ```
 </TabItem>
-<TabItem label="React">
+<TabItem label="React" icon="simple-icons:react">
 ```tsx
 // AnimatedSprite2D adopts sheet.alphaMap via the spriteSheet prop
 <animatedSprite2D

--- a/docs/src/content/docs/examples/hit-test.mdx
+++ b/docs/src/content/docs/examples/hit-test.mdx
@@ -153,7 +153,7 @@ The sidecar is **optional at runtime**. If the loader cannot find it — or the 
 
 Pass `alpha: true` to the loader. The loader probes for the `sprites.alpha.png` sibling, loads it if the hash matches, and attaches the result to `sheet.alphaMap`.
 
-<Tabs>
+<Tabs syncKey="framework">
 <TabItem label="Three.js">
 ```typescript
 const sheet = await SpriteSheetLoader.load('/sprites/sprites.json', { alpha: true })
@@ -174,19 +174,17 @@ const sheet = useLoader(SpriteSheetLoader, '/sprites/sprites.json', (loader) => 
 
 For a `Sprite2D`, assign the map and switch the mode. For `AnimatedSprite2D`, the constructor and the `spriteSheet` setter both adopt `sheet.alphaMap` automatically — you only need to set `hitTestMode`.
 
-<Tabs>
-<TabItem label="Three.js (Sprite2D)">
+<Tabs syncKey="framework">
+<TabItem label="Three.js">
 ```typescript
+// Sprite2D — assign the map, then switch the mode
 const sprite = new Sprite2D({ texture: sheet.texture, frame: sheet.getFrame('knight_idle') })
 sprite.alphaMap = sheet.alphaMap        // wire up the CPU map
 sprite.hitTestMode = 'alpha'            // enable pixel-perfect rejection
-sprite.alphaThreshold = 0.5            // optional — default is 0.5 (0–1)
-```
-</TabItem>
-<TabItem label="Three.js (AnimatedSprite2D)">
-```typescript
+sprite.alphaThreshold = 0.5             // optional — default is 0.5 (0–1)
+
+// AnimatedSprite2D — alphaMap is adopted automatically from sheet.alphaMap
 const knight = new AnimatedSprite2D({ spriteSheet: sheet, animation: 'idle' })
-// alphaMap is adopted automatically from sheet.alphaMap
 knight.hitTestMode = 'alpha'
 // knight.alphaThreshold defaults to 0.5
 ```

--- a/planning/2026-08-27-docs-audit-report.md
+++ b/planning/2026-08-27-docs-audit-report.md
@@ -1,0 +1,107 @@
+# Documentation Audit Report
+
+**Date:** 2026-08-27
+**Pages audited:** 41 prose (`docs/src/content/docs/**/*.mdx`, excluding generated `api/`)
+**Scope:** Accuracy + Engagement + LLM Docs + JSDoc
+**Method:** repo `documentation` skill (`audit.md` four layers, `diataxis.md` type rules)
+**Predecessor:** the 2026-05-24 audit, tracked as epic #96
+
+## Top-Level Findings
+
+Six pages have been added since the 2026-05-24 audit and had **never been audited**:
+
+| Added | Page |
+| --- | --- |
+| 2026-06-12 | `examples/hit-test.mdx` |
+| 2026-06-22 | `guides/hit-testing.mdx` |
+| 2026-07-01 | `guides/devtools-architecture.mdx` |
+| 2026-08-20 | `examples/hierarchy-clipping.mdx` |
+| 2026-08-22 | `guides/pixel-perfect-rendering.mdx` |
+| 2026-08-23 | `guides/private-ecs-migration.mdx` |
+
+The eleven epic-#96 children (#101–#108, #98, #100, #104) still describe the *older* pages; nothing in
+the epic covers these six.
+
+## Layer 1 — Accuracy
+
+| Check | Result |
+| --- | --- |
+| `syncKey` on every code-sample `Tabs` block | **2 defects, fixed** — `examples/hit-test.mdx:156,177` |
+| Tab labels match the site convention (`Three.js` / `React`) | **2 defects, fixed** — `Three.js (Sprite2D)` / `Three.js (AnimatedSprite2D)` were one-off labels that break framework sync (site uses `Three.js` 57x, `React` 58x) |
+| R3F imports from `@react-three/fiber/webgpu` | pass — zero bare `@react-three/fiber` imports |
+| Relative cross-links resolve | pass — **158/158**, verified against route semantics (`trailingSlash: always`, so each page is a route directory) |
+| Malformed anchors (`../page#frag/`) | pass — none |
+| Version-pin consistency | pass — three.js `^0.185.1` (10 mentions, matches catalog), R3F `10.0.0-alpha.3` (12 mentions) |
+
+## Layer 2 — Engagement
+
+### Type purity (criterion 5)
+
+`examples/hit-test.mdx` — declared **Tutorial** (Examples bucket). **Fails.**
+`## Two paths to the same raycaster` is alternatives and `### Roadmap — not yet supported` is
+neither guided nor a lesson; both are Tutorial must-not content. Split candidate.
+
+`examples/hit-test.mdx` vs `guides/hit-testing.mdx` — **content duplication.** Near-identical
+heading sets: pointer events, hit-test modes, alpha mode, tile picking, hover under a moving camera.
+The Tutorial and the How-to are covering the same ground rather than cross-linking.
+
+`guides/pixel-perfect-rendering.mdx` — declared **How-to**. Minor: `## Limitations` is Explanation.
+
+`guides/private-ecs-migration.mdx` — declared **How-to**. **Passes.** Imperative task headings
+throughout; the newest page is the most type-pure.
+
+`guides/devtools-architecture.mdx` — **no finding.** The `guides/` path prefix is a file convention,
+not the IA bucket; `astro.config.mjs` places it in the **Concepts** sidebar group, where its
+explanatory content is correct.
+
+### Visual coverage (criterion 2)
+
+8 of 41 pages carry no visual (checked against the real component inventory in
+`docs/src/components/`, not a guessed list):
+
+| Page | Note |
+| --- | --- |
+| `getting-started/quick-start.mdx` | the canonical Tutorial shows no picture of the result |
+| `guides/pixel-perfect-rendering.mdx` | strong `<Compare>` candidate — pixel-perfect vs fractional is a seam-slider case |
+| `guides/shadows-setup.mdx` | How-to, no visual |
+| `guides/private-ecs-migration.mdx` | migration How-to, low priority |
+| `examples/index.mdx`, `showcases/index.mdx` | gallery/index pages |
+| `getting-started/installation.mdx`, `llm-prompts.mdx` | Reference/prompt pages, visual not applicable |
+
+### Signature callout (criterion 4)
+
+29 of 41 pages carry no `:::tip[Performance note]`. The skill treats this as soft — only a
+perf-relevant page with none is suspect. Not itemised as findings here.
+
+## Layer 3 — LLM Docs
+
+**Pass.** `llms.txt` / `llms-full.txt` are generated at build time by `starlight-llms-txt`
+(`docs/astro.config.mjs`), not hand-maintained, so the audit's drift concern does not apply.
+
+## Layer 4 — JSDoc
+
+`SpriteGroup.stats` (`packages/three-flatland/src/pipeline/SpriteGroup.ts:1058`) points readers at a
+`Flatland.stats` that does not exist. Tracked as #99; PR #122 proposes redirecting it to
+`flatland.spriteGroup.stats`, but that accessor returns `RenderStats` — `spriteCount`, `batchCount`,
+`visibleSprites` — with **no `drawCalls`**, which is the value the comment is about. `RenderStats`'s
+own docblock names the correct destination: the debug bus `stats` feature in the
+`@three-flatland/debug` subpath. The fix is a redirect there, not to `spriteGroup.stats`.
+
+## Cross-Cutting Recommendations
+
+1. Add "source TSDoc audit for `three-flatland` core" as a child of #96 — the epic's API-reference
+   children (#100, #104) are scoped to devtools pages and guide tables, so #99 has no owner.
+2. Split `examples/hit-test.mdx` per the `diataxis.md` recipe, and de-duplicate it against
+   `guides/hit-testing.mdx`.
+3. Close #98 if superseded — `create-three-flatland` shipped in #203 on 2026-07-20.
+4. #97 still blocks the prose half of #96. Its first acceptance criterion is already met by
+   `~/.claude/skills/voice-register/` (anchored on a 229k interview corpus); what remains is wiring
+   `marketing-voice` to it with graceful degradation, since that skill lives outside the repo.
+
+## Environment note (not a docs defect)
+
+The docs build failed locally on an untouched tree until the worktree was repaired: `three` and
+`@types/three` were at 0.183.1 against a lockfile pinning 0.185.1/0.185.4, `astro` was 6.4.8 against
+7.1.3, and `packages/three-flatland/dist/` was a 2026-07-20 build that still imported `koota` at
+runtime. `pnpm install --frozen-lockfile` plus `nx build three-flatland` cleared it.
+Post-repair: **503 pages, exit 0.**

--- a/planning/2026-08-27-docs-audit-report.md
+++ b/planning/2026-08-27-docs-audit-report.md
@@ -28,7 +28,7 @@ the epic covers these six.
 | --- | --- |
 | `syncKey` on every code-sample `Tabs` block | **2 defects, fixed** — `examples/hit-test.mdx:156,177` |
 | Tab labels match the site convention (`Three.js` / `React`) | **2 defects, fixed** — `Three.js (Sprite2D)` / `Three.js (AnimatedSprite2D)` were one-off labels that break framework sync (site uses `Three.js` 57x, `React` 58x) |
-| R3F imports from `@react-three/fiber/webgpu` | pass — zero bare `@react-three/fiber` imports |
+| R3F imports from `@react-three/fiber/webgpu` | pass — zero `import` statements use bare `@react-three/fiber`. Prose and install commands mention the bare package 12 times, correctly, since that is the peer-dependency name |
 | Relative cross-links resolve | pass — **158/158**, verified against route semantics (`trailingSlash: always`, so each page is a route directory) |
 | Malformed anchors (`../page#frag/`) | pass — none |
 | Version-pin consistency | pass — three.js `^0.185.1` (10 mentions, matches catalog), R3F `10.0.0-alpha.3` (12 mentions) |


### PR DESCRIPTION
Stack 2 of 2. **Base: `docs/scaffolder-and-readme-drift` (#239)** — review that first; this branch is based on its tip, per the repo's stacked-PR convention in `planning/internal-ecs/results/stack-readiness.md`.

Re-audit of all 41 prose pages with the repo's `documentation` skill (four layers) and its `diataxis.md` type rules. Report lands at `planning/2026-08-27-docs-audit-report.md`.

## Why now

Six pages were added after the 2026-05-24 audit and had **never been audited**. The eleven epic-#96 children describe the *older* pages; nothing covered these.

| Added | Page |
| --- | --- |
| 2026-06-12 | `examples/hit-test.mdx` |
| 2026-06-22 | `guides/hit-testing.mdx` |
| 2026-07-01 | `guides/devtools-architecture.mdx` |
| 2026-08-20 | `examples/hierarchy-clipping.mdx` |
| 2026-08-22 | `guides/pixel-perfect-rendering.mdx` |
| 2026-08-23 | `guides/private-ecs-migration.mdx` |

## Fixed here

Both `Tabs` blocks in `examples/hit-test.mdx` were missing `syncKey`, so framework choice did not persist across those samples. One block also carried the one-off labels `Three.js (Sprite2D)` and `Three.js (AnimatedSprite2D)` — `syncKey` groups by label, and the site uses `Three.js` 57× / `React` 58×, so those variants could never join the framework group. Merged the two Three.js tabs into one canonical tab and tagged both blocks.

After the fix, every `Tabs` block site-wide carries a `syncKey`.

## Layer 1 results

| Check | Result |
| --- | --- |
| `syncKey` on code-sample tabs | 2 defects → **fixed** |
| Tab labels match site convention | 2 defects → **fixed** |
| R3F imports use `/webgpu` | pass |
| Relative cross-links resolve | pass — **158/158** |
| Malformed anchors | pass |
| Version pins consistent | pass — three `^0.185.1`, R3F `10.0.0-alpha.3` |

## Findings left open (not fixed here)

- **`examples/hit-test.mdx` fails type purity.** Declared Tutorial, but `## Two paths to the same raycaster` is alternatives and `### Roadmap — not yet supported` is neither guided nor a lesson. Split candidate — deliberately not attempted in the same PR as mechanical fixes.
- **`examples/hit-test.mdx` duplicates `guides/hit-testing.mdx`** — near-identical heading sets across a Tutorial and a How-to.
- **8 of 41 pages carry no visual.** `quick-start.mdx` is the notable one — the canonical Tutorial shows no picture of the result. `pixel-perfect-rendering.mdx` is a strong `<Compare>` candidate.
- **#99 has no owner.** `SpriteGroup.stats` cites a nonexistent `Flatland.stats`. PR #122 redirects it to `flatland.spriteGroup.stats`, but that returns `RenderStats` (`spriteCount`, `batchCount`, `visibleSprites`) with **no `drawCalls`** — the value the comment is about. The correct destination is the debug bus `stats` feature. Recommend closing #122 and adding a TSDoc-audit child to #96.

## Two findings I retracted

Recorded in the report so they are not re-raised:

- `guides/devtools-architecture.mdx` is **correctly** bucketed. The `guides/` path prefix is a file convention, not the IA bucket — `astro.config.mjs` places it in the **Concepts** group where its explanatory content belongs.
- The visual gap is **8 of 41, not 24**. My first pass used a guessed component list; measured against the real inventory in `docs/src/components/` (`<Diagram>`, `<HeroShader>`, `<FeatureCard>`, …) most pages do carry a visual.

## Verification

- `pnpm --filter=docs build` — exit 0, **503 pages**
- 158/158 relative cross-links resolve, checked against Starlight route semantics (`trailingSlash: always` makes each page a route directory)

No changeset: `docs/` and `planning/` are unpublished.
