### PR TITLE
docs(voice): wire marketing-voice to the author core voice and add anti-slop

### DIFF
--- a/.claude/skills/marketing-voice/SKILL.md
+++ b/.claude/skills/marketing-voice/SKILL.md
@@ -27,6 +27,35 @@ what belongs on it, and the audit). When writing or auditing a docs page, use
 both: `documentation` decides the page's type and contents, this skill decides
 how it reads.
 
+**REQUIRED SUB-FILE: `anti-slop.md`** — the banned-pattern sections below cover the
+*marketing* tells. `anti-slop.md` covers what survives that filter and still reads
+as machine-written: metaphor discipline, sentence complexity, rhythm, and the
+vocabulary substitutions. Read it before drafting, not after.
+
+## Voice precedence
+
+Three layers, applied in this order. A lower layer never overrides a higher one.
+
+1. **Author core voice** — who is talking. Sourced from the author's home-dir
+   `voice-register` skill (`~/.claude/skills/voice-register/`), which is distilled
+   from real writing samples rather than invented. `voice-samples.md` holds the
+   anchors; `composition-craft.md` holds the how-to-write laws; `scorers.md` holds
+   the pass/fail rubric.
+2. **Surface register** — how hot. The calm and dialed-up registers below, chosen
+   by surface. This decides temperature, never identity.
+3. **Anti-trope rules** — what never ships. The banned patterns below plus
+   `anti-slop.md`. These are subtractive and apply to every register.
+
+When layer 1 and layer 2 disagree on a sentence, layer 1 wins: the register is a
+dial on the author's voice, not a different writer.
+
+**This dependency is one-directional and optional.** `voice-register` lives outside
+this repo and knows nothing about it. If the home-dir skill is absent — a fresh
+machine, CI, a contributor who is not the author — this skill still works on its
+own: layers 2 and 3 are fully self-contained. Check for the file, use it when it is
+there, and do not block on it. Never copy its contents into this repo; it is the
+author's personal corpus, and a stale duplicate is worse than no copy.
+
 ## The voice in one line
 
 A senior engineer explaining a tool to another senior engineer. Direct

--- a/.claude/skills/marketing-voice/anti-slop.md
+++ b/.claude/skills/marketing-voice/anti-slop.md
@@ -1,0 +1,149 @@
+# Anti-slop
+
+Loaded by `marketing-voice`. The parent skill bans the *marketing* tells: intensifiers,
+three-beat repetition, setup-payoff aphorisms, cute closers. This file covers what survives
+that filter and still reads as machine-written.
+
+Three failure modes drive everything here. They are the ones a reader actually complains
+about, in the order they notice them.
+
+1. **Too complicated.** The sentence carries three ideas and the reader has to hold all
+   three to reach the verb.
+2. **Analogies nobody can follow.** A comparison that needs its own explanation, or that
+   maps onto nothing the reader already has.
+3. **Not a speaking voice.** No person would say this sentence out loud to another person.
+
+## The three tests
+
+Run these before any vocabulary check. They catch structure, and structure is what makes
+prose unreadable. A clean word list on a badly built paragraph is still a badly built
+paragraph.
+
+**Read it aloud.** Actually say it. If you run out of breath, the sentence is too long. If
+you stumble on a clause, the clause is in the wrong place. If it sounds like a text-to-speech
+engine, the rhythm is too even. This is the single highest-yield test in this file.
+
+**Reshuffle the paragraphs.** Swap two body paragraphs. If nothing breaks, you wrote a list
+of points, not an argument. Each paragraph should need the one before it.
+
+**Ask what is new.** Read each paragraph and name the one fact or claim it adds. If you
+cannot name it, cut the paragraph. Restating the premise in fresh words is the most common
+way machine prose fills space.
+
+## Metaphor discipline
+
+This is the rule the house voice most often breaks.
+
+A metaphor earns its place when it is **shorter than the literal explanation** and maps onto
+something the reader already knows. "A draw call is a phone call to the GPU" works: everyone
+knows phone calls are expensive to start and cheap to continue, which is the actual point.
+
+Cut the metaphor when any of these is true:
+
+- It needs a sentence of setup before it lands.
+- You extend it past one clause. Extended metaphors are where readers get lost, because they
+  start tracking the metaphor instead of the subject.
+- The reader has to know the source domain as well as you do.
+- You reach for a second metaphor to explain the first.
+- It is doing emotional work rather than explanatory work.
+
+When in doubt, state the mechanism. A reader who wanted the mechanism is served; a reader who
+wanted the picture can build their own.
+
+**One metaphor per page.** If two are competing, keep the one closer to the reader's daily work.
+
+## Complexity discipline
+
+- One idea per sentence. If you need "and" plus a subordinate clause, you have two sentences.
+- Put the subject and verb close together and near the front.
+- Do not nest. A parenthetical inside a subordinate clause is a rewrite, not a comma problem.
+- Name the actor. "The loader probes for the sidecar" beats "the sidecar is probed for."
+- Prefer the plain copula. "X is Y" beats "X serves as Y," "X represents Y," "X features Y."
+- If a sentence needs a comma to survive, it usually needs a period instead.
+
+## Sounding like a person
+
+- Vary sentence length on purpose. Mix short sentences with long ones. Uniform 15–25 word
+  sentences are the clearest machine signature after vocabulary.
+- Contractions are fine. "Doesn't" reads like speech; "does not" reads like a spec.
+- Repeat the right word instead of cycling synonyms. If "sprite" is the word, say "sprite"
+  three times. Rotating through "sprite, quad, billboard, instance" reads as thesaurus panic.
+- Have an opinion where one belongs. Relentless neutrality is itself a tell.
+- Do not sand out every irregularity. Over-polishing pushes prose *toward* the machine profile.
+
+## Structural tells
+
+| Pattern | Fix |
+| --- | --- |
+| "It's not X, it's Y" | State Y directly. One per piece, maximum. |
+| Rhetorical question as a section opener | If you know the answer, write the answer. |
+| "Let's look at…", "Let's break this down" | Start with the point. |
+| "Here's the thing.", "The catch?", "Plot twist:" | Delete the hook, keep the fact. |
+| "It's worth noting that", "Notably", "Importantly" | State the fact and let it carry itself. |
+| "could potentially", "may eventually" | Pick one hedge or neither. |
+| Three parallel clauses | Use two, or four, or a sentence. |
+| Three or more same-shape fragments in a row | Keep the one that earns it. |
+| "This is the interesting part" | If it is, the reader can tell. |
+| "In conclusion", "To summarize" | The conclusion should already read as one. |
+| Bold on every other phrase | One bolded phrase per section, or none. |
+| 5+ bullets that are bare noun phrases | Write prose, or make each a real claim. |
+| Vague attribution: "studies show" | Name the study or drop the clause. |
+
+**Em dashes.** Target zero. Hard ceiling of one per thousand words. A comma, colon, period, or
+parentheses does the job. The list-item form `- **Term** — description` is typography and does
+not count.
+
+## Vocabulary
+
+Substitute on sight. This is the shortest useful version of a much longer list; the sources
+below carry the full tables.
+
+| Instead of | Write |
+| --- | --- |
+| delve into, deep dive, unpack | look at, walk through |
+| leverage, utilize, harness | use |
+| robust, comprehensive | reliable, complete, thorough |
+| seamless, frictionless | smooth, or name what stopped breaking |
+| streamline, optimize (vague) | speed up, simplify, or give the number |
+| crucial, pivotal, paramount | important, or say what breaks without it |
+| landscape, realm, ecosystem, space | field, or name the actual thing |
+| intricate, nuanced, multifaceted | name the specific complexity |
+| showcase, boast, serve as, feature | show, has, is |
+| empower, unlock, elevate | let, enable, improve |
+| in order to | to |
+| due to the fact that | because |
+| it is important to note that | (cut) |
+
+Three or more of these in one paragraph is a rewrite, not an edit.
+
+## Never inject on a rewrite
+
+When editing someone else's prose, you may subtract and sharpen. You may not add:
+
+- First-person experience the author never claimed ("in my experience", "I've seen this before")
+- Manufactured stakes ("now more than ever", "in a world where")
+- Performed candor ("let's be honest", "real talk")
+- Fragments chopped out of whole sentences to fake rhythm
+- Any number, name, date, or mechanism the source did not contain
+
+The test: every fact in the rewrite came from the original. Cutting filler and making a vague
+claim concrete are in scope. Adding stance or invention is not.
+
+## When to rewrite instead of patch
+
+Five or more vocabulary hits, three or more structural patterns, and uniform sentence length
+together mean the structure is the problem. Patching phrases will not save it. State the core
+point in one sentence and rebuild from there.
+
+## Sources
+
+Synthesized from these public rule sets, adapted to this repo's voice. Full tables live upstream.
+
+- [conorbronsdon/avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) — the most
+  complete tiered vocabulary and pattern catalogue found; severity tiers and rewrite guardrails.
+- [hardikpandya/stop-slop](https://github.com/hardikpandya/stop-slop) — eight core rules and a
+  five-dimension score (directness, rhythm, trust, authenticity, density).
+- [jalaalrd/anti-ai-slop-writing](https://github.com/jalaalrd/anti-ai-slop-writing) — constraint
+  framing across multiple agent harnesses.
+- [realrossmanngroup/no_ai_slop_writing_rules](https://github.com/realrossmanngroup/no_ai_slop_writing_rules)
+  — 24 rules with worked wrong/right pairs.


### PR DESCRIPTION
### **User description**
Closes #97. Base `main`, independent of the docs-audit stack (#239 / #240) so it can merge on its own.

## Why this unblocks eleven issues

#96 has been gated on #97 since 2026-07-07. The hard half of #97 was already done and nobody noticed: `~/.claude/skills/voice-register/` exists and is anchored on a real interview corpus rather than invented. What was missing was the wiring.

Acceptance criteria from #97:

| Criterion | Before | Now |
| --- | --- | --- |
| Core author-voice doc in home dir, distilled from real samples | already met | unchanged |
| `marketing-voice` leans on it as its baseline | missing | **Voice precedence** section |
| One-directional, degrades gracefully if absent | missing | stated explicitly |
| Precedence note: core voice → register → anti-trope | missing | same section |

## Voice precedence

Three layers. A lower layer never overrides a higher one.

1. **Author core voice** — who is talking. From the home-dir `voice-register`.
2. **Surface register** — how hot. The existing calm / dialed-up registers. Temperature, never identity.
3. **Anti-trope rules** — what never ships. Existing banned patterns plus `anti-slop.md`.

Layer 1 wins any disagreement: the register is a dial on the author's voice, not a different writer.

The dependency is **one-directional and optional**. `voice-register` lives outside this repo and knows nothing about it. On a fresh machine, in CI, or for a contributor who is not the author, layers 2 and 3 are self-contained and the skill still works. Its contents are deliberately not copied here — a stale duplicate of a personal corpus is worse than no copy.

## anti-slop.md

The existing banned-pattern sections catch the *marketing* tells. This covers what survives that filter and still reads as machine-written.

Organised around the three failure modes readers actually report, in the order they notice them: sentences too complicated to parse, analogies that need their own explanation, and prose no person would say out loud.

The three tests come first — read aloud, reshuffle the paragraphs, ask what is new — because structure is what makes prose unreadable. The vocabulary table is last on purpose: a clean word list on a badly built paragraph is still a badly built paragraph.

Metaphor discipline gets its own section because it is the rule this repo's prose most often breaks. A metaphor earns its place when it is shorter than the literal explanation and maps onto something the reader already has. Cut it when it needs setup, when it runs past one clause, or when you reach for a second metaphor to explain the first. One per page.

## Sources

Synthesized and adapted rather than copied; full tables stay upstream and are linked in the file.

- [conorbronsdon/avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) — most complete tiered catalogue found; severity tiers and rewrite guardrails
- [hardikpandya/stop-slop](https://github.com/hardikpandya/stop-slop) — eight core rules, five-dimension score
- [jalaalrd/anti-ai-slop-writing](https://github.com/jalaalrd/anti-ai-slop-writing) — cross-harness constraint framing
- [realrossmanngroup/no_ai_slop_writing_rules](https://github.com/realrossmanngroup/no_ai_slop_writing_rules) — 24 rules with wrong/right pairs

No changeset: `.claude/skills/` is repo tooling. The published `@three-flatland/skills` package is `skills/` (codemod, flatland-bake, flatland-r3f, tsl) and is untouched.


___

### **PR Type**
Documentation


___

### **Description**
- Add three-layer voice precedence in `marketing-voice`.

- Author core voice → surface register → anti-trope rules.

- Document optional, one-directional home-dir dependency.

- Add `anti-slop.md` structural, metaphor, vocabulary, rewrite rules.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["marketing-voice SKILL.md"] --> B["Voice precedence section"]
    B --> C["Author core voice (home-dir voice-register)"]
    B --> D["Surface register (calm / dialed-up)"]
    B --> E["Anti-trope rules + anti-slop.md"]
    A --> F["anti-slop.md new subfile"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Wire marketing-voice to author core voice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/skills/marketing-voice/SKILL.md

<ul><li>Add required sub-file note pointing to <code>anti-slop.md</code>.<br> <li> Add Voice precedence section with three layers: author core voice, <br>surface register, anti-trope rules.<br> <li> State layer 1 wins conflicts and register is a dial on author voice, <br>not a different writer.<br> <li> Document one-directional optional dependency on home-dir <br><code>voice-register</code>, degraded gracefully.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/241/files#diff-6e4af97f4fcb3e29df848212a11864befd0692f1dcf6671ec7f7496ea1ad0f52">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>anti-slop.md</strong><dd><code>Add anti-slop rewrite guardrails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/skills/marketing-voice/anti-slop.md

<ul><li>New 149-line anti-slop guide loaded by <code>marketing-voice</code>.<br> <li> Introduce three reader-reported failure modes and three structural <br>tests: read aloud, reshuffle paragraphs, ask what is new.<br> <li> Add metaphor discipline, complexity discipline, sounding-like-a-person <br>rules, and structural tells table.<br> <li> Include vocabulary substitutions, never-inject rewrite guardrails, and <br>when-to-rewrite threshold.<br> <li> Credit four public anti-slop rule sets.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/241/files#diff-092eafb724fd36c03e497bbe163159baaf9abc71bf1794f952dde7e81284ddc1">+149/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

