### PR TITLE
docs: sentence-case headings site-wide, plus copied anthropomorphism and two superlatives

### DIFF
--- a/docs/src/content/docs/branding.mdx
+++ b/docs/src/content/docs/branding.mdx
@@ -11,31 +11,31 @@ This page provides live-rendered versions of the `three-flatland` marketing asse
 
 <p><strong>Click an asset below</strong> to open it in a full-resolution capture modal. Once in the modal, right-click the asset, select <strong>Inspect</strong>, and use <strong>Capture node screenshot</strong>.</p>
 
-## Official Icon
+## Official icon
 
 <div className="asset-preview-link" data-type="icon-only">
   <BrandAsset id="preview-icon-only" type="icon-only" />
 </div>
 
-## Repository Banner (1280x640)
+## Repository banner (1280x640)
 
 <div className="asset-preview-link" data-type="banner">
   <BrandAsset id="preview-banner" type="banner" />
 </div>
 
-## Social Preview Card (1200x630)
+## Social preview card (1200x630)
 
 <div className="asset-preview-link" data-type="og">
   <BrandAsset id="preview-og" type="og" />
 </div>
 
-## Bluesky Banner (3000x1000)
+## Bluesky banner (3000x1000)
 
 <div className="asset-preview-link" data-type="wide">
   <BrandAsset id="preview-wide" type="wide" />
 </div>
 
-## X Card Preview (1200x628)
+## X card preview (1200x628)
 
 <div className="asset-preview-link" data-type="social-x">
   <BrandAsset id="preview-social-x" type="social-x" />

--- a/docs/src/content/docs/examples/animation.mdx
+++ b/docs/src/content/docs/examples/animation.mdx
@@ -40,7 +40,7 @@ const sprite = new AnimatedSprite2D({
 });
 ```
 
-## Playback Control
+## Playback control
 
 ```typescript
 sprite.play('run');              // Play by name
@@ -50,7 +50,7 @@ sprite.play('hit', {
 sprite.speed = 1.5;              // 1.5x speed
 ```
 
-## Animation Update
+## Animation update
 
 Advance the animation each frame by calling `update(deltaMs)`:
 
@@ -68,7 +68,7 @@ function animate() {
 }
 ```
 
-## Further Reading
+## Further reading
 
 - [TSL Nodes](../tsl-nodes/) - Add custom shader effects
 - [Tilemap](../tilemap/) - Create tile-based maps

--- a/docs/src/content/docs/examples/basic-sprite.mdx
+++ b/docs/src/content/docs/examples/basic-sprite.mdx
@@ -38,7 +38,7 @@ const sprite = new Sprite2D({
 });
 ```
 
-## Further Reading
+## Further reading
 
 - [Animation](../animation/) - Add spritesheet animation
 - [Batch Demo](../batch-demo/) - Render thousands of sprites

--- a/docs/src/content/docs/examples/batch-demo.mdx
+++ b/docs/src/content/docs/examples/batch-demo.mdx
@@ -17,7 +17,7 @@ export const reactFiles = loadExample('react', 'batch-demo')
   reactFiles={reactFiles}
 >
 
-## Automatic Batching
+## Automatic batching
 
 `SpriteGroup` automatically batches sprites that share the same material, minimizing draw calls:
 
@@ -33,7 +33,7 @@ for (let i = 0; i < 1000; i++) {
 }
 ```
 
-## Sort Layers and Sorting
+## Sort layers and sorting
 
 Use sort layers and zIndex for proper depth sorting:
 
@@ -53,7 +53,7 @@ const { spriteCount, batchCount, visibleSprites } = spriteGroup.stats;
 console.log(`Sprites: ${spriteCount}, Batches: ${batchCount}, Visible: ${visibleSprites}`);
 ```
 
-## Further Reading
+## Further reading
 
 - [TSL Nodes](../tsl-nodes/) - Add shader effects
 - [Tilemap](../tilemap/) - Efficient tile-based rendering

--- a/docs/src/content/docs/examples/hit-test.mdx
+++ b/docs/src/content/docs/examples/hit-test.mdx
@@ -220,7 +220,7 @@ The raycast contract is the foundation; these build on it and are tracked separa
 - **Skia node hit-testing** — path-accurate picking inside Skia surfaces via `SkPath::contains` in our WASM C API ([#130](https://github.com/thejustinwalsh/three-flatland/issues/130)).
 - **Baked alpha sidecar schema** — `meta.alpha` atlas-JSON discovery, landing with the atlas schema work ([#124](https://github.com/thejustinwalsh/three-flatland/issues/124)).
 
-## Further Reading
+## Further reading
 
 - [Hit Testing Guide](../../guides/hit-testing/) — the task recipes outside this example's context, including `@pmndrs/pointer-events` and the open-work roadmap
 - [Sprites Guide](../../guides/sprites/) — Sprite2D properties and layers

--- a/docs/src/content/docs/examples/knightmark.mdx
+++ b/docs/src/content/docs/examples/knightmark.mdx
@@ -18,7 +18,7 @@ export const reactFiles = loadExample('react', 'knightmark')
   showCommonFiles={['public/sprites/knight.json']}
 >
 
-## What It Demonstrates
+## What it demonstrates
 
 Knightmark is a sprite stress test inspired by classic benchmarks like Bunnymark. It showcases:
 
@@ -27,9 +27,9 @@ Knightmark is a sprite stress test inspired by classic benchmarks like Bunnymark
 - **Spatial hashing** — efficient collision detection between sprites
 - **Y-sorting** — depth-correct rendering via `zIndex`
 
-## Key Patterns
+## Key patterns
 
-### Animated Sprites with State Machines
+### Animated sprites with state machines
 
 Each knight has a state machine (walk, roll, trip, idle) driving its animation:
 
@@ -47,7 +47,7 @@ sprite.play('death', {
 });
 ```
 
-### Y-Sort Depth Ordering
+### Y-Sort depth ordering
 
 Knights render in correct depth order by setting `zIndex` from their Y position:
 
@@ -55,7 +55,7 @@ Knights render in correct depth order by setting `zIndex` from their Y position:
 sprite.zIndex = -Math.floor(sprite.position.y);
 ```
 
-### Spatial Hash for Collisions
+### Spatial hash for collisions
 
 A simple spatial hash grid enables O(n) collision checks instead of O(n^2):
 
@@ -68,7 +68,7 @@ spatialHash.forEachNeighbor(knight, (other) => {
 });
 ```
 
-## Further Reading
+## Further reading
 
 - [Batch Rendering](../batch-demo/) - Learn more about batching
 - [Animation](../animation/) - Sprite animation basics

--- a/docs/src/content/docs/examples/lighting.mdx
+++ b/docs/src/content/docs/examples/lighting.mdx
@@ -17,7 +17,7 @@ export const reactFiles = loadExample('react', 'lighting')
   reactFiles={reactFiles}
 >
 
-## Interactive Lighting Demo
+## Interactive lighting demo
 
 This example demonstrates dynamic 2D lighting using `DefaultLightEffect` (Forward+ tiled culling): flickering torch lights, an animated hero and slime sprites, and a click-to-walk hero exploring an LDtk dungeon. Walk the hero up to a switchable torch and toggle it to watch the lit area change:
 
@@ -27,7 +27,7 @@ This example demonstrates dynamic 2D lighting using `DefaultLightEffect` (Forwar
 | **WASD / arrow keys** | Move the hero directly |
 | **Space** | Toggle the nearest switchable torch on/off |
 
-## Lighting Setup
+## Lighting setup
 
 The scene uses `DefaultLightEffect` (Forward+ tiled culling) for efficient per-tile light culling:
 
@@ -85,7 +85,7 @@ flatland.add(knight)
 const indicator = new Sprite2D({ texture: circleTexture, lit: false })
 ```
 
-## React: Declarative Lighting
+## React: declarative lighting
 
 In React, use `attachLighting` to wire the LightEffect to Flatland, `attachEffect` for normal providers, and `light2D` JSX elements for lights:
 
@@ -114,7 +114,7 @@ extend({ Flatland, Sprite2D, Light2D, DefaultLightEffect, NormalMapProvider })
 </flatland>
 ```
 
-## Further Reading
+## Further reading
 
 - [2D Lighting Guide](../../guides/lighting-setup/) — Full reference for `DefaultLightEffect`, normal providers, and shadow controls
 - [2D Lighting Concept](../../guides/lighting/) — How Forward+ tiling and the slot budget work

--- a/docs/src/content/docs/examples/pass-effects.mdx
+++ b/docs/src/content/docs/examples/pass-effects.mdx
@@ -18,7 +18,7 @@ export const reactFiles = loadExample('react', 'pass-effects')
   reactFiles={reactFiles}
 >
 
-## What This Example Shows
+## What this example shows
 
 This example demonstrates the **Pass Effect** system for full-screen post-processing. Switch between 5 presets to see different effect chains applied to a sprite scene:
 
@@ -30,7 +30,7 @@ This example demonstrates the **Pass Effect** system for full-screen post-proces
 | VHS Tape | 3 | VHS distortion + static noise + chromatic aberration |
 | Retro PC | 3 | Color quantize + scanlines + vignette |
 
-## Defining Pass Effects
+## Defining pass effects
 
 Use `createPassEffect` with a schema for parameters and a TSL node builder:
 
@@ -93,7 +93,7 @@ Use `createPassEffect` with a schema for parameters and a TSL node builder:
   </TabItem>
 </Tabs>
 
-## Adding Passes at Runtime
+## Adding passes at runtime
 
 Instantiate a pass and add it to Flatland. Passes chain in order — each receives the previous output:
 
@@ -140,7 +140,7 @@ Instantiate a pass and add it to Flatland. Passes chain in order — each receiv
   </TabItem>
 </Tabs>
 
-## Further Reading
+## Further reading
 
 - [Pass Effects Guide](../../guides/pass-effects/) — Full API reference and pass chain architecture
 - [TSL Nodes](../tsl-nodes/) — Per-sprite material effects

--- a/docs/src/content/docs/examples/skia.mdx
+++ b/docs/src/content/docs/examples/skia.mdx
@@ -18,7 +18,7 @@ export const reactFiles = loadExample('react', 'skia')
   reactFiles={reactFiles}
 >
 
-## What It Demonstrates
+## What it demonstrates
 
 - **SkiaCanvas** — off-screen texture rendering and screen-space overlay modes
 - **Drawing nodes** — `SkiaRect`, `SkiaCircle`, `SkiaLine`, `SkiaPathNode`, `SkiaTextNode`, `SkiaGroup`
@@ -28,9 +28,9 @@ export const reactFiles = loadExample('react', 'skia')
 - **attachSkiaTexture** — R3F attach helper for compositing Skia output onto 3D mesh materials
 - **useFrame phases** — `{ before: 'render' }` and `{ after: 'render' }` for render pipeline control
 
-## Key Patterns
+## Key patterns
 
-### Texture Mode
+### Texture mode
 
 Render Skia shapes to a texture and apply it to a 3D mesh:
 
@@ -66,7 +66,7 @@ Render Skia shapes to a texture and apply it to a 3D mesh:
   </TabItem>
 </Tabs>
 
-### Overlay Mode
+### Overlay mode
 
 Draw directly on top of the 3D scene (HUD, debug text):
 
@@ -104,7 +104,7 @@ Draw directly on top of the 3D scene (HUD, debug text):
   </TabItem>
 </Tabs>
 
-### Custom Paints (Gradients, Shaders)
+### Custom paints (Gradients, shaders)
 
 For effects beyond flat fill/stroke, create a `SkiaPaint` and assign it to a node's `paint` prop:
 
@@ -144,7 +144,7 @@ For effects beyond flat fill/stroke, create a `SkiaPaint` and assign it to a nod
 In React, create `SkiaPaint` and `SkiaPath` with `useState(() => ...)` initializers instead of `useMemo`. The `useState` initializer runs exactly once and survives React strict mode double-mounts, while `useMemo` can re-evaluate and cause WASM handles to be disposed unexpectedly.
 :::
 
-## Further Reading
+## Further reading
 
 - [Skia Guide](../../guides/skia/) — Concepts and API reference
 - [Basic Sprite](../basic-sprite/) — Three-flatland sprites

--- a/docs/src/content/docs/examples/slug-text.mdx
+++ b/docs/src/content/docs/examples/slug-text.mdx
@@ -14,7 +14,7 @@ export const reactFiles = loadExample('react', 'slug-text')
 
 <ExampleDetailLayout slug="slug-text" threeFiles={threeFiles} reactFiles={reactFiles}>
 
-## What This Example Shows
+## What this example shows
 
 This example demonstrates [`@three-flatland/slug`](../../guides/slug-text/) — GPU-accelerated text rendering that stays crisp at any zoom. Glyphs are evaluated as quadratic Bezier curves per-pixel in the fragment shader; there's no SDF atlas, no bitmap textures, no resolution ceiling.
 
@@ -27,7 +27,7 @@ This example demonstrates [`@three-flatland/slug`](../../guides/slug-text/) — 
 | Decorations             | Underline / strikethrough / super-sub via `StyleSpan[]`                               |
 | Canvas2D compare        | Onion / split / diff modes against `CanvasRenderingContext2D` for visual parity check |
 
-## Loading a Font
+## Loading a font
 
 `SlugFontLoader.load()` is the single entry point. It tries baked data (a single `.slug.glb`) first and falls back to runtime parsing of TTF/OTF/WOFF — opentype.js is dynamic-imported only on the runtime path, so baked-only bundles ship without it.
 
@@ -52,7 +52,7 @@ This example demonstrates [`@three-flatland/slug`](../../guides/slug-text/) — 
   </TabItem>
 </Tabs>
 
-## Rendering Text
+## Rendering text
 
 `SlugText` extends `InstancedMesh` — each glyph is an instanced quad evaluated per-pixel by the Slug fragment shader. Set `.text`, `.fontSize`, `.align` etc. and call `.update(camera)` once per frame.
 
@@ -141,7 +141,7 @@ Pass an `outline` option (or set `.outline` at runtime) to add a stroked outline
   </TabItem>
 </Tabs>
 
-## Multi-font Fallback
+## Multi-font fallback
 
 `SlugFontStack` composes multiple fonts and resolves missing codepoints per-character. `SlugStackText` renders one `InstancedMesh` per backing font, all parented under a `Group`.
 
@@ -180,7 +180,7 @@ Pass an `outline` option (or set `.outline` at runtime) to add a stroked outline
   </TabItem>
 </Tabs>
 
-## Further Reading
+## Further reading
 
 - [Slug Text Guide](../../guides/slug-text/) — Full API reference and patterns (measurement, decorations, pre-baking).
 - [TSL Nodes](../tsl-nodes/) — Custom shader effects via Three Shader Language.

--- a/docs/src/content/docs/examples/tilemap.mdx
+++ b/docs/src/content/docs/examples/tilemap.mdx
@@ -17,7 +17,7 @@ export const reactFiles = loadExample('react', 'tilemap')
   reactFiles={reactFiles}
 >
 
-## Tilemap Setup
+## Tilemap setup
 
 Load a map file and create a `TileMap2D`. Both `TiledLoader` and `LDtkLoader` return a `TileMapData` structure that `TileMap2D` consumes:
 
@@ -52,7 +52,7 @@ const gid = groundLayer.getTileAt(x, y);
 wallsLayer.setTileAt(x, y, newGid);
 ```
 
-## Animated Tiles
+## Animated tiles
 
 Call `update(deltaMs)` each frame to advance tile animations defined in the source map:
 
@@ -64,7 +64,7 @@ function animate() {
 }
 ```
 
-## Further Reading
+## Further reading
 
 - [Tilemaps Guide](../../guides/tilemaps/) - Advanced tilemap features
 - [Batch Rendering](../batch-demo/) - Other optimization techniques

--- a/docs/src/content/docs/examples/tsl-nodes.mdx
+++ b/docs/src/content/docs/examples/tsl-nodes.mdx
@@ -18,7 +18,7 @@ export const reactFiles = loadExample('react', 'tsl-nodes')
   reactFiles={reactFiles}
 >
 
-## What This Example Shows
+## What this example shows
 
 This example demonstrates the **Material Effect** system — the recommended way to create per-sprite shader effects. It showcases 8 visual modes on an animated sprite:
 
@@ -33,7 +33,7 @@ This example demonstrates the **Material Effect** system — the recommended way
 | Shadow | Dark blue tint with reduced alpha |
 | Pixelate | Resolution reduction and restoration |
 
-## Defining Effects
+## Defining effects
 
 Effects are defined with `createMaterialEffect`, which takes a schema for per-sprite data and a TSL node builder:
 
@@ -84,7 +84,7 @@ Effects are defined with `createMaterialEffect`, which takes a schema for per-sp
   </TabItem>
 </Tabs>
 
-## Applying Effects at Runtime
+## Applying effects at runtime
 
 Instantiate an effect, add it to a sprite, and animate its properties:
 
@@ -117,7 +117,7 @@ Instantiate an effect, add it to a sprite, and animate its properties:
   </TabItem>
 </Tabs>
 
-## Further Reading
+## Further reading
 
 - [TSL Nodes Guide](../../guides/tsl-nodes/) - Full node reference and Material Effect documentation
 - [Tilemap](../tilemap/) - Tile-based map rendering

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -10,7 +10,7 @@ import { Tabs, TabItem, Aside } from 'starlight-theme/components'
   `package.json` until you're ready to migrate.
 </Aside>
 
-## Scaffold a New Project
+## Scaffold a new project
 
 `create-three-flatland` generates a Vite-powered WebGPU starter: an interactive sprite scene, a Suspense
 loading overlay, oxlint/oxfmt, unit and Playwright tests, and `AGENTS.md`/`CLAUDE.md` so coding agents
@@ -53,7 +53,7 @@ npm create three-flatland@latest my-app -- --template three
 
 To add three-flatland to a project you already have, install the packages directly instead.
 
-## Package Manager
+## Package manager
 
 <Tabs syncKey="pkg">
   <TabItem label="npm" icon="simple-icons:npm">
@@ -96,7 +96,7 @@ To add three-flatland to a project you already have, install the packages direct
   </TabItem>
 </Tabs>
 
-### React Three Fiber (Optional)
+### React three fiber (Optional)
 
 React is not required. If you're using React Three Fiber, add the additional dependencies:
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -9,7 +9,7 @@ This guide shows you how to create your first sprite using three-flatland. Two m
 
 The code below drops into any project that already has three-flatland installed. Starting from nothing? [`npm create three-flatland@latest`](../installation/#scaffold-a-new-project) scaffolds a working Vite project with this scene already wired up.
 
-## Create a Sprite
+## Create a sprite
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -97,7 +97,7 @@ The code below drops into any project that already has three-flatland installed.
 WebGPU initialization is async. Forgetting `await renderer.init()` before the first render is the single most common bug in fresh three-flatland projects. If you see a blank canvas with no errors, this is almost always why.
 :::
 
-## Next Steps
+## Next steps
 
 - [Learn about sprites](../../guides/sprites/) - Position, scale, and customize sprites
 - [Keep pixel art crisp](../../guides/pixel-perfect-rendering/) - Coordinate cameras, snapping, textures, and DPR

--- a/docs/src/content/docs/guides/animation.mdx
+++ b/docs/src/content/docs/guides/animation.mdx
@@ -120,7 +120,7 @@ If you've ever wired up sprite animation by hand — frame timers, wraparound ma
   </TabItem>
 </Tabs>
 
-## Animation Set Definition
+## Animation set definition
 
 The `animationSet` option provides a structured way to define multiple animations:
 
@@ -143,7 +143,7 @@ animationSet: {
 }
 ```
 
-## Playback Control
+## Playback control
 
 ```typescript
 sprite.play('run') // Play animation by name
@@ -158,7 +158,7 @@ sprite.isPlaying('run') // Is 'run' animation playing?
 sprite.currentAnimation // Get current animation name
 ```
 
-## Playback Speed
+## Playback speed
 
 ```typescript
 sprite.speed = 1.5 // 1.5x speed
@@ -166,7 +166,7 @@ sprite.speed = 0.5 // Half speed
 sprite.speed = 2 // Double speed
 ```
 
-## Animation Callbacks
+## Animation callbacks
 
 Use the `play()` method's options to handle animation events:
 
@@ -186,7 +186,7 @@ sprite.play('attack', {
 })
 ```
 
-## Loading Spritesheets
+## Loading spritesheets
 
 The `SpriteSheetLoader` supports Aseprite JSON format. Texture presets (like `NearestFilter` for pixel art) are automatically applied:
 
@@ -205,7 +205,7 @@ console.log(frame) // { x, y, width, height, sourceWidth, sourceHeight, ... }
 See the [Loaders guide](../loaders/#texture-presets) to configure presets for smooth or pixel-art rendering.
 :::
 
-## Update Loop
+## Update loop
 
 The `update(deltaMs)` method must be called each frame to advance the animation:
 

--- a/docs/src/content/docs/guides/baking.mdx
+++ b/docs/src/content/docs/guides/baking.mdx
@@ -20,7 +20,7 @@ You only need this page when you're ready to *ship*. During development, the run
 
 For the runtime side of the same pipeline — how `SpriteSheetLoader` and `LDtkLoader` consume baked siblings via `normals: true` — see the [Baked Normal Pipeline](../loaders/#baked-normal-pipeline) section of the Loaders guide. This page is the *workflow* counterpart: how to run the baker offline, integrate it into CI, and reason about staleness.
 
-## The Bake Pipeline at a Glance
+## The bake pipeline at a glance
 
 <Diagram caption="The baked-normal pipeline — probe for a hash-stamped sidecar, load it on a match, or fall back to an in-memory bake; forceRuntime skips the probe." src={bakedNormalPipeline} />
 
@@ -72,7 +72,7 @@ Contributed by `@three-flatland/alphamap`. Reads an RGBA PNG and writes `<input>
 npx flatland-bake alpha <input.png> [output.png]
 ```
 
-## Sidecar Files & Hash Stamping
+## Sidecar files & hash stamping
 
 The baker writes a sibling PNG next to the source. Naming follows a fixed convention per baker type:
 
@@ -92,7 +92,7 @@ When the runtime probes the sidecar:
 3. Parse the `flatland` `tEXt` chunk and compare its `hash` to what the loader would have used.
 4. **Match** → load the baked PNG directly. **Mismatch** → re-bake in memory and warn.
 
-## Dev-Time Staleness Warnings
+## Dev-Time staleness warnings
 
 `devtimeWarn` is the shared warning channel — gated on `NODE_ENV !== 'production'` and deduped per `(category, url)` so the same message never fires twice. Sidecar-aware loaders use it uniformly across the ecosystem (currently just `normal`; future bakers slot into the same surface).
 
@@ -108,7 +108,7 @@ Two warning shapes you'll see while iterating:
 
 The canonical fix is to **re-bake** — run `flatland-bake` with the same descriptor your loader is using, the hash matches, the warning goes away. Don't reach for `forceRuntime` here: that flag declares "this asset's normal map is generated in the browser as a matter of architecture" (see [Browser-generated assets](#browser-generated-assets) below), not "shut this warning up while I iterate." Silencing the warn the wrong way buries the signal — the engine still gives you the data, but future maintainers lose the breadcrumb pointing at the missing bake step.
 
-## CI / Build Integration
+## CI / build integration
 
 `flatland-bake` is CLI-only today — there's no Vite or Rollup plugin yet. The recommended pattern is a `package.json` script that runs ahead of your main build:
 
@@ -125,7 +125,7 @@ For tilemaps and other multi-region descriptors, drive the bake from a small `ts
 
 The output PNGs are deterministic for a given descriptor — same input, same hash stamp, same bytes. Re-running the bake is a no-op when nothing changed, which makes incremental builds and `git diff` review straightforward.
 
-## When to Bake Offline vs Runtime
+## When to bake offline vs runtime
 
 :::tip[Performance note]
 Both paths produce identical pixel data — the in-memory bake and `flatland-bake` share the same `bakeNormalMap` core. The choice is about *when* the work happens, not what comes out. Iterate runtime; ship offline.
@@ -141,7 +141,7 @@ The choice is about *when* the work happens:
 
 In production, ship baked siblings and the loader becomes a single-image-fetch with no decode overhead. In development, skip the bake step entirely and let the runtime regenerate — much faster than re-running the CLI on every descriptor tweak.
 
-## Browser-Generated Assets
+## Browser-Generated assets
 
 `forceRuntime: true` declares **the browser is where this asset's normal map is produced** — not the CI bake step. The contract that "if you ask for normals, you get normals" doesn't change; only *where* the bake runs does.
 
@@ -161,11 +161,11 @@ const sheet = await SpriteSheetLoader.load('./sprites/proc-tiles.json', {
 
 If you just want to silence a stale-sidecar warning while iterating, **re-bake** instead. `forceRuntime` is the wrong tool for that — it silences the warn but it also tells every future maintainer "this asset's normals are produced in the browser, on purpose, forever," which is a different statement about the project's architecture.
 
-## Adding a New Bake Type
+## Adding a new bake type
 
 `@three-flatland/bake` is the generic framework; `@three-flatland/normals` is the model implementation. A new bake type lives in its own package, declares a `flatland.bake` manifest entry in its `package.json` pointing at a default-exported `Baker`, and reuses `hashDescriptor` + `writeSidecarPng` from `@three-flatland/bake/node` to stamp its outputs. On the runtime side it imports `bakedSiblingURL`, `probeBakedSibling`, and `devtimeWarn` from `@three-flatland/bake` to wire up the same probe-then-fallback flow. Once published, `flatland-bake --list` picks up the subcommand automatically — no central registry, no version coupling.
 
-## Related Reading
+## Related reading
 
 - **Runtime side of the normal pipeline** — [Loaders → Baked Normal Pipeline](../loaders/#baked-normal-pipeline)
 - **Wiring baked normals into lighting** — [Lighting → NormalMapProvider](../lighting-setup/#normalmapprovider)

--- a/docs/src/content/docs/guides/batch-rendering.mdx
+++ b/docs/src/content/docs/guides/batch-rendering.mdx
@@ -215,7 +215,7 @@ console.log(`Draw calls: ${renderer.info.render.calls}`)
 ### Share materials
 
 :::tip[Performance note]
-Sprites only batch together when they share the **same material instance** — not just the same texture, the same `new Sprite2DMaterial(...)` reference. Allocating a fresh material per sprite is the easiest way to silently tank batching.
+Sprites only batch together when they share the **same material instance** — not just the same texture, the same `new Sprite2DMaterial(...)` reference. Allocating a fresh material per sprite prevents batching, with no error to indicate it.
 :::
 
 ```typescript

--- a/docs/src/content/docs/guides/batch-rendering.mdx
+++ b/docs/src/content/docs/guides/batch-rendering.mdx
@@ -11,7 +11,7 @@ SpriteGroup automatically batches sprites that share the same material into sing
 
 The defaults are tuned for the common case (thousands of sprites, one or two materials). You almost never need to think about batching — but on the day you do, this page is the map.
 
-## How It Works
+## How it works
 
 When you add sprites to a `SpriteGroup`, they're grouped by material and layer into efficient GPU batches. Systems run automatically during Three.js rendering — no manual `update()` call needed.
 
@@ -112,7 +112,7 @@ The hint is advisory, not a hard cap. Enrollment continues automatically past it
 
 In React Three Fiber, pass a stable or memoized options tuple through `args`. `expectedSprites` is intentionally not a mutable JSX property, so changing the hint means changing the memoized constructor args and letting React Three Fiber reconstruct the object. Do not write `<spriteGroup expectedSprites={...}>` or `<flatland expectedSprites={...}>`.
 
-## Renderer Options
+## Renderer options
 
 The `SpriteGroup` constructor accepts optional batch configuration:
 
@@ -177,7 +177,7 @@ Older releases flattened some batched sprites against the batching root. If your
 When an automatically batched or retained hierarchy source remains in the authored scene graph, the batch suppresses its duplicate draw by temporarily setting the runtime `isMesh` discriminator to `false`. It returns to `true` when the sprite leaves the batch and has renderable content. Direct `SpriteGroup` sources are not scene children and can keep `isMesh === true`. Use `sprite instanceof Sprite2D` rather than `sprite.isMesh` to classify logical sprites, and serialize authored sprite data before enrollment: generic `Object3D.toJSON()` omits mesh geometry while a source draw is suppressed.
 :::
 
-## Automatic Change Detection
+## Automatic change detection
 
 Property changes on sprites are detected automatically through the ECS. When you update a sprite's tint, alpha, flip, frame, sortLayer, position, or ancestor transform, the renderer syncs only the changed data to the GPU on the next frame. No manual invalidation is needed with the default `autoInvalidateTransforms: true`.
 
@@ -193,7 +193,7 @@ For a static scene with `autoInvalidateTransforms: false`, call `spriteGroup.inv
 
 Retained hierarchy mode checks the authored subtree on each matrix update so arbitrary Three.js reparenting is detected without a Flatland-specific mutation API. For very large flat populations, add sprites directly to `SpriteGroup` or use automatic batching; those paths avoid the retained-subtree walk.
 
-## Performance Monitoring
+## Performance monitoring
 
 Check batch efficiency with the `stats` property:
 
@@ -210,9 +210,9 @@ console.log(`Draw calls: ${renderer.info.render.calls}`)
 
 **Goal:** Keep `batchCount` low relative to `spriteCount`. If you have 1000 sprites but 100 batches, you're not batching efficiently.
 
-## Optimization Tips
+## Optimization tips
 
-### Share Materials
+### Share materials
 
 :::tip[Performance note]
 Sprites only batch together when they share the **same material instance** — not just the same texture, the same `new Sprite2DMaterial(...)` reference. Allocating a fresh material per sprite is the easiest way to silently tank batching.
@@ -229,7 +229,7 @@ sprites.forEach((s) => {
 })
 ```
 
-### Use Texture Atlases
+### Use texture atlases
 
 Combine textures into a single atlas. All sprites using the atlas can share one material:
 
@@ -244,7 +244,7 @@ const player = new Sprite2D({ material, frame: frames.get('player') })
 const enemy = new Sprite2D({ material, frame: frames.get('enemy') })
 ```
 
-### Organize by Sort Layer
+### Organize by sort layer
 
 Sprites are sorted by sortLayer before batching. Keep related sprites on the same layer:
 
@@ -258,7 +258,7 @@ backgrounds.forEach((s) => (s.sortLayer = SortLayers.BACKGROUND))
 entities.forEach((s) => (s.sortLayer = SortLayers.ENTITIES))
 ```
 
-## Custom Materials
+## Custom materials
 
 If you're authoring a custom `Sprite2DMaterial` subclass — or a stand-alone TSL shader that consumes the same per-instance data — you read from the interleaved instance buffer that every batch shares.
 
@@ -329,7 +329,7 @@ Lit sprites in this batch render at full color; sprites with `lit = false` rende
 
 For the broader `colorTransform` / `MaterialEffect` API and where it sits in the pipeline, see the [Pass Effects guide](../pass-effects/). For the Sprite2D-side accessors that drive these flags (`lit`, `receiveShadows`, `castsShadow`, `shadowRadius`), see the [Sprites guide](../sprites/).
 
-## Next Steps
+## Next steps
 
 - [Flatland Guide](../flatland/) — Wrap SpriteGroup with camera, post-processing, and global uniforms
 - [Sprites Guide](../sprites/) — Sprite2D properties and configuration

--- a/docs/src/content/docs/guides/devtools.mdx
+++ b/docs/src/content/docs/guides/devtools.mdx
@@ -41,7 +41,7 @@ import AnnotatedImage from '../../../components/AnnotatedImage.astro';
   caption="Each panel is independently subscribable — collapsing a panel stops the corresponding data collection on the producer side too."
 />
 
-## Vite Plugin Setup
+## Vite plugin setup
 
 The dashboard is served as middleware by your Vite dev server. Add the plugin to your `vite.config.ts`:
 
@@ -79,7 +79,7 @@ The plugin sets `apply: 'serve'` internally — it's inert during production bui
 The dashboard's own assets are served by Vite via `/@fs/`, `/@vite/client`, and `node_modules/.vite/` — none of which are namespaced under the mount path. If your app sits behind a proxy (microfrontends, reverse proxy, etc.), open the dashboard at the underlying Vite port directly rather than the proxy origin.
 :::
 
-## Scene-Side Wiring (Flatland)
+## Scene-Side wiring (Flatland)
 
 Flatland users have nothing to wire up. When `DEVTOOLS_BUNDLED` is true (Vite sets `import.meta.env.DEV` in dev) and `isDevtoolsActive()` returns true at runtime, Flatland constructs its own `DevtoolsProvider` in its constructor and pumps stats into the bus on every `flatland.render(renderer)` call:
 
@@ -139,7 +139,7 @@ The runtime gate `isDevtoolsActive()` returns `false` when `window.__FLATLAND_DE
 The provider is a no-op stub when devtools isn't active, so per-frame cost stays negligible even when no dashboard is connected. Leaving devtools wiring in your scene code is free in production.
 :::
 
-## Scene-Side Wiring (Plain Three.js)
+## Scene-Side wiring (Plain Three.js)
 
 If you're driving three.js directly — no Flatland — call `createDevtoolsProvider()` from `three-flatland` and bracket your render call with `beginFrame` / `endFrame`:
 
@@ -177,7 +177,7 @@ Multi-pass renderers (SDF pass, occlusion pass, post-processing) work correctly:
 
 In production (when `DEVTOOLS_BUNDLED` is `false`), `createDevtoolsProvider` returns a no-op stub; `beginFrame`/`endFrame`/`dispose` all become empty calls that minify away.
 
-## In-Page Tweakpane Controls
+## In-Page Tweakpane controls
 
 `@three-flatland/devtools` wraps [Tweakpane v4](https://tweakpane.github.io/docs/) with a Flatland-themed pane that mounts directly into your page. Because it consumes the same bus as the standalone dashboard, the pane needs no scene wiring of its own — it discovers any provider the page has constructed and streams stats from it.
 
@@ -219,7 +219,7 @@ Two entry points:
 - `@three-flatland/devtools` — vanilla: `createPane`, `DevtoolsClient`, `applyTheme`, `FLATLAND_THEME`.
 - `@three-flatland/devtools/react` — hooks: `usePane`, `usePaneFolder`, `usePaneInput`, `usePaneButton`, `useFpsGraph`.
 
-### What You Get
+### What you get
 
 Calling `createPane()` (or `usePane()`) gives you:
 
@@ -231,7 +231,7 @@ Calling `createPane()` (or `usePane()`) gives you:
 
 There are no extra wiring calls. The pane has zero knowledge of your scene, your renderer, or your frame loop — it discovers a provider on the bus and streams stats. If your app already constructs a Flatland (or calls `createDevtoolsProvider` per the section above), the pane just works.
 
-### Three.js Usage
+### Three.js usage
 
 ```typescript
 import { WebGPURenderer } from 'three/webgpu'
@@ -262,7 +262,7 @@ You don't enable GPU timing yourself. When devtools is active the provider opts 
 
 On WebGPU, the adapter must expose `GPUFeatureName.TimestampQuery` (most desktop browsers). On WebGL2, `EXT_disjoint_timer_query_webgl2` must be present. Values trail by ~1 frame because the readback is async. The pane silently hides `gpu` from the mode cycle when unsupported.
 
-### React Usage
+### React usage
 
 The React hook is R3F-aware: it internally forces `driver: 'manual'` and registers a `useFrame(update, 1000)` at a late priority so the graph tick runs AFTER R3F's auto-render, capturing the true end-of-frame `renderer.info`.
 
@@ -315,7 +315,7 @@ export default function App() {
 
 All hooks create bindings synchronously during render (so controls appear without pop-in) and defer disposal across React Strict Mode's cleanup / re-mount cycle.
 
-### Bus Architecture (for the curious)
+### Bus architecture (for the curious)
 
 The pane, the dashboard, and the provider all communicate via two `BroadcastChannel`s:
 
@@ -338,7 +338,7 @@ applyTheme(pane.element, FLATLAND_THEME)
 
 `applyTheme` sets CSS custom properties on the pane element — fork `FLATLAND_THEME` (it's a plain object) to tweak colours without touching the package.
 
-### Pane Options
+### Pane options
 
 ```typescript
 createPane({
@@ -349,7 +349,7 @@ createPane({
 })
 ```
 
-## Dashboard Panels
+## Dashboard panels
 
 The dashboard renders four panels driven by feature subscriptions. Each panel is independently subscribable — collapse a panel and its data stops being collected on the producer side too.
 
@@ -383,7 +383,7 @@ Registered CPU arrays — `Float32Array`, `Uint32Array`, `Int32Array`. Each entr
 
 Registered `DataTexture` and `RenderTarget` outputs, viewable as images. Readbacks are async — the dashboard only triggers them when a texture is selected for preview, so leaving things registered is free until somebody actually opens the panel.
 
-## Custom Debug Instrumentation
+## Custom debug instrumentation
 
 Anything your scene already keeps in CPU memory or in a render target can show up in the dashboard. The `register*` calls are no-op when devtools isn't bundled, so they're safe to leave permanently in engine code.
 
@@ -460,7 +460,7 @@ The lighting and tile pipelines lean on the same APIs. Treat them as canonical e
 
 Both unregister on dispose to keep the registry tidy across hot-reloads.
 
-## Production Gating
+## Production gating
 
 Two layers turn the entire devtools subsystem off:
 
@@ -487,7 +487,7 @@ Only reachable when `DEVTOOLS_BUNDLED` is true. Reads `window.__FLATLAND_DEVTOOL
 
 This is a one-way switch: rogue clients can't enable devtools that wasn't bundled, so it's safe even if `__FLATLAND_DEVTOOLS__` somehow leaks into a production bundle.
 
-## Next Steps
+## Next steps
 
 - [Pass Effects guide](../pass-effects/) — Many of the lighting fields you'll see in the dashboard come from `DefaultLightEffect`'s schema.
 - [Batch Rendering guide](../batch-rendering/) — Background for what the dashboard's Batches panel is showing you.

--- a/docs/src/content/docs/guides/lighting-setup.mdx
+++ b/docs/src/content/docs/guides/lighting-setup.mdx
@@ -9,7 +9,7 @@ import light2dTypes from '../../../assets/diagrams/light2d-types.svg?raw';
 
 This guide covers the practical side of 2D lighting: adding `Light2D` sources, picking a `LightEffect` preset, animating and dragging lights, and tuning per-tile slot allocation for dense scenes. For the mental model behind Forward+ tiling, the slot budget, and the SDF shadow pass, see [2D Lighting](../lighting/).
 
-## Basic Setup
+## Basic setup
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -119,11 +119,11 @@ This guide covers the practical side of 2D lighting: adding `Light2D` sources, p
 All sprites receive lighting by default when a `LightEffect` is active. Set `lit: false` on sprites that should render at full brightness (e.g., UI elements, light indicators).
 :::
 
-## Light2D Types
+## Light2D types
 
 <Diagram caption="The four Light2D types and their emission shapes — point (radial falloff), directional (parallel rays), spot (soft-edged cone), and ambient (uniform fill)" src={light2dTypes} />
 
-### Point Light
+### Point light
 
 Radiates light from a position with distance-based falloff:
 
@@ -138,7 +138,7 @@ const torch = new Light2D({
 })
 ```
 
-### Directional Light
+### Directional light
 
 Parallel rays from a direction (like sunlight):
 
@@ -151,7 +151,7 @@ const sun = new Light2D({
 })
 ```
 
-### Spot Light
+### Spot light
 
 Cone of light from a position in a direction:
 
@@ -168,7 +168,7 @@ const spotlight = new Light2D({
 })
 ```
 
-### Ambient Light
+### Ambient light
 
 Uniform illumination — affects all lit sprites equally:
 
@@ -180,7 +180,7 @@ const ambient = new Light2D({
 })
 ```
 
-## LightEffect Presets
+## LightEffect presets
 
 `@three-flatland/presets` ships a lighting preset for the recommended rendering path:
 
@@ -216,7 +216,7 @@ lighting.shadowMaxDistance = 300
 
 For the full `DefaultLightEffect` schema (uniforms vs compile-time constants, removed fields, the `categoryQuotas` accessor), see the [Pass Effects guide](../pass-effects/#defaultlighteffect-schema).
 
-## Animating Lights
+## Animating lights
 
 Update Light2D properties at any time — they sync to the GPU automatically each frame:
 
@@ -242,7 +242,7 @@ function animate(delta: number) {
 }
 ```
 
-## Draggable Lights
+## Draggable lights
 
 Make lights interactive by converting screen coordinates to world space:
 
@@ -270,7 +270,7 @@ canvas.addEventListener('mouseup', () => {
 })
 ```
 
-## Light2D Properties
+## Light2D properties
 
 :::note[`type` vs `lightType`]
 The constructor option is `type` (`new Light2D({ type: 'point' })`); the instance property and the R3F prop are `lightType` (`<light2D lightType="point" />`). Both set the same thing — the constructor just uses the shorter key.
@@ -292,7 +292,7 @@ The constructor option is `type` (`new Light2D({ type: 'point' })`); the instanc
 | `category` | `string \| undefined` | `undefined` | Bucket tag for fill-light quotas |
 | `position2D` | `Vector2` | `(0, 0)` | 2D position helper |
 
-## Shadow Casting, Importance & Categories
+## Shadow casting, importance & categories
 
 Three Light2D fields control how lights compete for per-tile slots in dense scenes: `castsShadow` splits lights into heroes and fills, `importance` biases the rank score, and `category` buckets fills into independent quotas. They do nothing in small scenes; they make dense scenes readable. For why the slot budget exists and when these knobs start to matter, see [Tiled lighting and the slot budget](../lighting/#tiled-lighting-and-the-slot-budget).
 
@@ -426,7 +426,7 @@ In the `examples/react/lighting/` demo, the slime-quota slider drives `categoryQ
 - **Score-ranked eviction within a quota is intuitive.** When a category's quota is full and another fill of that category enters range, the closer / brighter one wins the slot. Tweaking individual fill `intensity` indirectly affects who survives in saturated tiles.
 - **Fills are cheap to leave on.** `light.enabled = false` is a zero-cost cull (rejected before per-tile upload), but a `castsShadow: false` fill that's just dim and far away is also nearly free — Forward+ won't even rank it into a tile it can't reach. Don't over-engineer toggling.
 
-## Normal Providers
+## Normal providers
 
 `DefaultLightEffect` supports normal-based directional diffuse shading. To enable it, add a normal provider effect to your sprites.
 
@@ -472,7 +472,7 @@ so leaving the runtime-bake fallback enabled is safe for sites where sidecars
 are always present — the bake path stays dormant.
 :::
 
-## Next Steps
+## Next steps
 
 - [2D Lighting](../lighting/) — The mental model: Forward+ tiling, the slot budget, and the SDF shadow pass
 - [Lighting Example](../../examples/lighting/) — Interactive demo with draggable lights and a live slime-quota slider

--- a/docs/src/content/docs/guides/lighting.mdx
+++ b/docs/src/content/docs/guides/lighting.mdx
@@ -24,7 +24,7 @@ three-flatland provides a complete 2D lighting system. Add `Light2D` instances a
 
 You don't need to understand Forward+, SDF tracing, or per-tile slot allocation to make a torch work — drop a `DefaultLightEffect` in, add a `Light2D`, your sprite gets lit. This page is the mental model: how lights reach the GPU, why dense scenes have a slot budget, and where shadows fit. For the step-by-step setup, the `Light2D` field reference, and the quota-tuning knobs, see the [Lighting guide](../lighting-setup/).
 
-## How It Works
+## How it works
 
 1. **Light2D** — scene graph objects that define light sources (point, spot, directional, ambient)
 2. **LightEffect** — a shader pipeline that reads all lights and produces per-fragment lighting
@@ -36,7 +36,7 @@ Flatland manages the lifecycle: it collects lights, syncs them to a GPU texture 
 
 `DefaultLightEffect`, the recommended preset, runs Forward+ tiled lighting: the screen is divided into tiles, each tile culls the lights that can't reach it, and the fragment shader iterates only the survivors. The per-fragment cost scales with lights *per tile*, not lights in the scene — a room with 200 lights costs the same per fragment as a room with 16, as long as no single tile is oversubscribed.
 
-## Tiled Lighting and the Slot Budget
+## Tiled lighting and the slot budget
 
 Forward+ gives each tile at most `MAX_LIGHTS_PER_TILE` (default `16`) light slots. In a sparsely lit room that ceiling is invisible — every torch fits in every tile and ranking doesn't matter. Pack the same room with 1000 glowing slimes and the picture changes: the tile budget becomes the bottleneck, and a misallocation will visibly push hero torches out of slots, dropping rooms into darkness despite the physical light still being present. The natural failure mode is a checkerboard of dark tiles where cosmetic fills won the slots and lit tiles where they didn't.
 
@@ -60,7 +60,7 @@ Hero lights (`castsShadow: true`) trace shadows against a signed-distance field 
 
 For the occlusion pipeline, occluder setup, and the per-light tracing math, see [Shadows](../shadows/).
 
-## Normal-Based Diffuse Shading
+## Normal-Based diffuse shading
 
 `DefaultLightEffect` reads a per-fragment normal when one is available, giving sprites directional diffuse response instead of flat illumination. Normals come from a baked normal-map atlas attached via `NormalMapProvider`; without one, surfaces are treated as flat (facing the camera) and lighting still works. The atlas's blue channel encodes elevation, which the effect consumes for elevation-aware shading.
 
@@ -101,7 +101,7 @@ The tiled architecture is what makes the lighting scale, and a few habits keep i
 - Toggle `light.enabled` rather than adding and removing lights; a disabled light is culled before the per-tile upload.
 - Set `lit: false` on sprites that never need lighting (UI, light indicators) so they skip the effect entirely.
 
-## Next Steps
+## Next steps
 
 - [Lighting guide](../lighting-setup/) — Setup, `Light2D` types, presets, animation, and quota tuning
 - [Lighting Example](../../examples/lighting/) — Interactive demo with draggable lights

--- a/docs/src/content/docs/guides/loaders.mdx
+++ b/docs/src/content/docs/guides/loaders.mdx
@@ -18,7 +18,7 @@ three-flatland provides loaders for common 2D asset formats. All loaders share a
 
 The default preset is `pixel-art` — `NearestFilter`, no mipmaps, clamp wrap. If you're shipping pixel art (most three-flatland projects), you don't have to configure anything.
 
-## Available Loaders
+## Available loaders
 
 | Loader | Format | Use Case |
 |--------|--------|----------|
@@ -60,7 +60,7 @@ Load textures with automatic preset application. Works seamlessly with R3F's `us
   </TabItem>
 </Tabs>
 
-### Multiple Textures
+### Multiple textures
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -92,7 +92,7 @@ Load textures with automatic preset application. Works seamlessly with R3F's `us
   </TabItem>
 </Tabs>
 
-### Override Presets
+### Override presets
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -158,7 +158,7 @@ Load spritesheets exported from [TexturePacker](https://www.codeandweb.com/textu
   </TabItem>
 </Tabs>
 
-### Multiple Spritesheets
+### Multiple spritesheets
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -182,7 +182,7 @@ Load spritesheets exported from [TexturePacker](https://www.codeandweb.com/textu
   </TabItem>
 </Tabs>
 
-### Supported Formats
+### Supported formats
 
 - **JSON Hash** (TexturePacker default) - Frames as object properties
 - **JSON Array** - Frames as array with `filename` property
@@ -301,7 +301,7 @@ Load projects from [LDtk](https://ldtk.io/). See the [Tilemaps guide](../tilemap
 - IntGrid collision data
 - Tile flip flags
 
-## Baked Normal Pipeline
+## Baked normal pipeline
 
 three-flatland's lighting wants per-fragment **normal vectors** (for N·L diffuse) and an **elevation** scalar (for elevation-aware wall caps in `DefaultLightEffect`). Authoring a normal-map atlas alongside the diffuse atlas covers the easy case; for tilemaps, where per-tile orientation is decided in the level editor, `LDtkLoader` goes a step further and *bakes* a per-tileset normal atlas at load time from per-tile custom data.
 
@@ -311,7 +311,7 @@ Both `SpriteSheetLoader` and `LDtkLoader` accept a `normals: true` option. The r
 
 The atlas encoding is RGB+A: R/G hold the tangent-space normal XY in `[0, 1]` (decoded to `[-1, 1]` at sample time, with Z reconstructed as `sqrt(1 − x² − y²)`), B holds elevation in `[0, 1]`, and A passes through the source alpha.
 
-### Resolution Strategy
+### Resolution strategy
 
 Both loaders use the same resolution path for the baked atlas:
 
@@ -415,7 +415,7 @@ The atlas lands on each tileset as `tileset.normalMap`:
 
 The blue (elevation) channel feeds `DefaultLightEffect`'s elevation-aware diffuse — wall caps physically sit *above* `lightHeight` in the lighting math, so torches geometrically miss them. See the [Shadows guide](../shadows/#elevation-aware-shadows) for the elevation-channel story.
 
-### Wiring to the Lighting System
+### Wiring to the lighting system
 
 Once the normal map is loaded, attach a `NormalMapProvider` MaterialEffect to the consuming `Sprite2D` / `AnimatedSprite2D` / `TileMap2D`. The provider feeds the `normal` and `elevation` channels into the active `LightEffect` (typically `DefaultLightEffect`).
 
@@ -507,11 +507,11 @@ Once the normal map is loaded, attach a `NormalMapProvider` MaterialEffect to th
 
 For the broader lighting story, see the [Lighting guide](../lighting/) (presets and Light2D types) and the [Shadows guide](../shadows/) (elevation-aware shaping and the SDF trace). For the `NormalMapProvider` MaterialEffect in context with the rest of the effect system, see [Pass Effects](../pass-effects/#the-three-effect-layers).
 
-## Texture Presets
+## Texture presets
 
 All loaders use a unified texture configuration system. Presets control filtering, wrapping, and mipmaps.
 
-### Available Presets
+### Available presets
 
 | Preset | Filtering | Wrap | Mipmaps | Best For |
 |--------|-----------|------|---------|----------|
@@ -519,7 +519,7 @@ All loaders use a unified texture configuration system. Presets control filterin
 | `'smooth'` | Linear | Clamp | On | HD sprites, smooth graphics |
 | `'none'` | — | — | — | Full manual control |
 
-### Configuration Hierarchy
+### Configuration hierarchy
 
 Texture options follow a hierarchy (highest to lowest priority):
 
@@ -539,7 +539,7 @@ const texture = useLoader(TextureLoader, '/sprite.png', (loader) => {
 
 Each level overrides the ones below it. `TextureConfig` follows the library-wide `FlatlandConfig` until it receives its own override. If nothing is set, `'pixel-art'` is used.
 
-### Global Configuration
+### Global configuration
 
 Set the coordinated library-wide preset, or specialize only texture loading:
 
@@ -560,7 +560,7 @@ const mapData = await TiledLoader.load('/maps/level.json');
 TextureConfig.reset();
 ```
 
-### Per-Loader Configuration
+### Per-Loader configuration
 
 Override the default for a specific loader type:
 
@@ -582,7 +582,7 @@ const sprites = await SpriteSheetLoader.load('/sprites/ui.json');      // smooth
 const mapData = await TiledLoader.load('/maps/dungeon.json');          // pixel-art
 ```
 
-### Per-Instance Configuration
+### Per-Instance configuration
 
 Override for a specific load call:
 
@@ -621,7 +621,7 @@ Override for a specific load call:
   </TabItem>
 </Tabs>
 
-### Full Manual Control
+### Full manual control
 
 Use `'none'` for complete control via `.then()`:
 
@@ -639,7 +639,7 @@ const sheet = await SpriteSheetLoader.load('/sprites/tiles.json', {
 });
 ```
 
-### Common Patterns
+### Common patterns
 
 **Pixel Art Game (default)**
 ```typescript

--- a/docs/src/content/docs/guides/pass-effects.mdx
+++ b/docs/src/content/docs/guides/pass-effects.mdx
@@ -27,7 +27,7 @@ import Compare from '../../../components/Compare.astro';
 
 Pass Effects are full-screen post-processing effects applied after sprite rendering. They transform the entire scene output — CRT curvature, scanlines, color quantization, VHS distortion, and more. Pass effects require a [Flatland](../flatland/) instance.
 
-## The Three Effect Layers
+## The three effect layers
 
 import Diagram from '../../../components/Diagram.astro';
 import effectLayers from '../../../assets/diagrams/effect-layers.svg?raw';
@@ -49,7 +49,7 @@ The rest of this guide focuses on PassEffect; for LightEffect authoring see the 
 **MaterialEffects** and **PassEffects** both transform color, but at different scales: a MaterialEffect runs once per sprite fragment with access to that sprite's UVs and atlas frame, a PassEffect runs once per screen fragment with access to the composited scene texture. **LightEffects** are different again — they're not a transform, they're the lighting model itself, consumed by every lit sprite's MaterialEffect chain.
 :::
 
-## Creating a Pass Effect
+## Creating a pass effect
 
 Use `createPassEffect` with a name, a schema defining parameters, and a pass builder function:
 
@@ -77,7 +77,7 @@ type PassEffectFn = (input: Node<'vec4'>, uv: Node<'vec2'>) => Node<'vec4'>
 
 Schema fields become typed properties on instances with zero-cost uniform updates — changing a value updates the GPU uniform directly without rebuilding the shader graph.
 
-## Using Pass Effects
+## Using pass effects
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -161,7 +161,7 @@ Schema fields become typed properties on instances with zero-cost uniform update
   </TabItem>
 </Tabs>
 
-## Pass Chaining :badge[Advanced]{variant=note}
+## Pass chaining :badge[Advanced]{variant=note}
 
 Multiple passes compose into a single pipeline. Each pass receives the previous pass's output:
 
@@ -178,7 +178,7 @@ flatland.addPass(vignette)    // 4. Darken edges
 Passes that only do color math (posterize, quantize, scanlines, vignette) merge into a single shader — TSL compiles the chain into one GPU program. Passes that call `convertToTexture(input)` internally (CRT curvature, VHS distortion, chromatic aberration) introduce an intermediate texture sample because they need to read at different UVs. Stack the cheap ones freely; reach for the texture-sampling ones with intent.
 :::
 
-### Dynamic Switching
+### Dynamic switching
 
 Swap pass chains at runtime:
 
@@ -190,7 +190,7 @@ const crt = new CRTPass()
 flatland.addPass(crt)
 ```
 
-### Pass Management API
+### Pass management API
 
 | Method | Description |
 |--------|-------------|
@@ -200,7 +200,7 @@ flatland.addPass(crt)
 | `flatland.passes` | Read-only array of current passes |
 | `pass.enabled` | Toggle a pass without removing it |
 
-## Effects That Need Texture Sampling
+## Effects that need texture sampling
 
 Some effects distort UVs — they read pixels at offset positions. These require `convertToTexture(input)` to create a sampable texture from the node graph:
 
@@ -223,7 +223,7 @@ Effects that need `convertToTexture`: `crtComplete`, `crtCurvature`, `vhsDistort
 
 Effects that work directly on the color node: `posterize`, `quantize`, `scanlines`, `lcdGrid`, `crtVignette`, `lcdBacklightBleed`, `staticNoise`.
 
-## Animating Parameters
+## Animating parameters
 
 Schema properties update the GPU uniform directly — no shader recompilation:
 
@@ -236,11 +236,11 @@ vhs.time = elapsed        // Drive distortion animation
 vhs.intensity = 0.02      // Adjust strength
 ```
 
-## Available TSL Nodes
+## Available TSL nodes
 
 All post-processing nodes are exported from `@three-flatland/nodes`:
 
-### CRT Display
+### CRT display
 
 | Node | Description |
 |------|-------------|
@@ -260,7 +260,7 @@ All post-processing nodes are exported from `@three-flatland/nodes`:
 | `scanlinesGlow` | Bright scanline edges |
 | `scanlinesInterlaced` | Alternating-field interlace |
 
-### LCD Display
+### LCD display
 
 | Node | Description |
 |------|-------------|
@@ -270,7 +270,7 @@ All post-processing nodes are exported from `@three-flatland/nodes`:
 | `lcdPocket` | Game Boy-style LCD |
 | `lcdGBC` | Game Boy Color LCD |
 
-### Retro Color
+### Retro color
 
 | Node | Description |
 |------|-------------|
@@ -279,7 +279,7 @@ All post-processing nodes are exported from `@three-flatland/nodes`:
 | `bayerDither4x4` | Ordered dithering |
 | `palettize` | Map to a color palette |
 
-### Analog Video
+### Analog video
 
 | Node | Description |
 |------|-------------|
@@ -289,7 +289,7 @@ All post-processing nodes are exported from `@three-flatland/nodes`:
 | `ntscComposite` | NTSC signal artifacts |
 | `analogGlitch` | Random glitch bands |
 
-## DefaultLightEffect Schema
+## DefaultLightEffect schema
 
 `DefaultLightEffect` is a LightEffect, not a PassEffect — but it's the most heavily-customized effect in the preset set, and its schema is documented here as the canonical place readers will look for "what knobs does the recommended lighting actually have?". For an introduction to LightEffects in general, see the [Lighting guide](../lighting/#how-it-works).
 
@@ -313,7 +313,7 @@ Assigning these is a `.value =` write on a TSL uniform node — costs nothing. A
 | `lightHeight` | `0.75` | Universal +Z component added to every light's direction — higher reads as more top-lit. |
 | `rimIntensity` | `0` | Strength of the rim-lighting accumulator. Rim power is fixed at `(1 − N·L)²`. |
 
-### Compile-Time Constants (writable, but each write rebuilds)
+### Compile-Time constants (writable, but each write rebuilds)
 
 These are stored as primitive constants on the effect instance. Setting them is legal at runtime, but each assignment triggers a shader rebuild and emits a dev-mode warning:
 
@@ -345,14 +345,14 @@ const rimEnabled = rimIntensity > 0
 The cel formula `floor(x*N + 0.5)/N` rounds mid-tones up to the next quantization step — the boost is visible, while the compensating darkenings happen at very low values where they read as "still black." Net effect: cel mode looks BRIGHTER than smooth mode for the same physical scene values. **Disabling `bandsEnabled` may make a calibrated scene look dimmer** until you retune intensities (torches, fills, ambient) upward to compensate. The smooth branch is doing nothing wrong — the cel branch was inflating mid-tones.
 :::
 
-### Removed Fields
+### Removed fields
 
 The following fields existed in earlier versions and have been removed. If you're migrating, delete the assignments — they'll be silently undefined now.
 
 - **`rimPower`** — rim sharpness is now hardcoded as `(1 − N·L)²`. Saves a per-light `pow()` (an SFU instruction) for the case nobody actually slid at runtime. Fork the effect if you need a different curve.
 - **`capShadowStrength`** / **`capShadowThreshold`** — the manual wall-cap darkening hack is replaced by elevation-aware N·L. Walls whose elevation exceeds `lightHeight` physically receive a negative L.z, clamp N·L to zero, and end up with only ambient — no special-case uniform required.
 
-### `categoryQuotas` — JSX-Only Sugar
+### `categoryQuotas` — JSX-Only sugar
 
 `DefaultLightEffect` instances expose a `categoryQuotas` accessor that proxies to the underlying `forwardPlus.setFillQuota(category, quota)` API. It's purely a declarative convenience for JSX users who don't want to grab a ref and reach into `forwardPlus`:
 
@@ -367,7 +367,7 @@ Each set RESETS all buckets to default first, then applies the record — so rem
 
 For the full story on what these buckets are and how `category` maps onto them — including the per-category quota tuning APIs — see [Shadow Casting, Importance & Categories](../lighting-setup/#shadow-casting-importance--categories) in the Lighting guide.
 
-## Next Steps
+## Next steps
 
 - [Pass Effects Example](../../examples/pass-effects/) — Interactive demo with 5 presets
 - [Lighting Guide](../lighting/) — What a LightEffect actually is, plus Light2D fields

--- a/docs/src/content/docs/guides/shadows-setup.mdx
+++ b/docs/src/content/docs/guides/shadows-setup.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from 'starlight-theme/components';
 
 This guide covers the practical side of shadows: opting sprites and tilemap tiles in or out, the self-shadow `shadowRadius` knobs, enabling elevation-aware shaping for top-down maps, and the shadow uniforms on `DefaultLightEffect`. For the pipeline itself — how the occlusion mask, the JFA-generated SDF, and the per-light sphere-trace fit together — see [Shadows & Occlusion](../shadows/).
 
-## Opting In and Out
+## Opting in and out
 
 Three flags control who participates in the shadow pipeline. All three are zero-cost runtime toggles — flipping them takes effect on the next frame with no shader rebuild.
 
@@ -66,7 +66,7 @@ const uiPanel = new Sprite2D({ texture: uiTex })
 uiPanel.receiveShadows = false
 ```
 
-## Tilemap Occluders
+## Tilemap occluders
 
 Tilemap walls are the bulk of static occluders in most scenes. Rather than tagging tiles one-by-one, mark whole categories of tiles by their LDtk `obj.type`:
 
@@ -124,7 +124,7 @@ sprite.shadowRadius = 28  // tighter than auto-derived ~64
 lighting.shadowStartOffsetScale = 1.2
 ```
 
-## Enabling Elevation-Aware Shadows
+## Enabling Elevation-Aware shadows
 
 `DefaultLightEffect` shapes light by elevation automatically once a sprite provides a per-fragment `elevation` channel — wall caps stop receiving direct light because they sit above the torch in the lighting math. The mechanism and the `L = normalize(vec3(toLight2D, lightHeight - elevation))` math live in [Elevation-Aware Shadows](../shadows/#elevation-aware-shadows). To turn it on:
 
@@ -165,7 +165,7 @@ lighting.shadowMaxDistance = 300  // fade shadows beyond 300 world units
 
 `shadowPixelSize` is purely cosmetic — it produces blocky pixel-art shadow silhouettes by snapping the trace origin to a coarse grid. It does not reduce GPU cost; every fragment still traces. Use it for retro aesthetics, not for performance.
 
-## Performance Knobs
+## Performance knobs
 
 The per-light trace is gated on the GPU so most fragments skip it cheaply (see [the gating conditions](../shadows/#performance) in the concept page for the full mechanism). The two knobs you control directly:
 
@@ -176,7 +176,7 @@ Setting `castsShadow: false` on cosmetic fill lights (slime auras, particle glow
 - Per-sprite `castsShadow` controls the silhouette mask, which is rendered once per frame regardless of light count. Adding more caster sprites grows the mask render cost; adding more lights grows the trace cost.
 - The OcclusionPass renders its silhouette mask at half of the active `LightEffect` processing surface. Set `lighting.resolutionScale = 0.5` to halve all effect-owned surface dimensions; the shadow mask then becomes one quarter of the physical drawing-buffer dimensions. This can improve low-end performance or deliberately produce a blockier result without changing camera framing or canvas DPR.
 
-## Next Steps
+## Next steps
 
 - [Shadows & Occlusion](../shadows/) — The mental model: occlusion mask, JFA-generated SDF, and the per-light trace
 - [Lighting guide](../lighting-setup/) — `Light2D` types, presets, and the hero/fill split

--- a/docs/src/content/docs/guides/shadows-setup.mdx
+++ b/docs/src/content/docs/guides/shadows-setup.mdx
@@ -131,7 +131,7 @@ lighting.shadowStartOffsetScale = 1.2
 1. Attach a `NormalMapProvider` with a baked normal map whose blue channel encodes elevation (see [Lighting → NormalMapProvider](../lighting-setup/#normalmapprovider)).
 2. Use `DefaultLightEffect`, which declares `requires: ['normal', 'elevation']`.
 
-The fastest way to get a normal map with a populated elevation channel is `LDtkLoader`'s [Baked Normal Pipeline](../loaders/#baked-normal-pipeline) — tagging tiles with `tileDir` / `tileCap*` / `tileElevation` custom data produces a per-tileset atlas where wall caps bake at elevation 1 and faces at the configured face elevation. The elevation channel is populated via the same offline pipeline `flatland-bake` ships — see the [Baking guide](../baking/) for running it ahead of time.
+`LDtkLoader`'s [baked normal pipeline](../loaders/#baked-normal-pipeline) populates the elevation channel — tagging tiles with `tileDir` / `tileCap*` / `tileElevation` custom data produces a per-tileset atlas where wall caps bake at elevation 1 and faces at the configured face elevation. The elevation channel is populated via the same offline pipeline `flatland-bake` ships — see the [Baking guide](../baking/) for running it ahead of time.
 
 Tune `lightHeight` to taste — `0.75` reads as "torches sit above the floor, below the wall caps." Raising it to `1.5` lights everything (sun-like); lowering toward `0` makes torches barely scrape the floor and dramatically extends shadows.
 

--- a/docs/src/content/docs/guides/shadows.mdx
+++ b/docs/src/content/docs/guides/shadows.mdx
@@ -11,7 +11,7 @@ three-flatland renders per-light, SDF-traced soft shadows. Casters silhouette th
 
 If your scene doesn't have shadows yet, you don't need this page. Come back when your hero is on screen and you want a proper torch-on-wall moment. This page is the mental model: how the pipeline turns casters into a distance field and how the trace reads it. For opting sprites and tiles in or out, the `shadowRadius` knobs, and the tuning uniforms, see the [Shadows guide](../shadows-setup/).
 
-## How Shadows Work
+## How shadows work
 
 The shadow pipeline runs as a pre-pass before the main scene render:
 
@@ -37,7 +37,7 @@ shadowRadius = max(Math.abs(scale.x), Math.abs(scale.y))
 
 This tracks scale changes automatically and covers animated sprites whose source frame size differs (e.g. `AnimatedSprite2D` updates `scale` from `frame.sourceWidth/Height`). For most scenes you set `castsShadow = true` and never think about `shadowRadius` again. When you do need to override it — transparent art padding, non-uniform scale, a tighter escape — the [Shadows guide](../shadows-setup/#self-shadow-and-shadowradius) covers the manual knobs.
 
-## Elevation-Aware Shadows
+## Elevation-Aware shadows
 
 <Diagram caption="Why elevated wall caps go dark — a light's +Z component is lightHeight − elevation, so caps above the torch get a negative L.z and N·L clamps to zero." src={shadowElevation} />
 
@@ -71,7 +71,7 @@ In practice this means most fragments skip the trace cheaply:
 
 This is why flipping cosmetic fills to `castsShadow: false` is the dominant shadow-perf lever: the 32-tap SDF trace is the per-light cost, and a fill that skips it is nearly free. The [Shadows guide](../shadows-setup/#performance-knobs) covers the practical knobs (occlusion-mask resolution, caster counts).
 
-## Next Steps
+## Next steps
 
 - [Shadows guide](../shadows-setup/) — Opt-in flags, `shadowRadius`, elevation setup, and tuning uniforms
 - [2D Lighting](../lighting/) — The Forward+ pipeline shadows plug into

--- a/docs/src/content/docs/guides/skia.mdx
+++ b/docs/src/content/docs/guides/skia.mdx
@@ -86,7 +86,7 @@ Peer dependencies: `three ^0.185.1`. For React: `@react-three/fiber 10.0.0-alpha
 
 `@three-flatland/skia/react` is browser-only on R3F alpha.3. Its upstream Inspector reads `localStorage` during module evaluation, so place the import behind your framework's client boundary rather than evaluating it during SSR.
 
-### WASM Setup
+### WASM setup
 
 Skia ships ~1 MB WASM binaries (one for WebGL, one for WebGPU). **Vite handles this automatically** in dev — no config needed. For production builds or other bundlers, copy the WASM to your public directory:
 
@@ -205,7 +205,7 @@ The root node that owns the render target and walks children to draw. Two modes:
   </TabItem>
 </Tabs>
 
-### Render Pipeline
+### Render pipeline
 
 SkiaCanvas does not auto-render. Call `render()` each frame — it automatically marks the canvas dirty and draws:
 
@@ -242,11 +242,11 @@ SkiaCanvas does not auto-render. Call `render()` each frame — it automatically
   </TabItem>
 </Tabs>
 
-## Drawing Nodes :badge[Alpha]{variant=caution}
+## Drawing nodes :badge[Alpha]{variant=caution}
 
 All nodes extend `SkiaNode` (which extends Three.js `Object3D`) and accept inline paint props.
 
-### Common Paint Props
+### Common paint props
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -258,7 +258,7 @@ All nodes extend `SkiaNode` (which extends Three.js `Object3D`) and accept inlin
 | `blendMode` | `BlendMode` | Compositing blend mode |
 | `paint` | `SkiaPaint` | Explicit paint (overrides all above) |
 
-### Shape Nodes
+### Shape nodes
 
 ```tsx
 {/* Rectangle with rounded corners */}
@@ -323,7 +323,7 @@ Uses standard Object3D `position`, `scale`, and `rotation.z` (radians). The `deg
 | `clipRect` | `[x, y, w, h]` clip rectangle |
 | `backdropBlur` | Frosted glass effect |
 
-## Font Loading
+## Font loading
 
 :::tip[Performance note]
 The typeface is cached by URL, and sized fonts are cached internally on the typeface — so calling `.atSize(14)` and `.atSize(32)` from many components shares a single font fetch and a single set of size objects. No need to memoize.
@@ -364,7 +364,7 @@ The typeface is cached by URL, and sized fonts are cached internally on the type
 
 The typeface resolves the `SkiaContext` lazily — if no context is available when `atSize()` is called, it falls back to the global `SkiaContext.instance` singleton. Inside a `<SkiaCanvas>` subtree, this is always available.
 
-## Custom Paints
+## Custom paints
 
 For gradients, shaders, and effects beyond flat fill/stroke, create a `SkiaPaint`:
 
@@ -393,7 +393,7 @@ useFrame(({ elapsed }) => {
 return <skiaRect paint={paint} x={0} y={0} width={200} height={50} />
 ```
 
-## Path Operations
+## Path operations
 
 Create paths programmatically and perform boolean operations:
 
@@ -410,7 +410,7 @@ pathNode.path = result
 
 Operations: `difference`, `intersect`, `union`, `xor`, `reverse-difference`.
 
-## Texture Attachment (React)
+## Texture attachment (React)
 
 `attachSkiaTexture` is an R3F attach helper that grabs `.texture` from a `SkiaCanvas` and assigns it to the parent material's `map`:
 
@@ -425,7 +425,7 @@ import { SkiaCanvas, attachSkiaTexture } from '@three-flatland/skia/react'
 </meshBasicMaterial>
 ```
 
-## Next Steps
+## Next steps
 
 - [Skia Example](../../examples/skia/) — Full interactive demo
 - [Sprites Guide](../sprites/) — Three-flatland 2D sprites

--- a/docs/src/content/docs/guides/slug-text.mdx
+++ b/docs/src/content/docs/guides/slug-text.mdx
@@ -79,7 +79,7 @@ The `@three-flatland/slug` API isn't settled yet. We're dogfooding it and foldin
 Slug text works with both the WebGPU renderer and its WebGL2 fallback. The TSL shaders compile to WGSL or GLSL ES 3.0 automatically.
 :::
 
-## Loading Fonts
+## Loading fonts
 
 `SlugFontLoader` is the single entry point for loading fonts. It automatically tries pre-baked data first (a single `.slug.glb`), and falls back to runtime parsing from the `.ttf` if baked data isn't available.
 
@@ -114,7 +114,7 @@ After loading, the font provides:
 - `font.unitsPerEm`, `font.ascender`, `font.descender`, `font.capHeight` — font metrics
 - `font.measureText(text, fontSize)`, `font.measureParagraph(text, fontSize, opts)`, `font.wrapText(text, fontSize, maxWidth)` — measurement helpers
 
-## SlugText Properties
+## SlugText properties
 
 `SlugText` extends `InstancedMesh` — each glyph is an instanced quad evaluated per-pixel by the Slug fragment shader.
 
@@ -133,7 +133,7 @@ After loading, the font provides:
 
 All properties can be set after construction. Changes are applied on the next `update()` call.
 
-## Per-Frame Updates
+## Per-Frame updates
 
 `SlugText.update(camera)` does two things:
 
@@ -159,7 +159,7 @@ All properties can be set after construction. Changes are applied on the next `u
   </TabItem>
 </Tabs>
 
-## Viewport Size
+## Viewport size
 
 For correct edge dilation (half-pixel anti-aliasing at quad boundaries), call `setViewportSize` when the viewport changes:
 
@@ -186,7 +186,7 @@ For correct edge dilation (half-pixel anti-aliasing at quad boundaries), call `s
   </TabItem>
 </Tabs>
 
-## Dynamic Text
+## Dynamic text
 
 Change any property and the text rebuilds on the next `update()`:
 
@@ -198,7 +198,7 @@ text.color = 0xff0000
 // Geometry rebuilds automatically on next update() call
 ```
 
-## Multi-line & Word Wrap
+## Multi-line & word wrap
 
 Set `maxWidth` to enable automatic word wrapping. Line breaks (`\n`) are also supported:
 
@@ -341,7 +341,7 @@ text.setOpacity(0) // hide fill, keep outline visible
 
 The current dynamic shader uses `min(distance)` over the glyph's curves, producing a clean **bevel** at exterior corners. Interior corners stay crisp by construction. Miter / round joins, caps, dashing, and a 1× fill cost baked path are landing in [Phase 5 (#37)](https://github.com/thejustinwalsh/three-flatland/issues/37); the dynamic shader will stay as `outline.mode = 'dynamic'` for live width scrubbing.
 
-## Material Options
+## Material options
 
 `SlugText` creates a `SlugMaterial` internally. Several shader-level options are available at construction time (some compile-time constants, some runtime uniforms):
 
@@ -354,7 +354,7 @@ The current dynamic shader uses `min(distance)` over the glyph's curves, produci
 | `pixelSnap`   | `boolean` | `true`  | Snap glyph positions to pixel grid.      |
 | `supersample` | `boolean` | `false` | 2×2 supersampling (expensive).           |
 
-## Pre-baking Fonts
+## Pre-baking fonts
 
 For production, use `slug-bake` to pre-process fonts offline. This eliminates opentype.js at runtime and lets you subset to only the glyphs you need:
 
@@ -386,7 +386,7 @@ Rely on your CDN's gzip/brotli — the browser decompresses automatically with z
 
 Missing glyphs render as a fallback rectangle. Named ranges: `ascii`, `latin`, `latin+`. Custom ranges use hex (`0x20-0x7E`) or decimal (`32-126`).
 
-## How It Works
+## How it works
 
 The Slug algorithm renders each pixel by:
 

--- a/docs/src/content/docs/guides/tilemaps.mdx
+++ b/docs/src/content/docs/guides/tilemaps.mdx
@@ -20,7 +20,7 @@ For your first map, you don't need to think about chunks, layers, or culling. Dr
 
 <Diagram caption="How TileMap2D builds a map — a tile atlas plus per-layer grid data become chunked geometry, stacked by layer for depth, with markOccluders flagging wall tiles as shadow casters." src={tilemapStructure} />
 
-## Creating a Tilemap
+## Creating a tilemap
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -77,7 +77,7 @@ For your first map, you don't need to think about chunks, layers, or culling. Dr
   </TabItem>
 </Tabs>
 
-## Map Data Structure
+## Map data structure
 
 The `TileMapData` interface describes the map format:
 
@@ -97,9 +97,9 @@ interface TileMapData {
 }
 ```
 
-## Loading Maps
+## Loading maps
 
-### Tiled Editor (.json/.tmj)
+### Tiled editor (.json/.tmj)
 
 Load maps created with the [Tiled Map Editor](https://www.mapeditor.org/):
 
@@ -134,7 +134,7 @@ Load maps created with the [Tiled Map Editor](https://www.mapeditor.org/):
   </TabItem>
 </Tabs>
 
-### LDtk Editor (.ldtk)
+### LDtk editor (.ldtk)
 
 Load maps created with [LDtk](https://ldtk.io/):
 
@@ -186,7 +186,7 @@ Load maps created with [LDtk](https://ldtk.io/):
 See the [Loaders guide](../loaders/#texture-presets) to configure texture filtering for pixel-art or smooth rendering.
 :::
 
-## Working with Layers
+## Working with layers
 
 Access and manipulate tile layers:
 
@@ -202,7 +202,7 @@ groundLayer.visible = false;
 console.log(tilemap.layerCount);
 ```
 
-## Tile Operations
+## Tile operations
 
 Read and modify tiles at runtime:
 
@@ -217,7 +217,7 @@ const tileGid = layer.getTileAt(x, y);
 layer.setTileAt(x, y, newTileGid);
 ```
 
-## Shadow Casting
+## Shadow casting
 
 Tilemaps participate in the lighting pipeline as shadow occluders. Rather than tagging tiles one by one, you mark whole categories of tiles by their LDtk `obj.type` — typically the `'collision'` IntGrid identifier that LDtk assigns to wall tiles by default.
 
@@ -271,7 +271,7 @@ Per-tile cast-shadow flags are preserved when you toggle layer-level state like 
 
 For the broader story on how the SDF pre-pass, occlusion mask, and shadow tracing fit together, see the [Shadows guide](../shadows/). For the per-sprite analogue (`Sprite2D` instances opting in/out as occluders), see the [Sprites guide](../sprites/).
 
-## Coordinate Conversion
+## Coordinate conversion
 
 Convert between world and tile coordinates:
 
@@ -295,7 +295,7 @@ console.log('Total chunks:', tilemap.totalChunkCount);
 console.log('Layer count:', tilemap.layerCount);
 ```
 
-## Chunked Rendering
+## Chunked rendering
 
 Tilemaps use chunked rendering for performance. Configure the chunk size based on your needs:
 
@@ -308,7 +308,7 @@ const tilemap = new TileMap2D({
 
 Smaller chunks = more draw calls but finer culling. Larger chunks = fewer draw calls but coarser culling. The default of 512 keeps most maps in a single chunk; lower it only for very large maps where finer culling pays off.
 
-## Animated Tiles
+## Animated tiles
 
 Tiles with animation data (from Tiled) are automatically animated. Call `update()` each frame:
 

--- a/docs/src/content/docs/guides/tsl-nodes.mdx
+++ b/docs/src/content/docs/guides/tsl-nodes.mdx
@@ -27,11 +27,11 @@ TSL node functions (tint, hueShift, outline, dissolve, etc.) are exported from `
 
 <Diagram caption="Composing a sprite's effect chain — the base texture color flows through each effect node as inputColor and out as a vec4, chaining in addEffect order into one node material." src={tslNodeChain} />
 
-## Material Effects :badge[Recommended]{variant=success}
+## Material effects :badge[Recommended]{variant=success}
 
 The Material Effect system lets you define shader effects as reusable classes with typed, animatable properties. Effects are composed into the sprite's shader pipeline automatically.
 
-### Defining an Effect
+### Defining an effect
 
 Use `createMaterialEffect` with a schema (per-sprite data) and a TSL node builder:
 
@@ -63,7 +63,7 @@ The `node` callback receives:
 - `inputUV` — atlas UV coordinates (TSL vec2 node)
 - `attrs` — TSL nodes for each schema field, automatically packed into GPU buffers
 
-### Using Effects
+### Using effects
 
 <Tabs syncKey="framework">
   <TabItem label="Three.js" icon="simple-icons:threedotjs">
@@ -101,7 +101,7 @@ The `node` callback receives:
   </TabItem>
 </Tabs>
 
-### Closure-Captured Textures
+### Closure-Captured textures
 
 Effects that need texture references can capture them via closures. The `node` callback runs once during shader compilation:
 
@@ -118,7 +118,7 @@ const Dissolve = createMaterialEffect({
 
 See the [TSL Nodes example](../../examples/tsl-nodes/) for all 8 effects in action.
 
-## Low-Level TSL Usage :badge[Advanced]{variant=note}
+## Low-Level TSL usage :badge[Advanced]{variant=note}
 
 For full shader control, you can compose TSL nodes directly on a `MeshBasicNodeMaterial`. This is useful for custom materials outside the sprite pipeline:
 
@@ -143,7 +143,7 @@ material.colorNode = Fn(() => {
 })();
 ```
 
-## Sprite Sampling Nodes
+## Sprite sampling nodes
 
 ### `sampleSprite`
 
@@ -170,7 +170,7 @@ const frameUV = spriteUV(frameUniform);
 // Use frameUV for texture sampling or effects
 ```
 
-## Color Nodes
+## Color nodes
 
 ### `tint` / `tintAdditive`
 
@@ -228,7 +228,7 @@ const bright = brightness(color, 0.2);
 const contrasty = contrast(color, 1.5);
 ```
 
-## Effect Nodes
+## Effect nodes
 
 ### `outline8`
 
@@ -274,7 +274,7 @@ const dissolved = dissolvePixelated(color, uv, progress, noiseTexture, 16);
 const dissolved = dissolveDirectional(color, uv, progress, direction);
 ```
 
-## Retro Effect Nodes
+## Retro effect nodes
 
 ### `colorReplace`
 
@@ -335,7 +335,7 @@ import { posterize } from '@three-flatland/nodes';
 const posterized = posterize(color, 4);
 ```
 
-## Combining Effects
+## Combining effects
 
 With Material Effects, multiple effects can be active simultaneously. Each effect chains through the previous color:
 
@@ -363,7 +363,7 @@ material.colorNode = Fn(() => {
 })();
 ```
 
-## Performance Tips
+## Performance tips
 
 :::tip[Performance note]
 Material Effects pack per-sprite data into fixed-size GPU buffers, so adding effects to thousands of sprites doesn't cost extra draw calls — it costs shader ops per fragment. Reach for `addEffect()` freely. Compose, don't worry.
@@ -374,7 +374,7 @@ Material Effects pack per-sprite data into fixed-size GPU buffers, so adding eff
 - Cache compiled materials when reusing effects
 - Avoid dynamic branching in hot paths
 
-## Next Steps
+## Next steps
 
 - [TSL Nodes Example](../../examples/tsl-nodes/) — Interactive demo of 8 material effects
 - [Pass Effects Guide](../pass-effects/) — Full-screen post-processing with CRT, LCD, VHS, and more

--- a/docs/src/content/docs/llm-prompts.mdx
+++ b/docs/src/content/docs/llm-prompts.mdx
@@ -7,7 +7,7 @@ import { Aside, Tabs, TabItem } from 'starlight-theme/components'
 
 three-flatland provides machine-readable documentation so AI coding assistants can help you write correct code from the start. This page explains what's available and includes ready-to-use prompts.
 
-## Machine-Readable Documentation
+## Machine-Readable documentation
 
 three-flatland publishes two files that AI assistants can consume directly:
 
@@ -28,7 +28,7 @@ These follow the [llms.txt standard](https://llmstxt.org/) — a convention for 
 
 Copy a prompt below, paste it into your AI assistant, and replace the placeholder at the end with your task.
 
-### Getting Started
+### Getting started
 
 The general-purpose prompt. Works with any AI assistant that can fetch URLs.
 
@@ -50,7 +50,7 @@ Help me with the following:
 [Describe your task here]
 ```
 
-### Build from an Example
+### Build from an example
 
 Start from a working example and adapt it. The AI reads the actual source code from GitHub, so it builds on patterns that are known to work.
 
@@ -100,7 +100,7 @@ Replace `EXAMPLE_NAME` with one of these:
 | `slug-text`    | GPU-rendered vector text with the Slug font pipeline       |
 | `knightmark`   | Sprite benchmark with batching stress test                 |
 
-### Deep Context (File Access Required)
+### Deep context (File access required)
 
 For AI assistants that can read local files — Claude Code, Cursor, Copilot workspace. The AI reads the project's own documentation files and explores the source code based on your task.
 
@@ -121,7 +121,7 @@ Help me with the following:
 [Describe your task here]
 ```
 
-## Common Pitfalls
+## Common pitfalls
 
 These are the mistakes AI assistants make most often with three-flatland. If you see any of these in generated code, correct the AI:
 

--- a/docs/src/content/docs/showcases/breakout.mdx
+++ b/docs/src/content/docs/showcases/breakout.mdx
@@ -15,7 +15,7 @@ import ShowcaseGame from '../../../components/ShowcaseGame';
 
 The breakout mini-game is built on three-flatland and [Koota ECS](https://github.com/pmndrs/koota). All game state lives in ECS traits, all logic runs in pure-function systems, and all rendering flows through a single Flatland instance.
 
-### Game Loop
+### Game loop
 
 A 4-state machine drives the top-level loop. Each state runs a different subset of systems per frame:
 
@@ -28,7 +28,7 @@ A 4-state machine drives the top-level loop. Each state runs a different subset 
 
 State transitions are explicit — `startGame`, `levelClear`, `loseLife`, `gameOver`, `returnToAttract` — each one resets the appropriate entities and spawns new ones.
 
-### Collision Detection
+### Collision detection
 
 The game uses swept line-segment vs AABB testing (slab method) to prevent tunneling at high ball speeds:
 
@@ -39,7 +39,7 @@ The game uses swept line-segment vs AABB testing (slab method) to prevent tunnel
 
 Paddle collision adds angle control: the horizontal offset from paddle center maps to a launch angle (up to 60 degrees), and paddle velocity at the moment of contact applies english to the ball's trajectory.
 
-### Rendering Pipeline
+### Rendering pipeline
 
 All sprites render through a single `<flatland>` element:
 
@@ -52,9 +52,9 @@ All sprites render through a single `<flatland>` element:
 </flatland>
 ```
 
-Game logic runs in R3F's default update phase. Flatland renders in the **render phase** (`{ phase: 'render' }`), which tells R3F to skip its own render pass. This separation ensures all ECS trait values are synced to `MaterialEffect` instances before the draw call.
+Game logic runs in R3F's default update phase. Flatland renders in the **render phase** (`{ phase: 'render' }`), so R3F skips its own render pass. This separation ensures all ECS trait values are synced to `MaterialEffect` instances before the draw call.
 
-### Material Effects
+### Material effects
 
 Two custom effects built with `createMaterialEffect` provide visual feedback without shader recompilation:
 
@@ -64,11 +64,11 @@ Two custom effects built with `createMaterialEffect` provide visual feedback wit
 
 Both effects are registered on their materials at creation time. Each component's `useFrame` reads the ECS trait value and writes it to the effect instance ref — a one-line sync per entity per frame.
 
-### Dithered Shading
+### Dithered shading
 
 All sprite materials use a `colorTransform` that applies Bayer 4x4 ordered dithering with a diagonal self-shadow. The dither grid is scaled by sprite world-size so cells are square regardless of aspect ratio. UVs are quantized to cell centers, then a diagonal gradient (upper-left = light, lower-right = shadow) modulates brightness through the dither pattern. The result is a retro shading style with no textures needed beyond the base sprite.
 
-### ECS Trait Design
+### ECS trait design
 
 Traits fall into four categories:
 
@@ -79,7 +79,7 @@ Traits fall into four categories:
 
 The `GameState` singleton carries score, lives, level, countdown timer, streak counter, multiplier, carried ball speed across levels, and high score (persisted to `localStorage`).
 
-### Attract Mode AI
+### Attract mode AI
 
 The AI uses three layers of smoothing to mimic human play:
 
@@ -89,7 +89,7 @@ The AI uses three layers of smoothing to mimic human play:
 
 A slow-drifting offset (re-randomized every 4-8 seconds) adds subtle imperfection so the AI doesn't look robotic.
 
-### Project Structure
+### Project structure
 
 ```
 minis/breakout/
@@ -121,13 +121,13 @@ minis/breakout/
 The mini-game is designed to be importable by the docs site as a library package. This drove two design choices: all textures are generated at runtime via `CanvasTexture` (zero network requests), and sound is injected as a `zzfx` prop function so the host controls audio context and volume.
 :::
 
-### External Dependencies
+### External dependencies
 
 - [Koota](https://github.com/pmndrs/koota) — Entity Component System
 - [React Three Fiber](https://r3f.docs.pmnd.rs/) — React renderer for Three.js
 - [ZzFX](https://github.com/KilledByAPixel/ZzFX) — Tiny sound generator
 
-## Next Steps
+## Next steps
 
 - [Flatland Guide](../../guides/flatland/) — Deep dive into the Flatland API used by this game
 - [TSL Nodes Guide](../../guides/tsl-nodes/) — Custom material effects like the flash and dissolve


### PR DESCRIPTION
### **User description**
Site-wide mechanical cleanup against the `technical-writing` standard. Base `main`.

## Sentence-case headings

**202 headings across 30 files.** Google specifies sentence case for headings and titles. The site used Title Case throughout, while the two rewritten Flatland pages used sentence case, so it was inconsistent with itself as well as with the standard.

Identifiers, acronyms, and product names keep their casing: `TextureLoader`, `SpriteSheetLoader`, `WebGPU`, `TSL`, `ECS`, `WASM`, `API`, `Three.js`, `R3F`. Fenced code is untouched and badge directives keep their labels.

**Anchors are unaffected.** The slugger already lowercases, so `Available Loaders` and `Available loaders` both produce `available-loaders`. Verified by resolving all 36 anchored cross-links against the built HTML: zero broken.

## The third copy of an anthropomorphism

`showcases/breakout.mdx` said the render phase "tells R3F to skip its own render pass". That exact sentence was fixed twice on the Flatland pages while this copy sat untouched, which is what happens when copied prose gets fixed one page at a time.

## Two unverifiable superlatives

- `shadows-setup` called the baked normal pipeline "the fastest way" to populate an elevation channel. Nothing measures that.
- `batch-rendering` said a fresh material per sprite "is the easiest way to silently tank batching" — superlative plus figurative language in one clause.

Both now state the behaviour.

## What this PR deliberately does NOT do

**The 291 prose em dashes are not touched.** I attempted a mechanical pass and every heuristic produced wrong output on real lines:

- Treating `— ` + article as an appositive taking a comma: caught `…the closest \`t\` wins — the ball is placed at…`, an independent clause where a comma creates a run-on.
- Treating paired dashes as parentheticals: dropped a required comma in `sprites (…) \`hitTestMode\``, converted a coordinated clause `find it (or the hash doesn't match…)`, and caught a carved-out `- **Term** — description` list item only because that line happened to have two dashes.

Each instance needs a reading to decide between comma, colon, period, parentheses, or a restructure. That belongs in the per-page rewrites, not a bulk regex. The count by category, for whoever picks it up:

| Category | Count | Disposition |
| --- | ---: | --- |
| `- **Term** — description` list form | 39 | carved out, keep |
| Prose, single dash | 165 | per-page judgment |
| List items, other | 113 | per-page judgment |
| Prose, paired parenthetical | 38 | per-page judgment |
| Table cells | 36 | typography, keep |
| Headings | 9 | resolved by the sentence-case pass |

## Verification

`pnpm --filter=docs build` — exit 0, 503 pages. 36/36 anchored cross-links resolve.

No changeset: `docs/` is unpublished.


___

### **PR Type**
Documentation, Enhancement, Bug fix


___

### **Description**
- Replace marketing-voice skill with technical-writing skill

- Switch all docs headings to sentence case

- Split Flatland guide into setup how-to and explanation

- Remove private-ECS migration guide, add codemods and changesets

- Fix debug subpath docblock and remove superlatives


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Replace marketing-voice with technical-writing"] --> B["Sentence-case headings across docs"]
  B --> C["New flatland-setup how-to guide"]
  B --> D["Private-ECS migration guide removed"]
  D --> E["Add koota-peer-dependency codemod"]
  A --> F["Update documentation skill references"]
  B --> G["Fix debug subpath docblock and superlatives"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>SKILL.md</strong><dd><code>Added technical-writing skill based on Google style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-65e251f38bb704850ccee68f54f0f1d1394c8d7be48113bf8997cfb54fbfd7ce">+334/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>banned.md</strong><dd><code>Added banned vocabulary and structures for technical writing</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-807efbdbbf2247ef29f0df25508a887bdf742bc9810cda4a661c88b5d241d4bf">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>checklist.md</strong><dd><code>Added audit checklist for technical writing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-1c705bf80c63184e0d8dfeef780afd543756d1439ae8077f8c5def07e0e59551">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Removed marketing-voice skill (replaced)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-6e4af97f4fcb3e29df848212a11864befd0692f1dcf6671ec7f7496ea1ad0f52">+0/-1038</a></td>

</tr>

<tr>
  <td><strong>anti-slop.md</strong><dd><code>Removed anti-slop file (replaced)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-092eafb724fd36c03e497bbe163159baaf9abc71bf1794f952dde7e81284ddc1">+0/-149</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>voice-corpus.md</strong><dd><code>Removed voice-corpus file (replaced)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-f136d8b130128918fa236aeac56f784c8230729c5c45ab60ef9c4190c3976322">+0/-285</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flatland-setup.mdx</strong><dd><code>New how-to guide for Flatland scene setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-9af0a2a16854d973bf9423335a4fcebb7566f6fc3ff3aa64e3b2c0f6aaf1b120">+240/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flatland.mdx</strong><dd><code>Rewritten as explanation page after extracting how-to content</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-5d4f1fe2a15abecc4fdb52872bf5082b04a5ad4055fd30b1eebf6d8ab59aad85">+66/-311</a></td>

</tr>

<tr>
  <td><strong>private-ecs-migration.mdx</strong><dd><code>Removed migration guide in favor of changesets and codemods</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-15e59f6aa08ea59fd9d9008979662d20459e4db7d4464ca9ea7b525c90c4a827">+0/-220</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Updated required sub-skill to technical-writing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-642ed0287c12b9fcd1c703ce903e48714dea12672304cd405959acb1d9db09a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>diataxis.md</strong><dd><code>Updated voice reference to technical-writing skill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-c986281221d716c40e20239c9e13f614034b19efbd9da4cb912fb4585f8f94ec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch-rendering.mdx</strong><dd><code>Sentence-case headings and removed superlative</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-2b484629a6228fa31c7e8dadc62763dc192ccbb61ec8a3679fd8499e4252e574">+11/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>koota-peer-dependency-codemod.md</strong><dd><code>Added changeset for new koota removal codemod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-e5365d8df4c36f6fae6b94b14ce37f86c9026725017343ab7205e23b26b3adcf">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>private-ecs-publication-and-capacity.md</strong><dd><code>Expanded breaking changes with koota and expectedSprites details</code></dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-be493d521cf6bd53b1772bed56f7293e49176115ef13f14cda3cf32526b0e7d2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>private-ecs-runtime-migration.md</strong><dd><code>Expanded breaking changes with migration specifics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-6d500d666d4eb9e677847804b7597d662f6f4c393bac0c6ca9cfeaa9661f8b24">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Added koota-peer-dependency codemod to index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-01665d7e663da1349bc49b3d7d6471c69ee021321ebf6b943556933641958cec">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>koota-peer-dependency-removal.md</strong><dd><code>New codemod for removing unused koota peer dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-81ebf3eec45c360a0512826bad5586f2e526cc6042284b02dfa4e59e03f73c84">+134/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>render-stats-debug-subpath.md</strong><dd><code>Fixed debug subpath in RenderStats docblock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-e930de0bdae43f53ec526458ce8e6d4f46bef5ffaaaeb51966fe24240c8d8a78">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Corrected devtools producer subpath in docblock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-8fe023dd2f9926f0a77527baab27ecb5a8f30cfc442d019686ced045c56e5592">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>astro.config.mjs</strong><dd><code>Updated nav label to point to flatland-setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>31 files</summary><table>
<tr>
  <td><strong>branding.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-703d4bbaadb0230debb83be2f8f89b102e8dbc50ae35ea1152b99dad06a6afe2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-88eb8c0209651f5f7e678c7a86f74f7a35e5f47a8f9375d6184d3bd9e1c63967">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basic-sprite.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-c8abc2bc295fcdd26dbc7bc03eedfbaac471cb4e39d22f645abde166fbbf2524">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch-demo.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-88447bac1a6a769815758b5e0f88ca9c66cb881a786c68a506981f47af3f5ba7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hit-test.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-2554f0af6dbb1fe9cdc35c3ec4a0307c1d275f6741bd48b80d549b313aa3d959">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>knightmark.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-4cd0fd02f113c69cf0406c1e8903a9ac6ddef0fa3e725ff8275a61af0fea5fd4">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lighting.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-6671db1bc3a4d98d25d2aed8c9ec388bf0c998fc7f4f70b4bde5a3bc7903375c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pass-effects.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-f91e8795d0fbe929a6b30143e0dcfc5e06d50af2cb031c4b25da1cde51edf9ce">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>skia.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-5a938fb444d4f82cf5fa820efd7f1360c3e8db45d8bf8daa354f62eb3a204f9d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>slug-text.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-963fb73dc6adfb301c302003a1453222ddf18638f0843885494d3ef5d05e194a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tilemap.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-d7b36ad23cd063c00a20e78ba44e2effad384c7ea60b37c9460cd9111148ee36">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tsl-nodes.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-4149bf6dab00c273ffb7e68c03039a12e0bb0580d66c0d797372dbeebcaa9f7e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installation.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-5bf04f00fe5aa859d201c6a70aaeb2992626e256f841ef0c0be206d1d9eb9248">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quick-start.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-90b831eaf439854f3a6717b41e03e65d19ff3c9ec391e1083aa7a3bf9528c8e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-d053b023a7fde6b43a768f5bba391cfe7bef20aa26d7a5d773c2fe94df6f278f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>baking.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-c951636d30b45048b57a5ecf285bb1d868abdd5bdf2c12a3abdf655b5a2c29fb">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devtools.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-e97b640318a6bee7a420eca48c53c60089e3d3447e323297fe3a00a25ed5b270">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lighting-setup.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-14a79ebaed1158381495fb81b65bb1b457693eb6b209d6da4f8c5a1f0118c963">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lighting.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-ced899d3e98e89314a3ccb40c73534b894bb0f144d6aabad77243e1bbbeb981a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loaders.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-57601952b4a23ddd3641bd950772898316cd1bed89036d4f25be29ce3d47814f">+16/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pass-effects.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-fc6da8a831e1b3d466f9cb744e0615e6df276c168cf9468323e211c3611730bb">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shadows-setup.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-af9880c8917c041192ad9dcd08238cda32ba01b1bc6cdc2afc1a035aa46d57f5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shadows.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-18c42ca546409df1266ea57bef821386c9c9a9d55fa5b3ed522d2b17acb46c71">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>skia.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-e06c438a797d4967537442e1b2c704357dfbedbe4016e4e13a85f06a2aefac09">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>slug-text.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-8c3169a396b60d0d01c5a98c95da136d56bde31ea2f8c6b40ce49cf5f2714c30">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tilemaps.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-52e3779748478a6105a79e4f22d2573a918e7838ded15df33d3402a36fe19289">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tsl-nodes.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-a000fa07ca2ef35640fcd6de598eb21db23a2faa1abe8ca54c140c450a967aab">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>llm-prompts.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-94225b57c70bfc11676cf61b96b62df82a9e262de401be0c088d4c7710c0ae34">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>breakout.mdx</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-9efd3a59f310c7e0f57156eea49b2d81e264471ac806607dd7e3a65310306a96">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>effect-vector-whole-tuple.md</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-563e96133f795b951692661b48e47c2cc5a5307bc8a458bded3cdf3c087b42ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>2026-05-24-docs-diataxis-restructure.md</strong></td>
  <td><a href="https://github.com/thejustinwalsh/three-flatland/pull/244/files#diff-76c84c5460fe7dc54141de9f2b1228ec3fd0faa8eb56361ca70899de420a04a9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for setting up a Flatland scene with Three.js and React examples.
  * Reorganized the Flatland documentation into focused setup and conceptual guides.
  * Standardized documentation headings to sentence case.
  * Corrected the RenderStats debug-protocol reference.
  * Updated navigation to highlight the new setup guide.

* **Chores**
  * Added migration guidance for removing unused Koota dependencies and adopting updated renderer APIs.
  * Documented upcoming capacity hints and disposal behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->