### PR TITLE
docs: split the Flatland concept from its setup how-to

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -401,6 +401,7 @@ export default defineConfig({
             label: 'Guides',
             items: [
               { label: 'Sprites', slug: 'guides/sprites' },
+              { label: 'Flatland Setup', slug: 'guides/flatland-setup' },
               { label: 'Alpha API Migration', slug: 'guides/private-ecs-migration' },
               { label: 'Pixel-Perfect Rendering', slug: 'guides/pixel-perfect-rendering' },
               { label: 'Animation', slug: 'guides/animation' },

--- a/docs/src/content/docs/guides/flatland-setup.mdx
+++ b/docs/src/content/docs/guides/flatland-setup.mdx
@@ -102,11 +102,7 @@ Flatland's managed camera follows the library-wide `pixel-art` preset by default
 
 ## Adding Objects
 
-`flatland.add()` routes objects automatically:
-
-- **Sprite2D** instances go to the internal `SpriteGroup` for batched rendering
-- **Light2D** instances are tracked for the lighting system
-- **Other Object3D** instances are added directly to the internal scene
+`flatland.add()` dispatches on type — see [Object Routing](../flatland/#object-routing) for what goes where.
 
 ```typescript
 // Sprite2D → batched via SpriteGroup
@@ -151,13 +147,17 @@ const indicator = new Sprite2D({ texture, lit: false }) // always full brightnes
 
 `resolutionScale` belongs to the effect that owns the surface-dependent resources. A value of `0.5` receives half-width and half-height dimensions in `LightEffect.resize()`, reducing area to one quarter while leaving camera framing, canvas resolution, renderer DPR, and logical viewport uniforms unchanged. Change Three.js `renderer.setPixelRatio()` or R3F `<Canvas dpr={...}>` instead when the entire frame should render at a lower resolution.
 
-Flatland owns an attached effect's lifecycle. Replacing the active effect or calling `setLighting(null)` disposes its GPU resources before detaching it. The effect instance can be attached again and will receive a fresh `init → resize → update` sequence, but effect-owned GPU resource handles must not be used while it is detached.
+Flatland owns an attached effect's lifecycle, so `setLighting(null)` or a replacement disposes the old effect's GPU resources before detaching it. See [Effect Ownership](../flatland/#effect-ownership) for the full contract.
 
 See the [2D Lighting guide](../lighting/) for preset comparisons, Light2D types, and custom effects.
 
 ## Sizing and Aspect
 
-Calling `resize(width, height)` starts a manual sizing session, and the active destination at that moment fixes the unit for the session. With no render target attached, pass logical CSS pixels; the renderer's current DPR is applied on every render. A target attached later is therefore sized to `width × DPR` by `height × DPR`. With a render target attached, pass physical texels, matching `RenderTarget.setSize()`; those dimensions remain physical across later target swaps or a return to the canvas. Automatic sizing only observes user-owned render targets and never resizes them. Assigning either a numeric `aspect` or `'auto'` after `resize()` ends the manual sizing session and resumes automatic effect sizing; `'auto'` also resumes automatic camera framing. Read `flatland.resolvedAspect` when you need the current numeric ratio.
+Flatland sizes its camera from the render surface on its own. Call `resize(width, height)` only when you need to override that.
+
+`resize()` starts a manual sizing session. Whichever destination is active when you call it decides the unit. With no render target attached, pass logical CSS pixels; the renderer's current DPR is applied on every render. A target attached later is therefore sized to `width × DPR` by `height × DPR`. With a render target attached, pass physical texels, matching `RenderTarget.setSize()`; those dimensions stay physical even after you swap targets or go back to rendering on the canvas. Automatic sizing only observes user-owned render targets and never resizes them. Assigning either a numeric `aspect` or `'auto'` after `resize()` ends the manual sizing session and resumes automatic effect sizing; `'auto'` also resumes automatic camera framing. Read `flatland.resolvedAspect` when you need the current numeric ratio.
+
+With `pixelPerfect: false`, pass `aspect` or assign `flatland.aspect` to pin the regular internal camera.
 
 When you supply a camera through `camera`, Flatland preserves its authored frustum. The aspect controls above apply to the internal camera; `resolvedAspect` reports the supplied camera's actual frustum ratio.
 
@@ -251,7 +251,7 @@ post.bands = 10
 The render pipeline auto-initializes on the first `addPass()` call. Passes chain in insertion order — each receives the previous pass's output.
 
 :::tip[Performance note]
-Adding the first pass switches Flatland onto the render-pipeline path: the scene renders to an offscreen target, then each pass runs as a full-screen draw. One or two passes are cheap; a long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where you can.
+Fuse effects into a single pass where the math allows it. [The Post-Processing Trade](../flatland/#the-post-processing-trade) explains what the first pass changes and why a long chain costs more.
 :::
 
 | Method                  | Description                       |

--- a/docs/src/content/docs/guides/flatland-setup.mdx
+++ b/docs/src/content/docs/guides/flatland-setup.mdx
@@ -1,0 +1,322 @@
+---
+title: Flatland Setup
+description: Construct a Flatland, add objects, wire lighting and passes, and render to a target.
+---
+
+import { Tabs, TabItem } from 'starlight-theme/components'
+
+These are the calls that stand a `Flatland` up and keep it running. For what it owns and why that ownership is the right trade, see [Flatland](../flatland/).
+
+## Basic Setup
+
+<Tabs syncKey="framework">
+  <TabItem label="Three.js" icon="simple-icons:threedotjs">
+    ```typescript
+    import { WebGPURenderer } from 'three/webgpu'
+    import { Flatland, Sprite2D, TextureLoader } from 'three-flatland'
+
+    const renderer = new WebGPURenderer()
+    await renderer.init()
+    document.body.appendChild(renderer.domElement)
+
+    function resizeRenderer() {
+      renderer.setSize(window.innerWidth, window.innerHeight)
+    }
+    resizeRenderer()
+    window.addEventListener('resize', resizeRenderer)
+
+    const flatland = new Flatland({ viewSize: 400, clearColor: 0x1a1a2e })
+    const texture = await new TextureLoader().loadAsync('/sprites/hero.png')
+
+    flatland.add(new Sprite2D({ texture }))
+
+    function animate() {
+      flatland.render(renderer)
+      requestAnimationFrame(animate)
+    }
+    animate()
+    ```
+
+  </TabItem>
+  <TabItem label="React" icon="simple-icons:react">
+    ```tsx
+    import { useRef } from 'react'
+    import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
+    import { Flatland, Sprite2D, Sprite2DMaterial } from 'three-flatland/react'
+    import type { Flatland as FlatlandType } from 'three-flatland/react'
+    import type { WebGPURenderer } from 'three/webgpu'
+
+    extend({ Flatland, Sprite2D, Sprite2DMaterial })
+
+    function Scene() {
+      const flatlandRef = useRef<FlatlandType>(null)
+      const renderer = useThree((state) => state.renderer)
+
+      // Render in the 'render' phase so R3F skips its own render
+      useFrame(() => {
+        flatlandRef.current?.render(renderer as unknown as WebGPURenderer)
+      }, { phase: 'render' })
+
+      return (
+        <flatland ref={flatlandRef} viewSize={400} clearColor={0x1a1a2e}>
+          <sprite2D texture={texture} />
+        </flatland>
+      )
+    }
+
+    export default function App() {
+      return (
+        <Canvas renderer={{ antialias: false }}>
+          <Scene />
+        </Canvas>
+      )
+    }
+    ```
+
+  </TabItem>
+</Tabs>
+
+:::caution[R3F render phase]
+In React Three Fiber, register `flatland.render()` in the **render phase** (`{ phase: 'render' }`). This tells R3F to skip its default render and lets Flatland control rendering. Game logic and ECS updates should run in the default update phase.
+:::
+
+## Constructor Options
+
+```typescript
+const flatland = new Flatland({
+  viewSize: 400, // Orthographic view height in world units
+  pixelPerfect: true, // Managed PixelPerfectCamera (system default)
+  clearColor: 0x1a1a2e, // Background color
+  clearAlpha: 1, // Background alpha (< 1 for transparent)
+  autoClear: true, // Clear before each render
+  postProcessing: false, // Enable post-processing pipeline
+  aspect: undefined, // Regular camera only: auto-sync, or set a number to pin it
+  camera: null, // Custom OrthographicCamera (null = internal)
+  renderTarget: null, // RenderTarget (null = render to viewport)
+})
+```
+
+See the [FlatlandOptions API reference](/three-flatland/api/three-flatland/src/interfaces/flatlandoptions/) for full type details.
+
+Flatland's managed camera follows the library-wide `pixel-art` preset by default. See [Pixel-Perfect Rendering](../pixel-perfect-rendering/) for the camera, object snapping, HiDPI behavior, and the `FlatlandConfig` hierarchy. Pass `pixelPerfect: false` for a regular orthographic camera.
+
+## Adding Objects
+
+`flatland.add()` routes objects automatically:
+
+- **Sprite2D** instances go to the internal `SpriteGroup` for batched rendering
+- **Light2D** instances are tracked for the lighting system
+- **Other Object3D** instances are added directly to the internal scene
+
+```typescript
+// Sprite2D → batched via SpriteGroup
+const sprite = new Sprite2D({ texture, anchor: [0.5, 0.5] })
+flatland.add(sprite)
+
+// Light2D → tracked by lighting system
+const light = new Light2D({ type: 'point', position: [50, 50], color: 0xff6600 })
+flatland.add(light)
+
+// Other Three.js objects → added to internal scene
+const mesh = new Mesh(geometry, material)
+flatland.add(mesh)
+```
+
+Global uniforms are automatically wired to each sprite's material on `add()`.
+
+## Lighting
+
+Flatland manages 2D lighting with `Light2D` sources and a `LightEffect` pipeline. Activate lighting by calling `setLighting()` with a preset:
+
+```typescript
+import { DefaultLightEffect } from '@three-flatland/presets'
+
+const lighting = new DefaultLightEffect()
+lighting.resolutionScale = 0.5 // Optional: half-resolution effect resources
+flatland.setLighting(lighting)
+```
+
+All sprites receive lighting by default. Set `lit: false` to opt out:
+
+```typescript
+const indicator = new Sprite2D({ texture, lit: false }) // always full brightness
+```
+
+| Method / Property        | Description                                                           |
+| ------------------------ | --------------------------------------------------------------------- |
+| `setLighting(effect)`    | Set the active LightEffect (or `null` to disable)                     |
+| `lighting`               | Current LightEffect (read-only)                                       |
+| `lights`                 | All tracked Light2D instances (read-only)                             |
+| `effect.resolutionScale` | Processing resolution relative to the physical surface (default: `1`) |
+
+`resolutionScale` belongs to the effect that owns the surface-dependent resources. A value of `0.5` receives half-width and half-height dimensions in `LightEffect.resize()`, reducing area to one quarter while leaving camera framing, canvas resolution, renderer DPR, and logical viewport uniforms unchanged. Change Three.js `renderer.setPixelRatio()` or R3F `<Canvas dpr={...}>` instead when the entire frame should render at a lower resolution.
+
+Flatland owns an attached effect's lifecycle. Replacing the active effect or calling `setLighting(null)` disposes its GPU resources before detaching it. The effect instance can be attached again and will receive a fresh `init → resize → update` sequence, but effect-owned GPU resource handles must not be used while it is detached.
+
+See the [2D Lighting guide](../lighting/) for preset comparisons, Light2D types, and custom effects.
+
+## Sizing and Aspect
+
+Calling `resize(width, height)` starts a manual sizing session, and the active destination at that moment fixes the unit for the session. With no render target attached, pass logical CSS pixels; the renderer's current DPR is applied on every render. A target attached later is therefore sized to `width × DPR` by `height × DPR`. With a render target attached, pass physical texels, matching `RenderTarget.setSize()`; those dimensions remain physical across later target swaps or a return to the canvas. Automatic sizing only observes user-owned render targets and never resizes them. Assigning either a numeric `aspect` or `'auto'` after `resize()` ends the manual sizing session and resumes automatic effect sizing; `'auto'` also resumes automatic camera framing. Read `flatland.resolvedAspect` when you need the current numeric ratio.
+
+When you supply a camera through `camera`, Flatland preserves its authored frustum. The aspect controls above apply to the internal camera; `resolvedAspect` reports the supplied camera's actual frustum ratio.
+
+:::caution[Breaking default]
+`Flatland` previously kept `aspect = 1` until `resize()` was called. Pass `aspect: 1` when that fixed square frustum was intentional. Remove per-frame or `useThree(state => state.size)` resize bridges when the camera should follow the render surface.
+:::
+
+## Global Uniforms
+
+Every Flatland instance exposes a `globals` object with shared uniforms. These update once per frame and are available to all sprite materials via TSL nodes.
+
+| Uniform        | Description                          |
+| -------------- | ------------------------------------ |
+| `time`         | Elapsed seconds (`undefined` = auto) |
+| `globalTint`   | Color tint for all sprites           |
+| `viewportSize` | Logical viewport size in pixels      |
+| `pixelRatio`   | Device pixel ratio                   |
+| `wind`         | Wind direction and strength          |
+| `fogColor`     | Fog color                            |
+| `fogRange`     | Fog near/far range                   |
+
+### Auto vs Manual Time
+
+By default, `time` is `undefined` and Flatland accumulates elapsed time automatically. Set it to a number for manual control:
+
+```typescript
+// Auto mode (default) — time accumulates each frame
+flatland.globals.time = undefined
+
+// Manual mode — set exact value
+flatland.globals.time = performance.now() / 1000
+```
+
+### Using Uniforms in TSL
+
+Access the TSL node directly for custom material effects:
+
+```typescript
+import { Sprite2DMaterial } from 'three-flatland'
+
+const material = new Sprite2DMaterial({
+  colorTransform: (ctx) => {
+    // Use the global tint node in a custom effect
+    const tinted = ctx.color.rgb.mul(flatland.globals.globalTintNode)
+    return tinted.toVec4(ctx.color.a)
+  },
+})
+```
+
+Each global has a corresponding TSL node: `timeNode`, `globalTintNode`, `viewportSizeNode`, `pixelRatioNode`, `windNode`, `fogColorNode`, `fogRangeNode`.
+
+## Statistics
+
+Monitor batching with `flatland.spriteGroup.stats`:
+
+```typescript
+const stats = flatland.spriteGroup.stats
+
+console.log(`Sprites: ${stats.spriteCount}`)
+console.log(`Batches: ${stats.batchCount}`)
+console.log(`Visible: ${stats.visibleSprites}`)
+```
+
+Draw calls aren't part of `stats` — read them from the renderer after a frame: `renderer.info.render.calls` reflects actual GPU work.
+
+## Post-Processing
+
+Add full-screen pass effects with `addPass()`:
+
+```typescript
+import { Flatland, createPassEffect } from 'three-flatland'
+import { posterize } from '@three-flatland/nodes'
+
+const PosterizePass = createPassEffect({
+  name: 'posterize',
+  schema: { bands: 6 },
+  pass:
+    ({ uniforms }) =>
+    (input, uv) =>
+      posterize(input, uniforms.bands),
+})
+
+const flatland = new Flatland({ viewSize: 400 })
+const post = new PosterizePass()
+flatland.addPass(post)
+
+// Zero-cost parameter updates
+post.bands = 10
+```
+
+The render pipeline auto-initializes on the first `addPass()` call. Passes chain in insertion order — each receives the previous pass's output.
+
+:::tip[Performance note]
+Adding the first pass switches Flatland onto the render-pipeline path: the scene renders to an offscreen target, then each pass runs as a full-screen draw. One or two passes are cheap; a long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where you can.
+:::
+
+| Method                  | Description                       |
+| ----------------------- | --------------------------------- |
+| `addPass(pass, order?)` | Add a pass effect                 |
+| `removePass(pass)`      | Remove a specific pass            |
+| `clearPasses()`         | Remove all passes                 |
+| `passes`                | Read-only array of current passes |
+
+See the [Pass Effects guide](../pass-effects/) for creating custom effects and the full node library.
+
+## Render to Texture
+
+Render Flatland output to a texture for use in 3D scenes:
+
+```typescript
+import { RenderTarget } from 'three'
+
+const target = new RenderTarget(512, 512)
+const flatland = new Flatland({ renderTarget: target })
+
+// Use the texture on a 3D mesh
+mesh.material.map = flatland.texture
+
+// Each frame: render 2D first, then 3D
+flatland.render(renderer)
+renderer.render(scene3D, camera3D)
+```
+
+Flatland defaults a render target with no color-space metadata to sRGB, which is
+the usual choice for 2D color output. It also keeps the pipeline write and the
+target metadata aligned, so sampling `flatland.texture` in another Flatland or
+Three.js scene preserves the source colors without a manual transfer function.
+
+Set the target's color space before its first GPU use (or pass a fresh target to
+Flatland). Changing color-space metadata after Three has allocated the target
+does not recreate its GPU attachment format.
+
+For linear or HDR output, declare that intent on the target. Flatland preserves
+explicit color-space and texture-type settings:
+
+```typescript
+import { HalfFloatType, LinearSRGBColorSpace, RenderTarget } from 'three'
+
+const hdrTarget = new RenderTarget(512, 512, {
+  type: HalfFloatType,
+  colorSpace: LinearSRGBColorSpace,
+})
+const hdrFlatland = new Flatland({ renderTarget: hdrTarget })
+```
+
+## Disposal
+
+Clean up all resources when done:
+
+```typescript
+flatland.dispose()
+```
+
+This destroys the ECS world, sprite batches, render pipeline, and all pass effect entities.
+
+## Next Steps
+
+- [Flatland](../flatland/) — what the pipeline owns and when to reach for it
+- [2D Lighting](../lighting/) — Light2D sources and LightEffect presets
+- [Pass Effects](../pass-effects/) — creating custom effects and the full node library
+- [Pixel-Perfect Rendering](../pixel-perfect-rendering/) — camera scaling, snapping, and presets
+- [TSL Nodes](../tsl-nodes/) — per-sprite material effects and low-level TSL usage

--- a/docs/src/content/docs/guides/flatland.mdx
+++ b/docs/src/content/docs/guides/flatland.mdx
@@ -1,13 +1,14 @@
 ---
 title: Flatland
-description: Self-contained 2D rendering pipeline with camera, post-processing, and global uniforms.
+description: How the Flatland pipeline owns a frame — camera, batching, lighting, and post-processing in one object.
 ---
 
-import { Tabs, TabItem } from 'starlight-theme/components'
+import Diagram from '../../../components/Diagram.astro'
+import framePipeline from '../../../assets/diagrams/frame-pipeline.svg?raw'
 
-`Flatland` is the high-level entry point for three-flatland. It wraps a `SpriteGroup` with an orthographic camera, global uniforms, post-processing pipeline, and render target support into a single object.
+`Flatland` is the high-level entry point for three-flatland. It wraps a `SpriteGroup` with an orthographic camera, global uniforms, a post-processing pipeline, and render-target support in a single object.
 
-If you're new and not sure whether you need `Flatland` or `SpriteGroup` — start here. The table below tells you when to graduate.
+This page covers what `Flatland` owns and when that ownership is the right trade. For the calls that set one up, see [Flatland Setup](../flatland-setup/).
 
 ## When to Use Flatland vs SpriteGroup
 
@@ -19,334 +20,46 @@ If you're new and not sure whether you need `Flatland` or `SpriteGroup` — star
 | **Global uniforms** | Automatic time, viewport, tint             | Not included                      |
 | **Render call**     | `flatland.render(...)`                     | `renderer.render(...)`            |
 
-Use `Flatland` when you want a complete 2D rendering setup. Use `SpriteGroup` when you need to mix sprites into an existing 3D scene with your own camera and render loop.
+The split is about who owns the frame. `Flatland` owns the camera, the sizing, and the draw, so a 2D scene needs no render loop of its own beyond one `render()` call. `SpriteGroup` owns none of that, which is what you want when sprites are one layer inside a 3D scene that already has a camera and a loop.
 
-## Basic Setup
+Reach for `SpriteGroup` when an existing scene is authoritative. Reach for `Flatland` when the 2D scene *is* the application.
 
-<Tabs syncKey="framework">
-  <TabItem label="Three.js" icon="simple-icons:threedotjs">
-    ```typescript
-    import { WebGPURenderer } from 'three/webgpu'
-    import { Flatland, Sprite2D, TextureLoader } from 'three-flatland'
-
-    const renderer = new WebGPURenderer()
-    await renderer.init()
-    document.body.appendChild(renderer.domElement)
-
-    function resizeRenderer() {
-      renderer.setSize(window.innerWidth, window.innerHeight)
-    }
-    resizeRenderer()
-    window.addEventListener('resize', resizeRenderer)
-
-    const flatland = new Flatland({ viewSize: 400, clearColor: 0x1a1a2e })
-    const texture = await new TextureLoader().loadAsync('/sprites/hero.png')
-
-    flatland.add(new Sprite2D({ texture }))
-
-    function animate() {
-      flatland.render(renderer)
-      requestAnimationFrame(animate)
-    }
-    animate()
-    ```
-
-  </TabItem>
-  <TabItem label="React" icon="simple-icons:react">
-    ```tsx
-    import { useRef } from 'react'
-    import { Canvas, extend, useFrame, useThree } from '@react-three/fiber/webgpu'
-    import { Flatland, Sprite2D, Sprite2DMaterial } from 'three-flatland/react'
-    import type { Flatland as FlatlandType } from 'three-flatland/react'
-    import type { WebGPURenderer } from 'three/webgpu'
-
-    extend({ Flatland, Sprite2D, Sprite2DMaterial })
-
-    function Scene() {
-      const flatlandRef = useRef<FlatlandType>(null)
-      const renderer = useThree((state) => state.renderer)
-
-      // Render in the 'render' phase so R3F skips its own render
-      useFrame(() => {
-        flatlandRef.current?.render(renderer as unknown as WebGPURenderer)
-      }, { phase: 'render' })
-
-      return (
-        <flatland ref={flatlandRef} viewSize={400} clearColor={0x1a1a2e}>
-          <sprite2D texture={texture} />
-        </flatland>
-      )
-    }
-
-    export default function App() {
-      return (
-        <Canvas renderer={{ antialias: false }}>
-          <Scene />
-        </Canvas>
-      )
-    }
-    ```
-
-  </TabItem>
-</Tabs>
-
-:::caution[R3F render phase]
-In React Three Fiber, register `flatland.render()` in the **render phase** (`{ phase: 'render' }`). This tells R3F to skip its default render and lets Flatland control rendering. Game logic and ECS updates should run in the default update phase.
-:::
-
-## Constructor Options
-
-```typescript
-const flatland = new Flatland({
-  viewSize: 400, // Orthographic view height in world units
-  pixelPerfect: true, // Managed PixelPerfectCamera (system default)
-  clearColor: 0x1a1a2e, // Background color
-  clearAlpha: 1, // Background alpha (< 1 for transparent)
-  autoClear: true, // Clear before each render
-  postProcessing: false, // Enable post-processing pipeline
-  aspect: undefined, // Regular camera only: auto-sync, or set a number to pin it
-  camera: null, // Custom OrthographicCamera (null = internal)
-  renderTarget: null, // RenderTarget (null = render to viewport)
-})
-```
-
-See the [FlatlandOptions API reference](/three-flatland/api/three-flatland/src/interfaces/flatlandoptions/) for full type details.
-
-Flatland's managed camera follows the library-wide `pixel-art` preset by default. See [Pixel-Perfect Rendering](../pixel-perfect-rendering/) for the camera, object snapping, HiDPI behavior, and the `FlatlandConfig` hierarchy. Pass `pixelPerfect: false` for a regular orthographic camera.
-
-## Adding Objects
-
-`flatland.add()` routes objects automatically:
-
-- **Sprite2D** instances go to the internal `SpriteGroup` for batched rendering
-- **Light2D** instances are tracked for the lighting system
-- **Other Object3D** instances are added directly to the internal scene
-
-```typescript
-// Sprite2D → batched via SpriteGroup
-const sprite = new Sprite2D({ texture, anchor: [0.5, 0.5] })
-flatland.add(sprite)
-
-// Light2D → tracked by lighting system
-const light = new Light2D({ type: 'point', position: [50, 50], color: 0xff6600 })
-flatland.add(light)
-
-// Other Three.js objects → added to internal scene
-const mesh = new Mesh(geometry, material)
-flatland.add(mesh)
-```
-
-Global uniforms are automatically wired to each sprite's material on `add()`.
-
-## Lighting
-
-Flatland manages 2D lighting with `Light2D` sources and a `LightEffect` pipeline. Activate lighting by calling `setLighting()` with a preset:
-
-```typescript
-import { DefaultLightEffect } from '@three-flatland/presets'
-
-const lighting = new DefaultLightEffect()
-lighting.resolutionScale = 0.5 // Optional: half-resolution effect resources
-flatland.setLighting(lighting)
-```
-
-All sprites receive lighting by default. Set `lit: false` to opt out:
-
-```typescript
-const indicator = new Sprite2D({ texture, lit: false }) // always full brightness
-```
-
-| Method / Property        | Description                                                           |
-| ------------------------ | --------------------------------------------------------------------- |
-| `setLighting(effect)`    | Set the active LightEffect (or `null` to disable)                     |
-| `lighting`               | Current LightEffect (read-only)                                       |
-| `lights`                 | All tracked Light2D instances (read-only)                             |
-| `effect.resolutionScale` | Processing resolution relative to the physical surface (default: `1`) |
-
-`resolutionScale` belongs to the effect that owns the surface-dependent resources. A value of `0.5` receives half-width and half-height dimensions in `LightEffect.resize()`, reducing area to one quarter while leaving camera framing, canvas resolution, renderer DPR, and logical viewport uniforms unchanged. Change Three.js `renderer.setPixelRatio()` or R3F `<Canvas dpr={...}>` instead when the entire frame should render at a lower resolution.
-
-Flatland owns an attached effect's lifecycle. Replacing the active effect or calling `setLighting(null)` disposes its GPU resources before detaching it. The effect instance can be attached again and will receive a fresh `init → resize → update` sequence, but effect-owned GPU resource handles must not be used while it is detached.
-
-See the [2D Lighting guide](../lighting/) for preset comparisons, Light2D types, and custom effects.
-
-## Render Loop
-
-import Diagram from '../../../components/Diagram.astro'
-import framePipeline from '../../../assets/diagrams/frame-pipeline.svg?raw'
+## What Happens in a Frame
 
 <Diagram caption="Per-frame render pipeline" src={framePipeline} />
 
-Each frame, call `render()`. `Flatland` reads the renderer drawing buffer or active render target size and updates its camera when the surface dimensions change:
+`render()` syncs the camera, global uniforms, lighting buffers, and sprite batches, then draws. Each of those is derived state: nothing in the pipeline requires per-frame bookkeeping from the application.
 
-```typescript
-function animate() {
-  flatland.render(renderer)
-  requestAnimationFrame(animate)
-}
-```
+Surface-dependent GPU resources are measured in physical drawing-buffer pixels, so canvas DPR and render-target texels share one coordinate space. `globals.viewportSize` stays the renderer's logical size and is paired with `globals.pixelRatio`. The two live in different units on purpose: effects allocate against physical pixels, while layout math in a shader wants the logical size the reader authored against.
 
-`render()` syncs the camera, global uniforms, lighting buffers, and sprite batches before drawing. Surface-dependent GPU resources use physical drawing-buffer pixels so canvas DPR and render-target texels stay in the same coordinate space; `globals.viewportSize` remains the renderer's logical size and is paired with `globals.pixelRatio`. The default `PixelPerfectCamera` selects and centers an integer-sized viewport inside the physical surface, so `resolvedAspect` can differ from the full surface when letterboxing is active. With `pixelPerfect: false`, pass `aspect` or assign `flatland.aspect` to pin the regular internal camera.
+The default `PixelPerfectCamera` selects and centers an integer-sized viewport inside the physical surface. When that integer scale does not divide the surface evenly, the result is letterboxed, and `resolvedAspect` reports the viewport ratio rather than the full surface ratio.
 
-Calling `resize(width, height)` starts a manual sizing session, and the active destination at that moment fixes the unit for the session. With no render target attached, pass logical CSS pixels; the renderer's current DPR is applied on every render. A target attached later is therefore sized to `width × DPR` by `height × DPR`. With a render target attached, pass physical texels, matching `RenderTarget.setSize()`; those dimensions remain physical across later target swaps or a return to the canvas. Automatic sizing only observes user-owned render targets and never resizes them. Assigning either a numeric `aspect` or `'auto'` after `resize()` ends the manual sizing session and resumes automatic effect sizing; `'auto'` also resumes automatic camera framing. Read `flatland.resolvedAspect` when you need the current numeric ratio.
+## Object Routing
 
-When you supply a camera through `camera`, Flatland preserves its authored frustum. The aspect controls above apply to the internal camera; `resolvedAspect` reports the supplied camera's actual frustum ratio.
+`add()` dispatches on type rather than asking the caller to pick a destination. `Sprite2D` instances go to the internal `SpriteGroup` and become batch candidates. `Light2D` instances register with the lighting system. Anything else is a plain `Object3D` and joins the internal scene directly.
 
-:::caution[Breaking default]
-`Flatland` previously kept `aspect = 1` until `resize()` was called. Pass `aspect: 1` when that fixed square frustum was intentional. Remove per-frame or `useThree(state => state.size)` resize bridges when the camera should follow the render surface.
-:::
+Global uniforms are wired to a sprite's material at `add()` time, which is why a sprite added later still sees the same `time` and `globalTint` as its neighbours.
 
-## Global Uniforms
+## Effect Ownership
 
-Every Flatland instance exposes a `globals` object with shared uniforms. These update once per frame and are available to all sprite materials via TSL nodes.
+An attached `LightEffect` belongs to the `Flatland` that holds it. Replacing the active effect, or clearing it, disposes its GPU resources before detaching. The instance can be attached again and receives a fresh `init → resize → update` sequence, but resource handles it produced while attached are invalid once it is detached.
 
-| Uniform        | Description                          |
-| -------------- | ------------------------------------ |
-| `time`         | Elapsed seconds (`undefined` = auto) |
-| `globalTint`   | Color tint for all sprites           |
-| `viewportSize` | Logical viewport size in pixels      |
-| `pixelRatio`   | Device pixel ratio                   |
-| `wind`         | Wind direction and strength          |
-| `fogColor`     | Fog color                            |
-| `fogRange`     | Fog near/far range                   |
+This is the same contract `dispose()` honours for the whole object: the ECS world, the sprite batches, the render pipeline, and every pass effect entity are destroyed together. Ownership is not shared, so there is no case where two objects both believe they hold a buffer.
 
-### Auto vs Manual Time
+## The Post-Processing Trade
 
-By default, `time` is `undefined` and Flatland accumulates elapsed time automatically. Set it to a number for manual control:
-
-```typescript
-// Auto mode (default) — time accumulates each frame
-flatland.globals.time = undefined
-
-// Manual mode — set exact value
-flatland.globals.time = performance.now() / 1000
-```
-
-### Using Uniforms in TSL
-
-Access the TSL node directly for custom material effects:
-
-```typescript
-import { Sprite2DMaterial } from 'three-flatland'
-
-const material = new Sprite2DMaterial({
-  colorTransform: (ctx) => {
-    // Use the global tint node in a custom effect
-    const tinted = ctx.color.rgb.mul(flatland.globals.globalTintNode)
-    return tinted.toVec4(ctx.color.a)
-  },
-})
-```
-
-Each global has a corresponding TSL node: `timeNode`, `globalTintNode`, `viewportSizeNode`, `pixelRatioNode`, `windNode`, `fogColorNode`, `fogRangeNode`.
-
-## Statistics
-
-Monitor batching with `flatland.spriteGroup.stats`:
-
-```typescript
-const stats = flatland.spriteGroup.stats
-
-console.log(`Sprites: ${stats.spriteCount}`)
-console.log(`Batches: ${stats.batchCount}`)
-console.log(`Visible: ${stats.visibleSprites}`)
-```
-
-Draw calls aren't part of `stats` — read them from the renderer after a frame: `renderer.info.render.calls` reflects actual GPU work.
-
-## Post-Processing
-
-Add full-screen pass effects with `addPass()`:
-
-```typescript
-import { Flatland, createPassEffect } from 'three-flatland'
-import { posterize } from '@three-flatland/nodes'
-
-const PosterizePass = createPassEffect({
-  name: 'posterize',
-  schema: { bands: 6 },
-  pass:
-    ({ uniforms }) =>
-    (input, uv) =>
-      posterize(input, uniforms.bands),
-})
-
-const flatland = new Flatland({ viewSize: 400 })
-const post = new PosterizePass()
-flatland.addPass(post)
-
-// Zero-cost parameter updates
-post.bands = 10
-```
-
-The render pipeline auto-initializes on the first `addPass()` call. Passes chain in insertion order — each receives the previous pass's output.
+Adding the first pass changes how a frame is drawn. Without passes, the scene draws straight to the destination. With one or more, the scene renders to an offscreen target and each pass runs as a full-screen draw over it.
 
 :::tip[Performance note]
-Adding the first pass switches Flatland onto the render-pipeline path: the scene renders to an offscreen target, then each pass runs as a full-screen draw. One or two passes are cheap; a long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where you can.
+One or two passes are cheap. A long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where the maths allows it.
 :::
 
-| Method                  | Description                       |
-| ----------------------- | --------------------------------- |
-| `addPass(pass, order?)` | Add a pass effect                 |
-| `removePass(pass)`      | Remove a specific pass            |
-| `clearPasses()`         | Remove all passes                 |
-| `passes`                | Read-only array of current passes |
-
-See the [Pass Effects guide](../pass-effects/) for creating custom effects and the full node library.
-
-## Render to Texture
-
-Render Flatland output to a texture for use in 3D scenes:
-
-```typescript
-import { RenderTarget } from 'three'
-
-const target = new RenderTarget(512, 512)
-const flatland = new Flatland({ renderTarget: target })
-
-// Use the texture on a 3D mesh
-mesh.material.map = flatland.texture
-
-// Each frame: render 2D first, then 3D
-flatland.render(renderer)
-renderer.render(scene3D, camera3D)
-```
-
-Flatland defaults a render target with no color-space metadata to sRGB, which is
-the usual choice for 2D color output. It also keeps the pipeline write and the
-target metadata aligned, so sampling `flatland.texture` in another Flatland or
-Three.js scene preserves the source colors without a manual transfer function.
-
-Set the target's color space before its first GPU use (or pass a fresh target to
-Flatland). Changing color-space metadata after Three has allocated the target
-does not recreate its GPU attachment format.
-
-For linear or HDR output, declare that intent on the target. Flatland preserves
-explicit color-space and texture-type settings:
-
-```typescript
-import { HalfFloatType, LinearSRGBColorSpace, RenderTarget } from 'three'
-
-const hdrTarget = new RenderTarget(512, 512, {
-  type: HalfFloatType,
-  colorSpace: LinearSRGBColorSpace,
-})
-const hdrFlatland = new Flatland({ renderTarget: hdrTarget })
-```
-
-## Disposal
-
-Clean up all resources when done:
-
-```typescript
-flatland.dispose()
-```
-
-This destroys the ECS world, sprite batches, render pipeline, and all pass effect entities.
+That switch is invisible from the API and worth knowing about anyway, because it explains why the first `addPass()` call has a cost the second one does not.
 
 ## Next Steps
 
+- [Flatland Setup](../flatland-setup/) — constructing, adding objects, passes, and render targets
 - [2D Lighting](../lighting/) — Light2D sources and LightEffect presets
-- [Pass Effects](../pass-effects/) — Full-screen post-processing effects
-- [Batch Rendering](../batch-rendering/) — How sprite batching works under the hood
-- [Pixel-Perfect Rendering](../pixel-perfect-rendering/) — Camera scaling, projected-pivot snapping, and presets
-- [TSL Nodes](../tsl-nodes/) — Per-sprite material effects and low-level TSL usage
+- [Pass Effects](../pass-effects/) — full-screen post-processing effects
+- [Batch Rendering](../batch-rendering/) — how sprite batching works under the hood
+- [Pixel-Perfect Rendering](../pixel-perfect-rendering/) — camera scaling, projected-pivot snapping, and presets

--- a/docs/src/content/docs/guides/flatland.mdx
+++ b/docs/src/content/docs/guides/flatland.mdx
@@ -28,11 +28,13 @@ Reach for `SpriteGroup` when an existing scene is authoritative. Reach for `Flat
 
 <Diagram caption="Per-frame render pipeline" src={framePipeline} />
 
-`render()` syncs the camera, global uniforms, lighting buffers, and sprite batches, then draws. Each of those is derived state: nothing in the pipeline requires per-frame bookkeeping from the application.
+`render()` syncs the camera, global uniforms, lighting buffers, and sprite batches, then draws. Each of those is derived state, so nothing in the pipeline needs per-frame bookkeeping from the application.
 
-Surface-dependent GPU resources are measured in physical drawing-buffer pixels, so canvas DPR and render-target texels share one coordinate space. `globals.viewportSize` stays the renderer's logical size and is paired with `globals.pixelRatio`. The two live in different units on purpose: effects allocate against physical pixels, while layout math in a shader wants the logical size the reader authored against.
+Sizing is derived too. `Flatland` reads the size of the renderer's drawing buffer, or of the active render target, and updates its camera when that size changes. You do not need a resize listener that pushes dimensions into the camera.
 
-The default `PixelPerfectCamera` selects and centers an integer-sized viewport inside the physical surface. When that integer scale does not divide the surface evenly, the result is letterboxed, and `resolvedAspect` reports the viewport ratio rather than the full surface ratio.
+Two units are in play, and they stay separate on purpose. Effects allocate GPU resources in physical pixels, so `Flatland` measures them against the drawing buffer. Shader layout code wants the logical size you authored against, so `globals.viewportSize` reports that instead, paired with `globals.pixelRatio` to convert between the two. [Pixel-Perfect Rendering](../pixel-perfect-rendering/) covers device pixel ratio and the sizing rules in full.
+
+The default `PixelPerfectCamera` picks a whole-number scale and centres the viewport inside the surface. A whole-number scale rarely fills the surface exactly, so bars are left along two edges and `resolvedAspect` reports the ratio of the viewport rather than of the whole surface.
 
 ## Object Routing
 
@@ -42,19 +44,19 @@ Global uniforms are wired to a sprite's material at `add()` time, which is why a
 
 ## Effect Ownership
 
-An attached `LightEffect` belongs to the `Flatland` that holds it. Replacing the active effect, or clearing it, disposes its GPU resources before detaching. The instance can be attached again and receives a fresh `init → resize → update` sequence, but resource handles it produced while attached are invalid once it is detached.
+An attached `LightEffect` belongs to the `Flatland` that holds it. Replacing the active effect, or clearing it, disposes the effect's GPU resources before detaching it. The instance can be attached again and receives a fresh `init → resize → update` sequence. Handles it produced while attached become invalid once it is detached.
 
-This is the same contract `dispose()` honours for the whole object: the ECS world, the sprite batches, the render pipeline, and every pass effect entity are destroyed together. Ownership is not shared, so there is no case where two objects both believe they hold a buffer.
+`dispose()` honours the same contract for the whole object. The ECS world, the sprite batches, the render pipeline, and every pass effect entity are destroyed together. Ownership is never shared, so two objects can never hold conflicting claims on one buffer.
 
 ## The Post-Processing Trade
 
 Adding the first pass changes how a frame is drawn. Without passes, the scene draws straight to the destination. With one or more, the scene renders to an offscreen target and each pass runs as a full-screen draw over it.
 
 :::tip[Performance note]
-One or two passes are cheap. A long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where the maths allows it.
+One or two passes are cheap. A long chain costs a full-screen sample per pass per frame, so fuse effects into a single pass where the math allows it.
 :::
 
-That switch is invisible from the API and worth knowing about anyway, because it explains why the first `addPass()` call has a cost the second one does not.
+The switch is invisible from the API. It is also why the first `addPass()` call costs more than the second.
 
 ## Next Steps
 


### PR DESCRIPTION
### **User description**
Closes #101. Stack 3 of 3. **Base: `docs/diataxis-type-purity` (#240)**, which bases on #239.

`diataxis.md` names this page as the repo's mode-mixing exemplar:

> A **Concept** page (Explanation) carrying a "Basic Setup" section and a Constructor Options table — e.g. `flatland.mdx` fuses explanation + how-to + reference.

It sat in the **Concepts** sidebar group while carrying Basic Setup, a constructor-options block, and eight how-to sections.

## The split

| Stays on `flatland.mdx` (Explanation) | Moves to `flatland-setup.mdx` (How-to) |
| --- | --- |
| What Flatland owns, and the Flatland-vs-SpriteGroup trade | Basic Setup, Constructor Options |
| What happens in a frame | Adding Objects, Lighting |
| Object routing | Sizing and Aspect |
| Effect ownership | Global Uniforms, Statistics |
| The post-processing trade | Post-Processing, Render to Texture, Disposal |

This matches the `lighting` / `lighting-setup` and `shadows` / `shadows-setup` pairs already in the repo. Reference tables travel with the how-to for now; lifting them to the API reference is #104.

The how-to spans were carried across **verbatim**, so this is a structural split rather than an unreviewed rewrite of existing prose. Only the new Explanation page is new writing.

## Three reader-persona reviews, and what they caught

Reviewed by three Sonnet agents briefed with `anti-slop.md`, the `marketing-voice` calm register, and `diataxis.md` — one per persona from the skill's "The reader" section.

**Content loss (highest severity, both verified against the original):**

- The concept page never said Flatland reads the render surface and updates its camera on its own. That made *Sizing and Aspect* read as if camera tracking needs a manual `resize()` — the opposite of the original, and enough to make a reader rebuild the resize bridge the page tells them to delete.
- The assignable `flatland.aspect` property vanished from both pages. A call signature going missing off a how-to.

**Duplication the split was supposed to eliminate:** effect lifecycle, object routing, and the offscreen-target explanation each appeared on both pages. Each now lives on the concept page, with the how-to carrying a one-line anchored cross-link.

**Prose fixes:** split the sentence stacking DPR, drawing-buffer pixels and texels before its clause resolved, and linked Pixel-Perfect Rendering at the point of use; replaced "letterboxed" with a plain description, since it borrows a video-framing analogy that does not map onto integer-scale viewport math; unstacked a three-clause `addPass()` sentence; dropped a personification; fixed a `math`/`maths` inconsistency.

**What passed:** no marketing intensifiers, no first-person, no three-beat, no `X is like Y` anywhere. One reviewer called the pages "the best showing against failure mode #2."

## Verification

- `pnpm --filter=docs build` — exit 0, **504 pages** (503 + the new page)
- All three cross-link anchors (`#effect-ownership`, `#object-routing`, `#the-post-processing-trade`) resolve in the built HTML
- Every original H2 accounted for on exactly one page

No changeset: `docs/` is unpublished.


___

### **PR Type**
Documentation


___

### **Description**
- Split `guides/flatland.mdx` into pure explanation content.

- Move setup recipes, constructor options, and tables to `flatland-setup.mdx`.

- Register new Flatland Setup page in the Guides sidebar.

- Keep concept narratives for ownership, routing, and frame pipeline.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["guides/flatland.mdx"] -- "keeps explanation only" --> B["Flatland Concept"]
  A -- "moves how-to content" --> C["guides/flatland-setup.mdx"]
  C -- "registered in sidebar" --> D["astro.config.mjs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>astro.config.mjs</strong><dd><code>Register Flatland Setup guide in sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/astro.config.mjs

- Add `Flatland Setup` entry to the Guides sidebar items list.


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/242/files#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flatland-setup.mdx</strong><dd><code>Create Flatland setup how-to page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/content/docs/guides/flatland-setup.mdx

<ul><li>Add new how-to page with Three.js and React tabs for basic setup.<br> <li> Include constructor options, object routing, lighting, sizing, and <br>uniform sections.<br> <li> Document statistics, post-processing, render-to-texture, and disposal <br>workflows.<br> <li> Add next steps that cross-link to the concept page and related guides.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/242/files#diff-9af0a2a16854d973bf9423335a4fcebb7566f6fc3ff3aa64e3b2c0f6aaf1b120">+322/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flatland.mdx</strong><dd><code>Refactor Flatland concept page to explanation only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/content/docs/guides/flatland.mdx

<ul><li>Remove Tabs, code blocks, option tables, and method tables.<br> <li> Focus on explanation topics: Flatland vs SpriteGroup, frame pipeline, <br>object routing, effect ownership, and post-processing trade.<br> <li> Add <code>Diagram</code> import and frame pipeline diagram.<br> <li> Update description and next steps to link to setup guide.</ul>


</details>


  </td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/242/files#diff-5d4f1fe2a15abecc4fdb52872bf5082b04a5ad4055fd30b1eebf6d8ab59aad85">+26/-311</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

